### PR TITLE
adding `Agent` trait under models::lib::agent, implementing for Compa…

### DIFF
--- a/src/models/company.rs
+++ b/src/models/company.rs
@@ -14,7 +14,7 @@
 use crate::{
     costs::Costs,
     models::{
-        lib::agent::AgentID,
+        lib::agent::{Agent, AgentID},
         process::Process,
         resource::Resource,
     },
@@ -204,6 +204,12 @@ impl Company {
             })
             .fold(Costs::new(), |acc, x| acc + x.costs().clone());
         process_costs + resource_costs
+    }
+}
+
+impl Agent for Company {
+    fn agent_id(&self) -> AgentID {
+        self.id().clone().into()
     }
 }
 

--- a/src/models/company_member.rs
+++ b/src/models/company_member.rs
@@ -13,7 +13,7 @@ use crate::{
     models::{
         account::AccountID,
         company::{CompanyID, Permission},
-        lib::agent::AgentID,
+        lib::agent::{Agent, AgentID},
         occupation::OccupationID,
         user::UserID,
     },
@@ -145,6 +145,12 @@ impl CompanyMember {
     /// Grab this member's CompanyID, converted from AgentID
     pub fn company_id(&self) -> Result<CompanyID> {
         self.inner().object().clone().try_into()
+    }
+}
+
+impl Agent for CompanyMember {
+    fn agent_id(&self) -> AgentID {
+        self.id().clone().into()
     }
 }
 

--- a/src/models/event.rs
+++ b/src/models/event.rs
@@ -28,7 +28,7 @@ use crate::{
 
         agreement::AgreementID,
         company_member::CompanyMember,
-        lib::agent::AgentID,
+        lib::agent::{Agent, AgentID},
         process::{Process, ProcessID},
         resource::{Resource, ResourceID},
         resource_spec::ResourceSpecID,
@@ -272,7 +272,7 @@ impl Event {
             Err(EventError::MismatchedResourceToID)?;
         }
         if let Some(provider) = state.provider.as_ref() {
-            if self.inner().provider() != &provider.id().clone().into() {
+            if self.inner().provider() != &provider.agent_id() {
                 Err(EventError::MismatchedProviderID)?;
             }
         }
@@ -1610,7 +1610,7 @@ mod tests {
         costs.track_labor("CEO", 69);   // should be tracked, our member is CEO
         costs.track_labor("machinist", 42);    // should not be tracked
         event.set_move_costs(Some(costs));
-        event.inner_mut().set_provider(state.provider.as_ref().unwrap().id().clone().into());
+        event.inner_mut().set_provider(state.provider.as_ref().unwrap().agent_id());
         event.inner_mut().set_effort_quantity(Some(Measure::new(dec!(0), Unit::Hour)));
         fuzz_state(event.clone(), state.clone(), &now);
 
@@ -1641,7 +1641,7 @@ mod tests {
 
         let mut event = make_event(vf::Action::Work, &company_id, &company_id, &state, &now);
         event.set_move_costs(Some(Costs::new()));
-        event.inner_mut().set_provider(state.provider.as_ref().unwrap().id().clone().into());
+        event.inner_mut().set_provider(state.provider.as_ref().unwrap().agent_id());
         event.inner_mut().set_effort_quantity(Some(Measure::new(dec!(5.4), Unit::Hour)));
         fuzz_state(event.clone(), state.clone(), &now);
 
@@ -1675,7 +1675,7 @@ mod tests {
         costs.track_labor("CEO", 69);   // should be tracked, our member is CEO
         costs.track_labor("gerrymandering", 42);    // should not be tracked
         event.set_move_costs(Some(costs));
-        event.inner_mut().set_provider(state.provider.as_ref().unwrap().id().clone().into());
+        event.inner_mut().set_provider(state.provider.as_ref().unwrap().agent_id());
         event.inner_mut().set_effort_quantity(Some(Measure::new(NumericUnion::Integer(12), Unit::Hour)));
         fuzz_state(event.clone(), state.clone(), &now);
 

--- a/src/models/lib/agent.rs
+++ b/src/models/lib/agent.rs
@@ -9,6 +9,13 @@ use crate::{
 use serde::{Serialize, Deserialize};
 use std::convert::TryFrom;
 
+/// A trait that holds common agent functionality, generally applied to models
+/// with ID types implemented in `AgentID`.
+pub trait Agent {
+    /// Convert the model's ID to and AgentID.
+    fn agent_id(&self) -> AgentID;
+}
+
 /// VF (correctly) assumes different types of actors in the economic network
 /// that have "agency" so here we define the objects that have agency within the
 /// Basis system. This lets us use a more generic `AgentID` object that fulfills

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -7,6 +7,9 @@
 
 use crate::{
     access::{Permission, Role},
+    models::{
+        lib::agent::{Agent, AgentID},
+    },
     error::{Error, Result},
 };
 
@@ -45,6 +48,12 @@ impl User {
             Err(Error::InsufficientPrivileges)?;
         }
         Ok(())
+    }
+}
+
+impl Agent for User {
+    fn agent_id(&self) -> AgentID {
+        self.id().clone().into()
     }
 }
 

--- a/src/transactions/agreement.rs
+++ b/src/transactions/agreement.rs
@@ -77,6 +77,7 @@ mod tests {
     use super::*;
     use crate::{
         models::{
+            lib::agent::Agent,
             company::{CompanyID, CompanyType},
             company_member::CompanyMemberID,
             occupation::OccupationID,
@@ -94,7 +95,7 @@ mod tests {
         let company_from = make_company(&CompanyID::create(), CompanyType::Private, "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
         let member = make_member(&CompanyMemberID::create(), user.id(), company_to.id(), &OccupationID::create(), vec![CompanyPermission::AgreementCreate], &now);
-        let participants = vec![company_to.id().clone().into(), company_from.id().clone().into()];
+        let participants = vec![company_to.agent_id(), company_from.agent_id()];
 
         let mods = create(&user, &member, &company_to, id.clone(), participants.clone(), "order 1234141", "hi i'm jerry. just going to order some widgets. don't mind me, just ordering widgets.", Some(now.clone()), true, &now).unwrap().into_vec();
         assert_eq!(mods.len(), 1);
@@ -134,19 +135,19 @@ mod tests {
         let company_from = make_company(&CompanyID::create(), CompanyType::Private, "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
         let member = make_member(&CompanyMemberID::create(), user.id(), company_to.id(), &OccupationID::create(), vec![CompanyPermission::AgreementCreate, CompanyPermission::AgreementUpdate], &now);
-        let participants = vec![company_to.id().clone().into(), company_from.id().clone().into()];
+        let participants = vec![company_to.agent_id(), company_from.agent_id()];
 
         let mods = create(&user, &member, &company_to, id.clone(), participants.clone(), "order 1234141", "hi i'm jerry. just going to order some widgets. don't mind me, just ordering widgets.", Some(now.clone()), true, &now).unwrap().into_vec();
         let agreement1 = mods[0].clone().expect_op::<Agreement>(Op::Create).unwrap();
         let now2 = util::time::now();
-        let mods = update(&user, &member, &company_to, agreement1.clone(), Some(vec![company_from.id().clone().into()]), Some("order 1111222".into()), Some("jerry's long-winded order".into()), None, None, &now2).unwrap().into_vec();
+        let mods = update(&user, &member, &company_to, agreement1.clone(), Some(vec![company_from.agent_id()]), Some("order 1111222".into()), Some("jerry's long-winded order".into()), None, None, &now2).unwrap().into_vec();
         let agreement2 = mods[0].clone().expect_op::<Agreement>(Op::Update).unwrap();
 
         assert_eq!(agreement2.id(), agreement1.id());
         assert_eq!(agreement2.inner().created(), agreement1.inner().created());
         assert_eq!(agreement2.inner().name(), &Some("order 1111222".into()));
         assert_eq!(agreement2.inner().note(), &Some("jerry's long-winded order".into()));
-        assert_eq!(agreement2.participants(), &vec![company_from.id().clone().into()]);
+        assert_eq!(agreement2.participants(), &vec![company_from.agent_id()]);
         assert_eq!(agreement2.active(), agreement1.active());
         assert_eq!(agreement2.created(), agreement1.created());
         assert_eq!(agreement2.updated(), &now2);

--- a/src/transactions/company.rs
+++ b/src/transactions/company.rs
@@ -93,6 +93,7 @@ mod tests {
         access::Role,
         models::{
             Op,
+            lib::agent::Agent,
             user::UserID,
             testutils::make_user,
         },
@@ -123,7 +124,7 @@ mod tests {
         assert_eq!(company.created(), &now);
         assert_eq!(company.updated(), &now);
         assert_eq!(founder.id(), &founder_id);
-        assert_eq!(founder.inner().subject(), &user.id().clone().into());
+        assert_eq!(founder.inner().subject(), &user.agent_id());
         assert_eq!(founder.inner().object(), &id.clone().into());
         assert_eq!(founder.inner().relationship(), &occupation_id);
         assert_eq!(founder.permissions(), &vec![CompanyPermission::All]);

--- a/src/transactions/company_member.rs
+++ b/src/transactions/company_member.rs
@@ -99,6 +99,7 @@ mod tests {
         models::{
             account::AccountID,
             company::{CompanyID, CompanyType},
+            lib::agent::Agent,
             user::UserID,
             testutils::{make_user, make_company, make_member},
         },
@@ -122,8 +123,8 @@ mod tests {
         assert_eq!(mods.len(), 1);
         let member = mods[0].clone().expect_op::<CompanyMember>(Op::Create).unwrap();
         assert_eq!(member.id(), &id);
-        assert_eq!(member.inner().subject(), &new_user.id().clone().into());
-        assert_eq!(member.inner().object(), &company.id().clone().into());
+        assert_eq!(member.inner().subject(), &new_user.agent_id());
+        assert_eq!(member.inner().object(), &company.agent_id());
         assert_eq!(member.inner().relationship(), &occupation_id);
         assert_eq!(member.permissions().len(), 0);
         assert_eq!(member.agreement(), &Some(agreement.clone()));

--- a/src/transactions/event/accounting.rs
+++ b/src/transactions/event/accounting.rs
@@ -233,6 +233,7 @@ mod tests {
     use super::*;
     use crate::{
         models::{
+            lib::agent::Agent,
             company::{CompanyID, CompanyType},
             company_member::CompanyMemberID,
             event::{EventID, EventError},
@@ -272,8 +273,8 @@ mod tests {
         assert_eq!(event.inner().has_point_in_time(), &Some(now.clone()));
         assert_eq!(event.inner().input_of(), &None);
         assert_eq!(event.inner().output_of(), &None);
-        assert_eq!(event.inner().provider().clone(), company.id().clone().into());
-        assert_eq!(event.inner().receiver().clone(), company.id().clone().into());
+        assert_eq!(event.inner().provider().clone(), company.agent_id());
+        assert_eq!(event.inner().receiver().clone(), company.agent_id());
         assert_eq!(event.inner().resource_quantity(), &Some(Measure::new(8, Unit::One)));
         assert_eq!(event.move_costs(), &None);
         assert_eq!(event.active(), &true);
@@ -340,8 +341,8 @@ mod tests {
         assert_eq!(event.inner().has_point_in_time(), &Some(now.clone()));
         assert_eq!(event.inner().input_of(), &Some(process_to.id().clone()));
         assert_eq!(event.inner().output_of(), &Some(process_from.id().clone()));
-        assert_eq!(event.inner().provider().clone(), company.id().clone().into());
-        assert_eq!(event.inner().receiver().clone(), company.id().clone().into());
+        assert_eq!(event.inner().provider().clone(), company.agent_id());
+        assert_eq!(event.inner().receiver().clone(), company.agent_id());
         assert_eq!(event.inner().resource_quantity(), &None);
         assert_eq!(event.move_costs(), &Some(Costs::new_with_labor("lawyer", 100)));
         assert_eq!(event.active(), &true);
@@ -419,8 +420,8 @@ mod tests {
         assert_eq!(event.inner().has_point_in_time(), &Some(now.clone()));
         assert_eq!(event.inner().input_of(), &None);
         assert_eq!(event.inner().output_of(), &None);
-        assert_eq!(event.inner().provider().clone(), company.id().clone().into());
-        assert_eq!(event.inner().receiver().clone(), company.id().clone().into());
+        assert_eq!(event.inner().provider().clone(), company.agent_id());
+        assert_eq!(event.inner().receiver().clone(), company.agent_id());
         assert_eq!(event.inner().resource_quantity(), &Some(Measure::new(8, Unit::One)));
         assert_eq!(event.move_costs(), &Some(Costs::new_with_labor("homemaker", 23)));
         assert_eq!(event.active(), &true);
@@ -430,19 +431,19 @@ mod tests {
         let mut costs2 = Costs::new();
         costs2.track_labor("homemaker", dec!(157) - dec!(23));
         assert_eq!(resource_from2.id(), resource.id());
-        assert_eq!(resource_from2.inner().primary_accountable(), &Some(company.id().clone().into()));
+        assert_eq!(resource_from2.inner().primary_accountable(), &Some(company.agent_id()));
         assert_eq!(resource_from2.inner().accounting_quantity(), &Some(Measure::new(dec!(15) - dec!(8), Unit::One)));
         assert_eq!(resource_from2.inner().onhand_quantity(), &Some(Measure::new(dec!(15) - dec!(8), Unit::One)));
-        assert_eq!(resource_from2.in_custody_of(), &company.id().clone().into());
+        assert_eq!(resource_from2.in_custody_of(), &company.agent_id());
         assert_eq!(resource_from2.costs(), &costs2);
 
         let mut costs2 = Costs::new();
         costs2.track_labor("homemaker", dec!(23) + dec!(2));
         assert_eq!(resource_to2.id(), resource_to.id());
-        assert_eq!(resource_to2.inner().primary_accountable(), &Some(company.id().clone().into()));
+        assert_eq!(resource_to2.inner().primary_accountable(), &Some(company.agent_id()));
         assert_eq!(resource_to2.inner().accounting_quantity(), &Some(Measure::new(dec!(8) + dec!(3), Unit::One)));
         assert_eq!(resource_to2.inner().onhand_quantity(), &Some(Measure::new(dec!(8) + dec!(3), Unit::One)));
-        assert_eq!(resource_to2.in_custody_of(), &company.id().clone().into());
+        assert_eq!(resource_to2.in_custody_of(), &company.agent_id());
         assert_eq!(resource_to2.costs(), &costs2);
 
         // test ResourceMover::Create()
@@ -457,8 +458,8 @@ mod tests {
         assert_eq!(event.inner().has_point_in_time(), &Some(now.clone()));
         assert_eq!(event.inner().input_of(), &None);
         assert_eq!(event.inner().output_of(), &None);
-        assert_eq!(event.inner().provider().clone(), company.id().clone().into());
-        assert_eq!(event.inner().receiver().clone(), company.id().clone().into());
+        assert_eq!(event.inner().provider().clone(), company.agent_id());
+        assert_eq!(event.inner().receiver().clone(), company.agent_id());
         assert_eq!(event.inner().resource_quantity(), &Some(Measure::new(8, Unit::One)));
         assert_eq!(event.move_costs(), &Some(Costs::new_with_labor("homemaker", 23)));
         assert_eq!(event.active(), &true);
@@ -468,19 +469,19 @@ mod tests {
         let mut costs2 = Costs::new();
         costs2.track_labor("homemaker", dec!(157) - dec!(23));
         assert_eq!(resource_from3.id(), resource.id());
-        assert_eq!(resource_from3.inner().primary_accountable(), &Some(company.id().clone().into()));
+        assert_eq!(resource_from3.inner().primary_accountable(), &Some(company.agent_id()));
         assert_eq!(resource_from3.inner().accounting_quantity(), &Some(Measure::new(dec!(15) - dec!(8), Unit::One)));
         assert_eq!(resource_from3.inner().onhand_quantity(), &Some(Measure::new(dec!(15) - dec!(8), Unit::One)));
-        assert_eq!(resource_from3.in_custody_of(), &company.id().clone().into());
+        assert_eq!(resource_from3.in_custody_of(), &company.agent_id());
         assert_eq!(resource_from3.costs(), &costs2);
 
         let mut costs2 = Costs::new();
         costs2.track_labor("homemaker", dec!(23));
         assert_eq!(resource_created.id(), resource_to.id());
-        assert_eq!(resource_created.inner().primary_accountable(), &Some(company.id().clone().into()));
+        assert_eq!(resource_created.inner().primary_accountable(), &Some(company.agent_id()));
         assert_eq!(resource_created.inner().accounting_quantity(), &Some(Measure::new(dec!(8), Unit::One)));
         assert_eq!(resource_created.inner().onhand_quantity(), &Some(Measure::new(dec!(8), Unit::One)));
-        assert_eq!(resource_created.in_custody_of(), &company.id().clone().into());
+        assert_eq!(resource_created.in_custody_of(), &company.agent_id());
         assert_eq!(resource_created.costs(), &costs2);
 
         let user2 = make_user(&UserID::create(), Some(vec![]), &now);
@@ -541,8 +542,8 @@ mod tests {
         assert_eq!(event.inner().has_point_in_time(), &Some(now.clone()));
         assert_eq!(event.inner().input_of(), &None);
         assert_eq!(event.inner().output_of(), &None);
-        assert_eq!(event.inner().provider().clone(), company.id().clone().into());
-        assert_eq!(event.inner().receiver().clone(), company.id().clone().into());
+        assert_eq!(event.inner().provider().clone(), company.agent_id());
+        assert_eq!(event.inner().receiver().clone(), company.agent_id());
         assert_eq!(event.inner().resource_quantity(), &Some(Measure::new(8, Unit::One)));
         assert_eq!(event.move_costs(), &None);
         assert_eq!(event.active(), &true);

--- a/src/transactions/event/delivery.rs
+++ b/src/transactions/event/delivery.rs
@@ -129,6 +129,7 @@ mod tests {
             company::{CompanyID, CompanyType},
             company_member::CompanyMemberID,
             event::{EventError, EventID},
+            lib::agent::Agent,
             occupation::OccupationID,
             process::ProcessID,
             resource::ResourceID,
@@ -171,8 +172,8 @@ mod tests {
         assert_eq!(event.inner().has_point_in_time(), &Some(now.clone()));
         assert_eq!(event.inner().input_of(), &None);
         assert_eq!(event.inner().output_of(), &Some(process.id().clone()));
-        assert_eq!(event.inner().provider().clone(), company.id().clone().into());
-        assert_eq!(event.inner().receiver().clone(), company.id().clone().into());
+        assert_eq!(event.inner().provider().clone(), company.agent_id());
+        assert_eq!(event.inner().receiver().clone(), company.agent_id());
         assert_eq!(event.move_costs(), &Some(process.costs().clone()));
         assert_eq!(event.active(), &true);
         assert_eq!(event.created(), &now);
@@ -187,8 +188,8 @@ mod tests {
         costs2.track_labor(occupation_id.clone(), dec!(42.2));
         costs2.track_labor("machinist", 157);
         assert_eq!(resource2.id(), resource.id());
-        assert_eq!(resource2.inner().primary_accountable(), &Some(company.id().clone().into()));
-        assert_eq!(resource2.in_custody_of(), &company.id().clone().into());
+        assert_eq!(resource2.inner().primary_accountable(), &Some(company.agent_id()));
+        assert_eq!(resource2.in_custody_of(), &company.agent_id());
         assert_eq!(resource2.inner().accounting_quantity(), &Some(Measure::new(dec!(15), Unit::One)));
         assert_eq!(resource2.inner().onhand_quantity(), &Some(Measure::new(dec!(15), Unit::One)));
         assert_eq!(resource2.inner().current_location(), &Some(loc.clone()));
@@ -250,8 +251,8 @@ mod tests {
         assert_eq!(event.inner().agreed_in(), &None);
         assert_eq!(event.inner().has_point_in_time(), &Some(now.clone()));
         assert_eq!(event.inner().input_of(), &Some(process.id().clone()));
-        assert_eq!(event.inner().provider().clone(), company.id().clone().into());
-        assert_eq!(event.inner().receiver().clone(), company.id().clone().into());
+        assert_eq!(event.inner().provider().clone(), company.agent_id());
+        assert_eq!(event.inner().receiver().clone(), company.agent_id());
         assert_eq!(event.move_costs(), &Some(Costs::new()));
         assert_eq!(event.active(), &true);
         assert_eq!(event.created(), &now);

--- a/src/transactions/event/modification.rs
+++ b/src/transactions/event/modification.rs
@@ -137,6 +137,7 @@ mod tests {
             company::{CompanyID, CompanyType},
             company_member::CompanyMemberID,
             event::{EventError, EventID},
+            lib::agent::Agent,
             occupation::OccupationID,
             process::ProcessID,
             resource::ResourceID,
@@ -173,8 +174,8 @@ mod tests {
         assert_eq!(event.inner().agreed_in(), &None);
         assert_eq!(event.inner().has_point_in_time(), &Some(now.clone()));
         assert_eq!(event.inner().input_of(), &Some(process.id().clone()));
-        assert_eq!(event.inner().provider().clone(), company.id().clone().into());
-        assert_eq!(event.inner().receiver().clone(), company.id().clone().into());
+        assert_eq!(event.inner().provider().clone(), company.agent_id());
+        assert_eq!(event.inner().receiver().clone(), company.agent_id());
         assert_eq!(event.inner().resource_quantity(), &Some(Measure::new(3, Unit::One)));
         assert_eq!(event.move_costs(), &Some(Costs::new()));
         assert_eq!(event.active(), &true);
@@ -182,8 +183,8 @@ mod tests {
         assert_eq!(event.updated(), &now);
 
         assert_eq!(resource2.id(), resource.id());
-        assert_eq!(resource2.inner().primary_accountable(), &Some(company.id().clone().into()));
-        assert_eq!(resource2.in_custody_of(), &company.id().clone().into());
+        assert_eq!(resource2.inner().primary_accountable(), &Some(company.agent_id()));
+        assert_eq!(resource2.in_custody_of(), &company.agent_id());
         assert_eq!(resource2.inner().accounting_quantity(), &Some(Measure::new(dec!(15), Unit::One)));
         assert_eq!(resource2.inner().onhand_quantity(), &Some(Measure::new(dec!(12), Unit::One)));
         assert_eq!(resource2.costs(), &Costs::new_with_resource("steel", 157));
@@ -249,8 +250,8 @@ mod tests {
         assert_eq!(event.inner().has_point_in_time(), &Some(now.clone()));
         assert_eq!(event.inner().input_of(), &None);
         assert_eq!(event.inner().output_of(), &Some(process.id().clone()));
-        assert_eq!(event.inner().provider().clone(), company.id().clone().into());
-        assert_eq!(event.inner().receiver().clone(), company.id().clone().into());
+        assert_eq!(event.inner().provider().clone(), company.agent_id());
+        assert_eq!(event.inner().receiver().clone(), company.agent_id());
         assert_eq!(event.move_costs(), &Some(process.costs().clone()));
         assert_eq!(event.active(), &true);
         assert_eq!(event.created(), &now);
@@ -265,8 +266,8 @@ mod tests {
         costs2.track_labor(occupation_id.clone(), dec!(102.3));
         costs2.track_resource("steel", 157);
         assert_eq!(resource2.id(), resource.id());
-        assert_eq!(resource2.inner().primary_accountable(), &Some(company.id().clone().into()));
-        assert_eq!(resource2.in_custody_of(), &company.id().clone().into());
+        assert_eq!(resource2.inner().primary_accountable(), &Some(company.agent_id()));
+        assert_eq!(resource2.in_custody_of(), &company.agent_id());
         assert_eq!(resource2.inner().accounting_quantity(), &Some(Measure::new(dec!(3), Unit::One)));
         assert_eq!(resource2.inner().onhand_quantity(), &Some(Measure::new(dec!(15), Unit::One)));
         assert_eq!(resource2.costs(), &costs2);

--- a/src/transactions/event/production.rs
+++ b/src/transactions/event/production.rs
@@ -258,6 +258,7 @@ mod tests {
             company::{CompanyID, CompanyType},
             company_member::CompanyMemberID,
             event::{EventError, EventID},
+            lib::agent::Agent,
             occupation::OccupationID,
             process::ProcessID,
             resource::ResourceID,
@@ -298,8 +299,8 @@ mod tests {
         assert_eq!(event.inner().agreed_in(), &None);
         assert_eq!(event.inner().has_point_in_time(), &Some(now.clone()));
         assert_eq!(event.inner().input_of(), &Some(process.id().clone()));
-        assert_eq!(event.inner().provider().clone(), company.id().clone().into());
-        assert_eq!(event.inner().receiver().clone(), company.id().clone().into());
+        assert_eq!(event.inner().provider().clone(), company.agent_id());
+        assert_eq!(event.inner().receiver().clone(), company.agent_id());
         assert_eq!(event.move_costs(), &Some(Costs::new_with_labor("homemaker", 23)));
         assert_eq!(event.active(), &true);
         assert_eq!(event.created(), &now);
@@ -382,8 +383,8 @@ mod tests {
         assert_eq!(event.inner().agreed_in(), &None);
         assert_eq!(event.inner().has_point_in_time(), &Some(now.clone()));
         assert_eq!(event.inner().input_of(), &Some(process.id().clone()));
-        assert_eq!(event.inner().provider().clone(), company.id().clone().into());
-        assert_eq!(event.inner().receiver().clone(), company.id().clone().into());
+        assert_eq!(event.inner().provider().clone(), company.agent_id());
+        assert_eq!(event.inner().receiver().clone(), company.agent_id());
         assert_eq!(event.move_costs(), &Some(Costs::new_with_labor("homemaker", 23)));
         assert_eq!(event.active(), &true);
         assert_eq!(event.created(), &now);
@@ -467,8 +468,8 @@ mod tests {
         assert_eq!(event.inner().has_point_in_time(), &Some(now.clone()));
         assert_eq!(event.inner().input_of(), &None);
         assert_eq!(event.inner().output_of(), &Some(process.id().clone()));
-        assert_eq!(event.inner().provider().clone(), company.id().clone().into());
-        assert_eq!(event.inner().receiver().clone(), company.id().clone().into());
+        assert_eq!(event.inner().provider().clone(), company.agent_id());
+        assert_eq!(event.inner().receiver().clone(), company.agent_id());
         assert_eq!(event.move_costs(), &Some(Costs::new_with_labor("homemaker", 23)));
         assert_eq!(event.active(), &true);
         assert_eq!(event.created(), &now);
@@ -551,8 +552,8 @@ mod tests {
         assert_eq!(event.inner().agreed_in(), &None);
         assert_eq!(event.inner().has_point_in_time(), &Some(now.clone()));
         assert_eq!(event.inner().input_of(), &Some(process.id().clone()));
-        assert_eq!(event.inner().provider().clone(), company.id().clone().into());
-        assert_eq!(event.inner().receiver().clone(), company.id().clone().into());
+        assert_eq!(event.inner().provider().clone(), company.agent_id());
+        assert_eq!(event.inner().receiver().clone(), company.agent_id());
         assert_eq!(event.move_costs(), &Some(Costs::new_with_labor("homemaker", dec!(0.3))));
         assert_eq!(event.active(), &true);
         assert_eq!(event.created(), &now);

--- a/src/transactions/event/service.rs
+++ b/src/transactions/event/service.rs
@@ -77,6 +77,7 @@ mod tests {
             company::{CompanyID, CompanyType},
             company_member::CompanyMemberID,
             event::{EventID, EventError},
+            lib::agent::Agent,
             occupation::OccupationID,
             process::{Process, ProcessID},
             testutils::{make_user, make_company, make_member, make_process},
@@ -115,8 +116,8 @@ mod tests {
         assert_eq!(event.inner().has_point_in_time(), &Some(now.clone()));
         assert_eq!(event.inner().input_of(), &Some(process_to.id().clone()));
         assert_eq!(event.inner().output_of(), &Some(process_from.id().clone()));
-        assert_eq!(event.inner().provider().clone(), company_from.id().clone().into());
-        assert_eq!(event.inner().receiver().clone(), company_to.id().clone().into());
+        assert_eq!(event.inner().provider().clone(), company_from.agent_id());
+        assert_eq!(event.inner().receiver().clone(), company_to.agent_id());
         assert_eq!(event.inner().resource_quantity(), &None);
         assert_eq!(event.move_costs(), &Some(Costs::new_with_labor("lawyer", 100)));
         assert_eq!(event.active(), &true);

--- a/src/transactions/event/transfer.rs
+++ b/src/transactions/event/transfer.rs
@@ -214,6 +214,7 @@ mod tests {
             company::{CompanyID, CompanyType},
             company_member::CompanyMemberID,
             event::{EventID, EventError},
+            lib::agent::Agent,
             occupation::OccupationID,
             resource::ResourceID,
             testutils::{make_user, make_company, make_member, make_resource},
@@ -252,8 +253,8 @@ mod tests {
         assert_eq!(event.inner().agreed_in(), &None);
         assert_eq!(event.inner().has_point_in_time(), &Some(now.clone()));
         assert_eq!(event.inner().input_of(), &None);
-        assert_eq!(event.inner().provider().clone(), company.id().clone().into());
-        assert_eq!(event.inner().receiver().clone(), company2.id().clone().into());
+        assert_eq!(event.inner().provider().clone(), company.agent_id());
+        assert_eq!(event.inner().receiver().clone(), company2.agent_id());
         assert_eq!(event.inner().resource_quantity(), &Some(Measure::new(8, Unit::One)));
         assert_eq!(event.move_costs(), &Some(Costs::new_with_labor("homemaker", 23)));
         assert_eq!(event.active(), &true);

--- a/src/transactions/event/work.rs
+++ b/src/transactions/event/work.rs
@@ -102,6 +102,7 @@ mod tests {
             company::{CompanyID, CompanyType},
             company_member::CompanyMemberID,
             event::{Event, EventID, EventError},
+            lib::agent::Agent,
             occupation::OccupationID,
             process::ProcessID,
             testutils::{make_user, make_company, make_member, make_process},

--- a/src/transactions/process.rs
+++ b/src/transactions/process.rs
@@ -104,6 +104,7 @@ mod tests {
         models::{
             company::{CompanyID, CompanyType},
             company_member::CompanyMemberID,
+            lib::agent::Agent,
             occupation::OccupationID,
             process_spec::ProcessSpecID,
             testutils::{make_user, make_company, make_member, make_process_spec},
@@ -167,12 +168,12 @@ mod tests {
         let mods = create(&user, &member, &company, id.clone(), spec.id().clone(), "Gazelle Freestyle Marathon", "tony making me build five of these stupid things", vec!["https://www.wikidata.org/wiki/Q1141557".parse().unwrap()], Some(now.clone()), None, vec![], true, &now).unwrap().into_vec();
         let process = mods[0].clone().expect_op::<Process>(Op::Create).unwrap();
 
-        let res = update(&user, &member, &company, process.clone(), Some("Make a GaZeLLe fReeStYlE".into()), None, None, Some(true), None, Some(now.clone()), Some(vec![company.id().clone().into()]), Some(false), &now);
+        let res = update(&user, &member, &company, process.clone(), Some("Make a GaZeLLe fReeStYlE".into()), None, None, Some(true), None, Some(now.clone()), Some(vec![company.agent_id()]), Some(false), &now);
         assert_eq!(res, Err(Error::InsufficientPrivileges));
 
         member.set_permissions(vec![CompanyPermission::ProcessUpdate]);
         let now2 = util::time::now();
-        let mods = update(&user, &member, &company, process.clone(), Some("Make a GaZeLLe fReeStYlE".into()), None, None, Some(true), None, Some(now2.clone()), Some(vec![company.id().clone().into()]), Some(false), &now2).unwrap().into_vec();
+        let mods = update(&user, &member, &company, process.clone(), Some("Make a GaZeLLe fReeStYlE".into()), None, None, Some(true), None, Some(now2.clone()), Some(vec![company.agent_id()]), Some(false), &now2).unwrap().into_vec();
         assert_eq!(mods.len(), 1);
 
         let process2 = mods[0].clone().expect_op::<Process>(Op::Update).unwrap();
@@ -181,7 +182,7 @@ mod tests {
         assert_eq!(process2.inner().classified_as(), &vec!["https://www.wikidata.org/wiki/Q1141557".parse().unwrap()]);
         assert_eq!(process2.inner().has_beginning(), &Some(now.clone()));
         assert_eq!(process2.inner().has_end(), &Some(now2.clone()));
-        assert_eq!(process2.inner().in_scope_of(), &vec![company.id().clone().into()]);
+        assert_eq!(process2.inner().in_scope_of(), &vec![company.agent_id()]);
         assert_eq!(process2.inner().name(), "Make a GaZeLLe fReeStYlE");
         assert_eq!(process2.inner().note(), &Some("tony making me build five of these stupid things".into()));
         assert_eq!(process2.company_id(), company.id());
@@ -193,12 +194,12 @@ mod tests {
 
         let mut user2 = user.clone();
         user2.set_roles(vec![]);
-        let res = update(&user2, &member, &company, process.clone(), Some("Make a GaZeLLe fReeStYlE".into()), None, None, Some(true), None, Some(now2.clone()), Some(vec![company.id().clone().into()]), Some(false), &now2);
+        let res = update(&user2, &member, &company, process.clone(), Some("Make a GaZeLLe fReeStYlE".into()), None, None, Some(true), None, Some(now2.clone()), Some(vec![company.agent_id()]), Some(false), &now2);
         assert_eq!(res, Err(Error::InsufficientPrivileges));
 
         let mut company2 = company.clone();
         company2.set_deleted(Some(now2.clone()));
-        let res = update(&user, &member, &company2, process.clone(), Some("Make a GaZeLLe fReeStYlE".into()), None, None, Some(true), None, Some(now2.clone()), Some(vec![company.id().clone().into()]), Some(false), &now2);
+        let res = update(&user, &member, &company2, process.clone(), Some("Make a GaZeLLe fReeStYlE".into()), None, None, Some(true), None, Some(now2.clone()), Some(vec![company.agent_id()]), Some(false), &now2);
         assert_eq!(res, Err(Error::ObjectIsDeleted("company".into())));
     }
 

--- a/src/transactions/resource.rs
+++ b/src/transactions/resource.rs
@@ -8,6 +8,7 @@ use crate::{
         Modifications,
         company::{Company, Permission as CompanyPermission},
         company_member::CompanyMember,
+        lib::agent::Agent,
         resource::{Resource, ResourceID},
         resource_spec::ResourceSpecID,
         user::User,
@@ -33,7 +34,7 @@ pub fn create(caller: &User, member: &CompanyMember, company: &Company, id: Reso
                 .lot(lot)
                 .name(name)
                 .note(note)
-                .primary_accountable(Some(company.id().clone().into()))
+                .primary_accountable(Some(company.agent_id()))
                 .tracking_identifier(tracking_id)
                 .unit_of_effort(unit_of_effort)
                 .build()
@@ -130,11 +131,11 @@ mod tests {
         assert_eq!(resource.inner().name(), &Some("widget batch".into()));
         assert_eq!(resource.inner().lot(), &Some(lot.clone()));
         assert_eq!(resource.inner().classified_as(), &vec!["https://www.wikidata.org/wiki/Q605117".parse().unwrap()]);
-        assert_eq!(resource.inner().primary_accountable(), &Some(company.id().clone().into()));
+        assert_eq!(resource.inner().primary_accountable(), &Some(company.agent_id()));
         assert_eq!(resource.inner().tracking_identifier(), &None);
         assert_eq!(resource.inner().note(), &Some("niceee".into()));
         assert_eq!(resource.inner().unit_of_effort(), &Some(Unit::Hour));
-        assert_eq!(resource.in_custody_of(), &company.id().clone().into());
+        assert_eq!(resource.in_custody_of(), &company.agent_id());
         assert!(resource.costs().is_zero());
         assert_eq!(resource.active(), &true);
         assert_eq!(resource.created(), &now);
@@ -184,11 +185,11 @@ mod tests {
         assert_eq!(resource2.inner().name(), &Some("better widgets".into()));
         assert_eq!(resource2.inner().lot(), &Some(lot.clone()));
         assert_eq!(resource2.inner().classified_as(), &vec!["https://www.wikidata.org/wiki/Q605117".parse().unwrap()]);
-        assert_eq!(resource2.inner().primary_accountable(), &Some(company.id().clone().into()));
+        assert_eq!(resource2.inner().primary_accountable(), &Some(company.agent_id()));
         assert_eq!(resource2.inner().tracking_identifier(), &Some("444-computers-and-equipment".into()));
         assert_eq!(resource2.inner().note(), &Some("niceee".into()));
         assert_eq!(resource2.inner().unit_of_effort(), &Some(Unit::WattHour));
-        assert_eq!(resource2.in_custody_of(), &company.id().clone().into());
+        assert_eq!(resource2.in_custody_of(), &company.agent_id());
         assert_eq!(resource2.active(), &false);
         assert_eq!(resource2.created(), &now);
         assert_eq!(resource2.updated(), &now);
@@ -232,11 +233,11 @@ mod tests {
         assert_eq!(resource2.inner().name(), &Some("widget batch".into()));
         assert_eq!(resource2.inner().lot(), &Some(lot.clone()));
         assert_eq!(resource2.inner().classified_as(), &vec!["https://www.wikidata.org/wiki/Q605117".parse().unwrap()]);
-        assert_eq!(resource2.inner().primary_accountable(), &Some(company.id().clone().into()));
+        assert_eq!(resource2.inner().primary_accountable(), &Some(company.agent_id()));
         assert_eq!(resource2.inner().tracking_identifier(), &None);
         assert_eq!(resource2.inner().note(), &Some("niceee".into()));
         assert_eq!(resource2.inner().unit_of_effort(), &Some(Unit::Hour));
-        assert_eq!(resource2.in_custody_of(), &company.id().clone().into());
+        assert_eq!(resource2.in_custody_of(), &company.agent_id());
         assert_eq!(resource2.active(), &true);
         assert_eq!(resource2.created(), &now);
         assert_eq!(resource2.updated(), &now);


### PR DESCRIPTION
…ny, Member, User. added agent_id() method to Agent trait and replaced all conversions from model id (ie model.id().clone().into()) with model.agent_id() in all code and tests. works swell, much cleaner, all tests passing, and now we have a bonafide Agent trait we can jam stuff into.

This fixes basisproject/tracker#102