### PR TITLE
Convert company/member model to new generic layout

### DIFF
--- a/src/access.rs
+++ b/src/access.rs
@@ -31,7 +31,6 @@ pub enum Permission {
     CompanyAdminDelete,
     CompanyAdminUpdate,
     CompanyCreate,
-    CompanySetType,
     CompanyUpdateAgreements,
     CompanyUpdateCommitments,
     CompanyUpdateIntents,
@@ -44,17 +43,12 @@ pub enum Permission {
     EventCreate,
     EventUpdate,
 
-    RegionCreate,
-    RegionDelete,
-    RegionUpdate,
-
     UserAdminCreate,
     UserAdminUpdate,
     UserCreate,
     UserDelete,
     UserSetRoles,
     UserUpdate,
-
 
     ResourceSpecCreate,
     ResourceSpecDelete,
@@ -99,9 +93,7 @@ impl Role {
                 ]
             }
             Role::Bank => {
-                vec![
-                    Permission::CompanySetType,
-                ]
+                vec![]
             },
             Role::User => {
                 vec![
@@ -182,7 +174,6 @@ pub mod tests {
         assert!(super_admin.can(&Permission::CompanyCreate));
         assert!(super_admin.can(&Permission::CompanyAdminUpdate));
         assert!(super_admin.can(&Permission::CompanyAdminDelete));
-        assert!(super_admin.can(&Permission::CompanySetType));
 
         let comp_admin = Role::CompanyAdmin;
         assert!(!comp_admin.can(&Permission::UserCreate));
@@ -192,7 +183,6 @@ pub mod tests {
         assert!(!comp_admin.can(&Permission::CompanyCreate));
         assert!(comp_admin.can(&Permission::CompanyAdminUpdate));
         assert!(comp_admin.can(&Permission::CompanyAdminDelete));
-        assert!(!comp_admin.can(&Permission::CompanySetType));
     }
 }
 

--- a/src/access.rs
+++ b/src/access.rs
@@ -30,7 +30,7 @@ pub enum Permission {
 
     CompanyAdminDelete,
     CompanyAdminUpdate,
-    CompanyCreatePrivate,
+    CompanyCreate,
     CompanySetType,
     CompanyUpdateAgreements,
     CompanyUpdateCommitments,
@@ -107,7 +107,7 @@ impl Role {
                 vec![
                     Permission::UserUpdate,
                     Permission::UserDelete,
-                    Permission::CompanyCreatePrivate,
+                    Permission::CompanyCreate,
                     Permission::CompanyUpdateAgreements,
                     Permission::CompanyUpdateCommitments,
                     Permission::CompanyUpdateIntents,
@@ -179,7 +179,7 @@ pub mod tests {
         assert!(super_admin.can(&Permission::UserUpdate));
         assert!(super_admin.can(&Permission::UserAdminUpdate));
         assert!(super_admin.can(&Permission::UserDelete));
-        assert!(super_admin.can(&Permission::CompanyCreatePrivate));
+        assert!(super_admin.can(&Permission::CompanyCreate));
         assert!(super_admin.can(&Permission::CompanyAdminUpdate));
         assert!(super_admin.can(&Permission::CompanyAdminDelete));
         assert!(super_admin.can(&Permission::CompanySetType));
@@ -189,7 +189,7 @@ pub mod tests {
         assert!(!comp_admin.can(&Permission::UserUpdate));
         assert!(!comp_admin.can(&Permission::UserAdminUpdate));
         assert!(!comp_admin.can(&Permission::UserDelete));
-        assert!(!comp_admin.can(&Permission::CompanyCreatePrivate));
+        assert!(!comp_admin.can(&Permission::CompanyCreate));
         assert!(comp_admin.can(&Permission::CompanyAdminUpdate));
         assert!(comp_admin.can(&Permission::CompanyAdminDelete));
         assert!(!comp_admin.can(&Permission::CompanySetType));

--- a/src/access.rs
+++ b/src/access.rs
@@ -40,6 +40,10 @@ pub enum Permission {
     CompanyUpdateProcesses,
     CompanyUpdateProcessSpecs,
 
+    CurrencyCreate,
+    CurrencyDelete,
+    CurrencyUpdate,
+
     EventCreate,
     EventUpdate,
 
@@ -93,7 +97,11 @@ impl Role {
                 ]
             }
             Role::Bank => {
-                vec![]
+                vec![
+                    Permission::CurrencyCreate,
+                    Permission::CurrencyUpdate,
+                    Permission::CurrencyDelete,
+                ]
             },
             Role::User => {
                 vec![

--- a/src/costs.rs
+++ b/src/costs.rs
@@ -51,10 +51,10 @@
 //! tracking system, the pencil would show the iron/steel content of that axe,
 //! albeit a small amount. Now, maybe the truck that ships the pencil uses tires
 //! from a company that processes rubber. Maybe that company uses pencils in
-//! their daily activities. Uh oh, an infinite circular reference.
+//! their daily activities. Uh oh, a near-infinite circular reference.
 //!
 //! Costs cannot be effectively "walked" because the graph is too vast and in
-//! some cases, recursively infinite. Instead what we do is aggregate the costs
+//! some cases, painfully recursively. Instead what we do is aggregate the costs
 //! at the output of each economic node (company-product pair). When another
 //! company orders that product, those costs are added to theirs and move
 //! through until *they* have an output, to which costs are attributed.

--- a/src/error.rs
+++ b/src/error.rs
@@ -38,7 +38,7 @@ pub enum Error {
     /// units, such as adding 12 Hours to 16 Kilograms
     #[error("operation on measurement with mismatched units")]
     MeasureUnitsMismatched,
-    /// The given `CompanyMember` must be a `MemberWorker` class
+    /// The given `Member` must be a `MemberWorker` class
     #[error("the member given must be a worker (not company, user, etc)")]
     MemberMustBeWorker,
     /// We're missing required fields in a call

--- a/src/error.rs
+++ b/src/error.rs
@@ -38,6 +38,9 @@ pub enum Error {
     /// units, such as adding 12 Hours to 16 Kilograms
     #[error("operation on measurement with mismatched units")]
     MeasureUnitsMismatched,
+    /// The given `CompanyMember` must be a `MemberWorker` class
+    #[error("the member given must be a worker (not company, user, etc)")]
+    MemberMustBeWorker,
     /// We're missing required fields in a call
     #[error("fields missing {0:?}")]
     MissingFields(Vec<String>),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,4 @@
-//! Welcome to the Basis Core. We realize there are many choices when evaluating
-//! rust-based economic libraries that facilitate a socialist mode of production
-//! and appreciate your choice of using Basis to further your revolutionary
-//! goals.
+//! Welcome to the Basis Core.
 //!
 //! This library provides a functional interface for interacting with a graph of
 //! economic nodes engaging in a socialist mode of production. What this means

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,14 +9,13 @@
 //!
 //! 1. People should be free to determine and fulfill their own needs (bottom-up
 //! organization)
-//! 1. Companies started within this network operate without profit
-//! 1. Productive instruments are shared and managed by members
+//! 1. Companies within this network operate without profit
+//! 1. Productive instruments and property are shared and managed by members
 //!
 //! Effectively, this is a codebase designed to support [the free association
-//! of producers][freeassoc],
-//! a system of production sought after by Marxists and Anarchists in which
-//! people are free to engage in production without the shackles of currency,
-//! profits, or top-down planning structures.
+//! of producers][freeassoc], a system of production sought after by Marxists
+//! and Anarchists in which people are free to engage in production without
+//! coercion.
 //!
 //! While this ideal is a long ways away, it is nonetheless worth striving for.
 //! We also recognize that there will be inevitable transitional periods between

--- a/src/models/company.rs
+++ b/src/models/company.rs
@@ -8,7 +8,7 @@
 //! This ultimately gives more control to companies to determine their own roles
 //! (outside the perview of this library) as needed.
 //!
-//! [Members]: ../company_member/struct.CompanyMember.html
+//! [Members]: ../member/struct.Member.html
 //! [access]: ../../access/
 
 use crate::{
@@ -22,7 +22,7 @@ use crate::{
 use serde::{Serialize, Deserialize};
 use vf_rs::vf;
 
-/// A permission gives a CompanyMember the ability to perform certain actions
+/// A permission gives a Member the ability to perform certain actions
 /// within the context of a company they have a relationship (a set of roles)
 /// with. 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]

--- a/src/models/company.rs
+++ b/src/models/company.rs
@@ -22,23 +22,6 @@ use crate::{
 use serde::{Serialize, Deserialize};
 use vf_rs::vf;
 
-/// Describes different company types. Different types behave differently within
-/// the system, and this is where we differentiate the behaviors.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub enum CompanyType {
-    /// For worker-owned companies that operate within the Basis network. Note
-    /// that syndicates can span multiple regions (for instance, a company that
-    /// has workers from several neighboring regions, or a company with many
-    /// remote workers).
-    ///
-    /// Example: A local, worker-owned widget factory
-    Syndicate,
-    /// For (capitalist pig) companies that exist outside of the Basis system.
-    ///
-    /// Example: Amazon
-    Private,
-}
-
 /// A permission gives a CompanyMember the ability to perform certain actions
 /// within the context of a company they have a relationship (a set of roles)
 /// with. 
@@ -175,8 +158,6 @@ basis_model! {
         /// The Agent object for this company, stores its name, image, location,
         /// etc.
         inner: vf::Agent,
-        /// What type of company
-        ty: CompanyType,
         /// Primary email address
         email: String,
     }
@@ -230,7 +211,7 @@ mod tests {
     #[test]
     fn totals_costs() {
         let company_id = CompanyID::create();
-        let company = make_company(&company_id, CompanyType::Syndicate, "jerry's delicious widgets", &util::time::now());
+        let company = make_company(&company_id, "jerry's delicious widgets", &util::time::now());
 
         let now = util::time::now();
         let process1 = make_process(&ProcessID::create(), &company_id, "make widgets", &Costs::new_with_labor("lumberjack", dec!(16.9)), &now);

--- a/src/models/company_member.rs
+++ b/src/models/company_member.rs
@@ -13,12 +13,15 @@ use crate::{
     models::{
         account::AccountID,
         company::{CompanyID, Permission},
-        lib::agent::{Agent, AgentID},
+        lib::{
+            agent::{Agent, AgentID},
+            basis_model::ActiveState,
+        },
         occupation::OccupationID,
         user::UserID,
     },
 };
-use getset::Getters;
+use getset::{Getters, Setters};
 use om2::{Measure, Unit, NumericUnion};
 use rust_decimal::prelude::*;
 use serde::{Serialize, Deserialize};
@@ -98,20 +101,97 @@ impl Compensation {
     }
 }
 
+/// Describes a company that is a member of a company.
+#[derive(Clone, Debug, PartialEq, Getters, Setters, Serialize, Deserialize)]
+#[getset(get = "pub", set = "pub(crate)")]
+pub struct MemberCompany {
+}
+
+impl MemberCompany {
+    /// Create a new company member
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+/// Describes an individual user who is a member of a company.
+#[derive(Clone, Debug, PartialEq, Getters, Setters, Serialize, Deserialize)]
+#[getset(get = "pub", set = "pub(crate)")]
+pub struct MemberUser {
+}
+
+impl MemberUser {
+    /// Create a new company member
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+/// Describes a worker who is a member of a company.
+#[derive(Clone, Debug, PartialEq, Getters, Setters, Serialize, Deserialize)]
+#[getset(get = "pub", set = "pub(crate)")]
+pub struct MemberWorker {
+    /// Holds the id of this worker's occupation at this company.
+    ///
+    /// Note that this could be held in VF's `AgentRelationship::relationship`
+    /// field, but since that object lives in the top-level member model and the
+    /// occupation really only applies to worker members, it is a conscious
+    /// decision to put occupation in the worker struct.
+    occupation: OccupationID,
+    /// Describes how the member is compensated for their labor. Must be
+    /// defined for the member to perform labor.
+    compensation: Option<Compensation>,
+}
+
+impl MemberWorker {
+    /// Create a new worker member
+    pub fn new<T: Into<OccupationID>>(occupation_id: T, compensation: Option<Compensation>) -> Self {
+        Self {
+            occupation: occupation_id.into(),
+            compensation,
+        }
+    }
+}
+
+/// Describes the type of membership for a particular CompanyMember record.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum MemberClass {
+    /// This member is another company.
+    ///
+    /// A company which is a member of greater company automatically implies
+    /// its members are also members of the greater company.
+    Company(MemberCompany),
+    /// This member is a user.
+    ///
+    /// A user member is a non-productive member that generally has use of the
+    /// assets of the greater company. This might be things like housing,
+    /// infrastructure, etc.
+    User(MemberUser),
+    /// This member is a worker.
+    ///
+    /// Worker members are productive members of a company. They generally have
+    /// a wage/occupation
+    Worker(MemberWorker),
+}
+
 basis_model! {
     /// A member of a company. Links a user to a company, and has other attached
     /// information like compensation, permission roles, etc.
     pub struct CompanyMember {
         id: <<CompanyMemberID>>,
-        /// Our inner VF relationship (stores both the UserID and CompanyID
-        /// under the `AgentID` generic type)
-        inner: vf::AgentRelationship<(), AgentID, OccupationID>,
-        /// The permissions this member has at their company (additive)
+        /// Our inner VF relationship (stores the AgentIDs of both the parties
+        /// involved in the relationship under `subject`/`object`).
+        inner: vf::AgentRelationship<(), AgentID, ()>,
+        /// Membership class (company or user). This also holds our permissions
+        /// for user members.
+        class: MemberClass,
+        /// The permissions this member has at this company (additive)
         permissions: Vec<Permission>,
-        /// Describes how the member is compensated for their labor. Must be
-        /// defined for the member to perform labor.
-        compensation: Option<Compensation>,
-        /// Agreement under which this membership takes place
+        /// Agreement under which this membership takes place. This can be an
+        /// employee agreement, or any general membership agreement (for
+        /// instance, there might be a "you can be a member of this housing
+        /// company as long as you don't burn down your house" agreement that
+        /// user members would need to agree to).
         agreement: Option<Url>,
     }
     CompanyMemberBuilder
@@ -137,14 +217,35 @@ impl CompanyMember {
         Ok(())
     }
 
-    /// Grab this member's UserID, converted from AgentID
-    pub fn user_id(&self) -> Result<UserID> {
-        self.inner().subject().clone().try_into()
+    /// Grab the the member's agent id for this member record
+    pub fn member_id(&self) -> &AgentID {
+        self.inner().subject()
     }
 
-    /// Grab this member's CompanyID, converted from AgentID
+    /// Grab the the groups's agent id for this member record
+    pub fn group_id(&self) -> &AgentID {
+        self.inner().object()
+    }
+
+    /// Try and get a `CompanyID` from this member's group id.
     pub fn company_id(&self) -> Result<CompanyID> {
-        self.inner().object().clone().try_into()
+        self.group_id().clone().try_into()
+    }
+
+    /// Grab this member's occupation id, if it has one
+    pub fn occupation_id<'a>(&'a self) -> Option<&'a OccupationID> {
+        match self.class() {
+            MemberClass::Worker(worker) => Some(worker.occupation()),
+            _ => None,
+        }
+    }
+
+    /// Grab this member's compensation object, if it has one
+    pub fn compensation<'a>(&'a self) -> Option<&'a Compensation> {
+        match self.class() {
+            MemberClass::Worker(worker) => worker.compensation().as_ref(),
+            _ => None,
+        }
     }
 }
 
@@ -160,18 +261,19 @@ mod test {
         models::{
             company::{CompanyID, Permission as CompanyPermission},
             user::UserID,
-            testutils::make_member,
+            testutils::make_member_worker,
         },
         util,
     };
+    use std::convert::TryInto;
     use super::*;
 
     #[test]
     fn can() {
         let now = util::time::now();
-        let member = make_member(&CompanyMemberID::create(), &UserID::create(), &CompanyID::create(), &OccupationID::create(), vec![CompanyPermission::MemberCreate, CompanyPermission::MemberUpdate], &now);
-        let user_id: UserID = member.user_id().unwrap();
-        let company_id: CompanyID = member.company_id().unwrap();
+        let member = make_member_worker(&CompanyMemberID::create(), &UserID::create(), &CompanyID::create(), &OccupationID::create(), vec![CompanyPermission::MemberCreate, CompanyPermission::MemberUpdate], &now);
+        let user_id: UserID = member.member_id().clone().try_into().unwrap();
+        let company_id: CompanyID = member.group_id().clone().try_into().unwrap();
         assert!(member.can(&CompanyPermission::MemberCreate));
         assert!(member.access_check(&user_id, &company_id, CompanyPermission::MemberCreate).is_ok());
         assert!(member.access_check(&user_id, &company_id, CompanyPermission::CompanyDelete).is_err());

--- a/src/models/event.rs
+++ b/src/models/event.rs
@@ -27,7 +27,7 @@ use crate::{
         Modifications,
 
         agreement::AgreementID,
-        company_member::{CompanyMember},
+        member::{Member},
         lib::{
             agent::{Agent, AgentID},
             basis_model::Deletable,
@@ -174,7 +174,7 @@ pub struct EventProcessState {
     /// The process this event is an output of
     output_of: Option<Process>,
     /// The provider (if a member) performing an action (generally `Work`)
-    provider: Option<CompanyMember>,
+    provider: Option<Member>,
     /// The resource this event operates on (Consume/Produce/etc)
     resource: Option<Resource>,
     /// The secondary resource we're operating on (Transfer/Move/etc)
@@ -684,7 +684,7 @@ mod tests {
         costs::Costs,
         models::{
             company::{CompanyID, Permission},
-            company_member::*,
+            member::*,
             process::Process,
             resource::Resource,
             user::UserID,
@@ -942,7 +942,7 @@ mod tests {
             .updated(now.clone())
             .build().unwrap();
         if !provider_is_company {
-            let member = CompanyMember::builder()
+            let member = Member::builder()
                 .id("5555")
                 .inner(
                     vf::AgentRelationship::builder()

--- a/src/models/event.rs
+++ b/src/models/event.rs
@@ -1634,6 +1634,14 @@ mod tests {
         state3.input_of.as_mut().map(|x| x.set_company_id(CompanyID::new("bliv")));
         let res = event.process(state3.clone(), &now);
         assert_eq!(res, Err(Error::Event(EventError::ProcessOwnerMismatch)));
+
+        let mut state4 = state.clone();
+        state4.provider.as_mut().unwrap().set_class(MemberClass::User(MemberUser::new()));
+        let res = event.process(state4.clone(), &now);
+        assert_eq!(res, Err(Error::MemberMustBeWorker));
+        state4.provider.as_mut().unwrap().set_class(MemberClass::Company(MemberCompany::new()));
+        let res = event.process(state4.clone(), &now);
+        assert_eq!(res, Err(Error::MemberMustBeWorker));
     }
 
     #[test]
@@ -1665,6 +1673,14 @@ mod tests {
         state3.input_of.as_mut().map(|x| x.set_company_id(CompanyID::new("bliv")));
         let res = event.process(state3.clone(), &now);
         assert_eq!(res, Err(Error::Event(EventError::ProcessOwnerMismatch)));
+
+        let mut state4 = state.clone();
+        state4.provider.as_mut().unwrap().set_class(MemberClass::User(MemberUser::new()));
+        let res = event.process(state4.clone(), &now);
+        assert_eq!(res, Err(Error::MemberMustBeWorker));
+        state4.provider.as_mut().unwrap().set_class(MemberClass::Company(MemberCompany::new()));
+        let res = event.process(state4.clone(), &now);
+        assert_eq!(res, Err(Error::MemberMustBeWorker));
     }
 
     #[test]
@@ -1702,6 +1718,14 @@ mod tests {
         state3.input_of.as_mut().map(|x| x.set_company_id(CompanyID::new("bliv")));
         let res = event.process(state3.clone(), &now);
         assert_eq!(res, Err(Error::Event(EventError::ProcessOwnerMismatch)));
+
+        let mut state4 = state.clone();
+        state4.provider.as_mut().unwrap().set_class(MemberClass::User(MemberUser::new()));
+        let res = event.process(state4.clone(), &now);
+        assert_eq!(res, Err(Error::MemberMustBeWorker));
+        state4.provider.as_mut().unwrap().set_class(MemberClass::Company(MemberCompany::new()));
+        let res = event.process(state4.clone(), &now);
+        assert_eq!(res, Err(Error::MemberMustBeWorker));
     }
 }
 

--- a/src/models/lib/agent.rs
+++ b/src/models/lib/agent.rs
@@ -3,6 +3,7 @@ use crate::{
     models::{
         company::CompanyID,
         company_member::CompanyMemberID,
+        lib::basis_model::Deletable,
         user::UserID,
     },
 };
@@ -11,7 +12,7 @@ use std::convert::TryFrom;
 
 /// A trait that holds common agent functionality, generally applied to models
 /// with ID types implemented in `AgentID`.
-pub trait Agent {
+pub trait Agent: Deletable {
     /// Convert the model's ID to and AgentID.
     fn agent_id(&self) -> AgentID;
 }

--- a/src/models/lib/agent.rs
+++ b/src/models/lib/agent.rs
@@ -2,7 +2,7 @@ use crate::{
     error::{Result, Error},
     models::{
         company::CompanyID,
-        company_member::CompanyMemberID,
+        member::MemberID,
         lib::basis_model::Deletable,
         user::UserID,
     },
@@ -26,7 +26,7 @@ pub enum AgentID {
     #[serde(rename = "company")]
     CompanyID(CompanyID),
     #[serde(rename = "member")]
-    CompanyMemberID(CompanyMemberID),
+    MemberID(MemberID),
     #[serde(rename = "user")]
     UserID(UserID),
 }
@@ -54,6 +54,6 @@ macro_rules! impl_agent_for_model_id {
 }
 
 impl_agent_for_model_id! { CompanyID }
-impl_agent_for_model_id! { CompanyMemberID }
+impl_agent_for_model_id! { MemberID }
 impl_agent_for_model_id! { UserID }
 

--- a/src/models/lib/mod.rs
+++ b/src/models/lib/mod.rs
@@ -34,7 +34,7 @@ macro_rules! load_models {
             (agreement, Agreement, AgreementID),
             (commitment, Commitment, CommitmentID),
             (company, Company, CompanyID),
-            (company_member, CompanyMember, CompanyMemberID),
+            (member, Member, MemberID),
             (currency, Currency, CurrencyID),
             (event, Event, EventID),
             (intent, Intent, IntentID),

--- a/src/models/member.rs
+++ b/src/models/member.rs
@@ -153,7 +153,7 @@ impl MemberWorker {
     }
 }
 
-/// Describes the type of membership for a particular CompanyMember record.
+/// Describes the type of membership for a particular Member record.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum MemberClass {
     /// This member is another company.
@@ -177,8 +177,8 @@ pub enum MemberClass {
 basis_model! {
     /// A member of a company. Links a user to a company, and has other attached
     /// information like compensation, permission roles, etc.
-    pub struct CompanyMember {
-        id: <<CompanyMemberID>>,
+    pub struct Member {
+        id: <<MemberID>>,
         /// Our inner VF relationship (stores the AgentIDs of both the parties
         /// involved in the relationship under `subject`/`object`).
         inner: vf::AgentRelationship<(), AgentID, ()>,
@@ -194,10 +194,10 @@ basis_model! {
         /// user members would need to agree to).
         agreement: Option<Url>,
     }
-    CompanyMemberBuilder
+    MemberBuilder
 }
 
-impl CompanyMember {
+impl Member {
     /// Determines if a member can perform an action (base on their permissions
     /// list). Note that we don't use roles here, the idea is that companies
     /// manage their own roles and permissions are assigned to users directly.
@@ -249,7 +249,7 @@ impl CompanyMember {
     }
 }
 
-impl Agent for CompanyMember {
+impl Agent for Member {
     fn agent_id(&self) -> AgentID {
         self.id().clone().into()
     }
@@ -271,7 +271,7 @@ mod test {
     #[test]
     fn can() {
         let now = util::time::now();
-        let member = make_member_worker(&CompanyMemberID::create(), &UserID::create(), &CompanyID::create(), &OccupationID::create(), vec![CompanyPermission::MemberCreate, CompanyPermission::MemberUpdate], &now);
+        let member = make_member_worker(&MemberID::create(), &UserID::create(), &CompanyID::create(), &OccupationID::create(), vec![CompanyPermission::MemberCreate, CompanyPermission::MemberUpdate], &now);
         let user_id: UserID = member.member_id().clone().try_into().unwrap();
         let company_id: CompanyID = member.group_id().clone().try_into().unwrap();
         assert!(member.can(&CompanyPermission::MemberCreate));

--- a/src/models/member.rs
+++ b/src/models/member.rs
@@ -14,11 +14,11 @@
 //! - `User` - An individual user who is a member of a company.
 //! - `Worker` - An individual who works at the parent company, making widgets
 //! or growing vegetables or any other productive role. Workers are the only
-//! members that can perform [work transactions][1] (via a [Process]) for a
+//! members that can perform [work transactions][1] (via a [Process][0]) for a
 //! company, which assign costs to companies and print and transfer credits to
 //! the worker's preferred account.
 //!
-//! [Process]: ../process/struct.Process.html
+//! [0]: ../process/struct.Process.html
 //! [1]: ../../transactions/event/work/index.html
 
 use crate::{

--- a/src/models/member.rs
+++ b/src/models/member.rs
@@ -1,12 +1,25 @@
-//! A company member represents a link between a user in the system and a
-//! company, and carries other information with it such as position (occupation)
-//! in the company, access permissions, and compensation.
+//! A member is a link between an agent (a user or a company) to a parent
+//! company. This link can carry other information, such occupation or
+//! compensation in the case of a worker member. All memberships grant ownership
+//! of the parent company, and this ownership is exercised by *individual*
+//! members.
 //!
-//! Members can perform labor into a [Process] within the company, which earns
-//! them credits and adds costs to the company which much be assigned to
-//! outgoing products and services.
+//! Members have classes which describe the membership:
+//!
+//! - `Company` - Describes a company that is a member of another company. This
+//! membership might come with certain privileges, such as usage of resources
+//! in the larger company. When a smaller company becomes a members of a larger
+//! company, the smaller company's members also become implicit members, and
+//! become part owners of the parent company.
+//! - `User` - An individual user who is a member of a company.
+//! - `Worker` - An individual who works at the parent company, making widgets
+//! or growing vegetables or any other productive role. Workers are the only
+//! members that can perform [work transactions][1] (via a [Process]) for a
+//! company, which assign costs to companies and print and transfer credits to
+//! the worker's preferred account.
 //!
 //! [Process]: ../process/struct.Process.html
+//! [1]: ../../transactions/event/work/index.html
 
 use crate::{
     error::{Error, Result},

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -237,7 +237,7 @@ pub(crate) mod testutils {
         models::{
             agreement::{Agreement, AgreementID},
             company::{Company, CompanyID, Permission as CompanyPermission},
-            company_member::*,
+            member::*,
             lib::agent::AgentID,
             occupation::OccupationID,
             process::{Process, ProcessID},
@@ -278,8 +278,8 @@ pub(crate) mod testutils {
             .build().unwrap()
     }
 
-    pub fn make_member_worker(member_id: &CompanyMemberID, user_id: &UserID, company_id: &CompanyID, occupation_id: &OccupationID, permissions: Vec<CompanyPermission>, now: &DateTime<Utc>) -> CompanyMember {
-        CompanyMember::builder()
+    pub fn make_member_worker(member_id: &MemberID, user_id: &UserID, company_id: &CompanyID, occupation_id: &OccupationID, permissions: Vec<CompanyPermission>, now: &DateTime<Utc>) -> Member {
+        Member::builder()
             .id(member_id.clone())
             .inner(
                 vf::AgentRelationship::builder()

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -237,7 +237,7 @@ pub(crate) mod testutils {
         models::{
             agreement::{Agreement, AgreementID},
             company::{Company, CompanyID, Permission as CompanyPermission},
-            company_member::{CompanyMember, CompanyMemberID},
+            company_member::*,
             lib::agent::AgentID,
             occupation::OccupationID,
             process::{Process, ProcessID},
@@ -278,16 +278,17 @@ pub(crate) mod testutils {
             .build().unwrap()
     }
 
-    pub fn make_member(member_id: &CompanyMemberID, user_id: &UserID, company_id: &CompanyID, occupation_id: &OccupationID, permissions: Vec<CompanyPermission>, now: &DateTime<Utc>) -> CompanyMember {
+    pub fn make_member_worker(member_id: &CompanyMemberID, user_id: &UserID, company_id: &CompanyID, occupation_id: &OccupationID, permissions: Vec<CompanyPermission>, now: &DateTime<Utc>) -> CompanyMember {
         CompanyMember::builder()
             .id(member_id.clone())
             .inner(
                 vf::AgentRelationship::builder()
                     .subject(user_id.clone())
                     .object(company_id.clone())
-                    .relationship(occupation_id.clone())
+                    .relationship(())
                     .build().unwrap()
             )
+            .class(MemberClass::Worker(MemberWorker::new(occupation_id.clone(), None)))
             .permissions(permissions)
             .active(true)
             .created(now.clone())

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -236,7 +236,7 @@ pub(crate) mod testutils {
         costs::Costs,
         models::{
             agreement::{Agreement, AgreementID},
-            company::{Company, CompanyID, CompanyType, Permission as CompanyPermission},
+            company::{Company, CompanyID, Permission as CompanyPermission},
             company_member::{CompanyMember, CompanyMemberID},
             lib::agent::AgentID,
             occupation::OccupationID,
@@ -267,10 +267,9 @@ pub(crate) mod testutils {
             .build().unwrap()
     }
 
-    pub fn make_company<T: Into<String>>(id: &CompanyID, ty: CompanyType, name: T, now: &DateTime<Utc>) -> Company {
+    pub fn make_company<T: Into<String>>(id: &CompanyID, name: T, now: &DateTime<Utc>) -> Company {
         Company::builder()
             .id(id.clone())
-            .ty(ty)
             .inner(vf::Agent::builder().name(name).build().unwrap())
             .email("jerry@widgets.biz")
             .active(true)

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -8,7 +8,10 @@
 use crate::{
     access::{Permission, Role},
     models::{
-        lib::agent::{Agent, AgentID},
+        lib::{
+            agent::{Agent, AgentID},
+            basis_model::ActiveState,
+        },
     },
     error::{Error, Result},
 };

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -1,6 +1,6 @@
 //! The user is the point of access to the entire system. Users have
 //! permissions, users own accounts, users are linked to companies (via
-//! `CompanyMember` objects), and much more.
+//! `Member` objects), and much more.
 //!
 //! Every person in the system (whether they are a member or not) is represented
 //! by a `User` object.

--- a/src/transactions/agreement.rs
+++ b/src/transactions/agreement.rs
@@ -14,7 +14,10 @@ use crate::{
     models::{
         Op,
         Modifications,
-        lib::agent::AgentID,
+        lib::{
+            agent::AgentID,
+            basis_model::Deletable,
+        },
         agreement::{Agreement, AgreementID},
         company::{Company, Permission as CompanyPermission},
         company_member::CompanyMember,
@@ -89,7 +92,7 @@ mod tests {
             company::CompanyID,
             company_member::CompanyMemberID,
             occupation::OccupationID,
-            testutils::{make_user, make_company, make_member},
+            testutils::{make_user, make_company, make_member_worker},
             user::UserID,
         },
         util,
@@ -102,7 +105,7 @@ mod tests {
         let company_to = make_company(&CompanyID::create(), "sam's widgets", &now);
         let company_from = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
-        let member = make_member(&CompanyMemberID::create(), user.id(), company_to.id(), &OccupationID::create(), vec![CompanyPermission::AgreementCreate], &now);
+        let member = make_member_worker(&CompanyMemberID::create(), user.id(), company_to.id(), &OccupationID::create(), vec![CompanyPermission::AgreementCreate], &now);
         let participants = vec![company_to.agent_id(), company_from.agent_id()];
 
         let mods = create(&user, &member, &company_to, id.clone(), participants.clone(), "order 1234141", "hi i'm jerry. just going to order some widgets. don't mind me, just ordering widgets.", Some(now.clone()), true, &now).unwrap().into_vec();
@@ -142,7 +145,7 @@ mod tests {
         let company_to = make_company(&CompanyID::create(), "sam's widgets", &now);
         let company_from = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
-        let member = make_member(&CompanyMemberID::create(), user.id(), company_to.id(), &OccupationID::create(), vec![CompanyPermission::AgreementCreate, CompanyPermission::AgreementUpdate], &now);
+        let member = make_member_worker(&CompanyMemberID::create(), user.id(), company_to.id(), &OccupationID::create(), vec![CompanyPermission::AgreementCreate, CompanyPermission::AgreementUpdate], &now);
         let participants = vec![company_to.agent_id(), company_from.agent_id()];
 
         let mods = create(&user, &member, &company_to, id.clone(), participants.clone(), "order 1234141", "hi i'm jerry. just going to order some widgets. don't mind me, just ordering widgets.", Some(now.clone()), true, &now).unwrap().into_vec();

--- a/src/transactions/agreement.rs
+++ b/src/transactions/agreement.rs
@@ -20,7 +20,7 @@ use crate::{
         },
         agreement::{Agreement, AgreementID},
         company::{Company, Permission as CompanyPermission},
-        company_member::CompanyMember,
+        member::Member,
         user::User,
     },
 };
@@ -32,7 +32,7 @@ use vf_rs::vf;
 /// agreement's `participants` list will be allowed to complete updates. This
 /// makes it so only those involved in the agreement can modify it or any of its
 /// data in any way.
-pub fn create<T: Into<String>>(caller: &User, member: &CompanyMember, company: &Company, id: AgreementID, participants: Vec<AgentID>, name: T, note: T, created: Option<DateTime<Utc>>, active: bool, now: &DateTime<Utc>) -> Result<Modifications> {
+pub fn create<T: Into<String>>(caller: &User, member: &Member, company: &Company, id: AgreementID, participants: Vec<AgentID>, name: T, note: T, created: Option<DateTime<Utc>>, active: bool, now: &DateTime<Utc>) -> Result<Modifications> {
     caller.access_check(Permission::CompanyUpdateAgreements)?;
     member.access_check(caller.id(), company.id(), CompanyPermission::AgreementCreate)?;
     if company.is_deleted() {
@@ -58,7 +58,7 @@ pub fn create<T: Into<String>>(caller: &User, member: &CompanyMember, company: &
 }
 
 /// Update an agreement, including the participant list.
-pub fn update(caller: &User, member: &CompanyMember, company: &Company, mut subject: Agreement, participants: Option<Vec<AgentID>>, name: Option<String>, note: Option<String>, created: Option<Option<DateTime<Utc>>>, active: Option<bool>, now: &DateTime<Utc>) -> Result<Modifications> {
+pub fn update(caller: &User, member: &Member, company: &Company, mut subject: Agreement, participants: Option<Vec<AgentID>>, name: Option<String>, note: Option<String>, created: Option<Option<DateTime<Utc>>>, active: Option<bool>, now: &DateTime<Utc>) -> Result<Modifications> {
     caller.access_check(Permission::CompanyUpdateAgreements)?;
     member.access_check(caller.id(), company.id(), CompanyPermission::AgreementUpdate)?;
     if company.is_deleted() {
@@ -90,7 +90,7 @@ mod tests {
         models::{
             lib::agent::Agent,
             company::CompanyID,
-            company_member::CompanyMemberID,
+            member::MemberID,
             occupation::OccupationID,
             testutils::{make_user, make_company, make_member_worker},
             user::UserID,
@@ -105,7 +105,7 @@ mod tests {
         let company_to = make_company(&CompanyID::create(), "sam's widgets", &now);
         let company_from = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
-        let member = make_member_worker(&CompanyMemberID::create(), user.id(), company_to.id(), &OccupationID::create(), vec![CompanyPermission::AgreementCreate], &now);
+        let member = make_member_worker(&MemberID::create(), user.id(), company_to.id(), &OccupationID::create(), vec![CompanyPermission::AgreementCreate], &now);
         let participants = vec![company_to.agent_id(), company_from.agent_id()];
 
         let mods = create(&user, &member, &company_to, id.clone(), participants.clone(), "order 1234141", "hi i'm jerry. just going to order some widgets. don't mind me, just ordering widgets.", Some(now.clone()), true, &now).unwrap().into_vec();
@@ -145,7 +145,7 @@ mod tests {
         let company_to = make_company(&CompanyID::create(), "sam's widgets", &now);
         let company_from = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
-        let member = make_member_worker(&CompanyMemberID::create(), user.id(), company_to.id(), &OccupationID::create(), vec![CompanyPermission::AgreementCreate, CompanyPermission::AgreementUpdate], &now);
+        let member = make_member_worker(&MemberID::create(), user.id(), company_to.id(), &OccupationID::create(), vec![CompanyPermission::AgreementCreate, CompanyPermission::AgreementUpdate], &now);
         let participants = vec![company_to.agent_id(), company_from.agent_id()];
 
         let mods = create(&user, &member, &company_to, id.clone(), participants.clone(), "order 1234141", "hi i'm jerry. just going to order some widgets. don't mind me, just ordering widgets.", Some(now.clone()), true, &now).unwrap().into_vec();

--- a/src/transactions/agreement.rs
+++ b/src/transactions/agreement.rs
@@ -86,7 +86,7 @@ mod tests {
     use crate::{
         models::{
             lib::agent::Agent,
-            company::{CompanyID, CompanyType},
+            company::CompanyID,
             company_member::CompanyMemberID,
             occupation::OccupationID,
             testutils::{make_user, make_company, make_member},
@@ -99,8 +99,8 @@ mod tests {
     fn can_create() {
         let now = util::time::now();
         let id = AgreementID::create();
-        let company_to = make_company(&CompanyID::create(), CompanyType::Private, "sam's widgets", &now);
-        let company_from = make_company(&CompanyID::create(), CompanyType::Private, "jerry's widgets", &now);
+        let company_to = make_company(&CompanyID::create(), "sam's widgets", &now);
+        let company_from = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
         let member = make_member(&CompanyMemberID::create(), user.id(), company_to.id(), &OccupationID::create(), vec![CompanyPermission::AgreementCreate], &now);
         let participants = vec![company_to.agent_id(), company_from.agent_id()];
@@ -139,8 +139,8 @@ mod tests {
     fn can_update() {
         let now = util::time::now();
         let id = AgreementID::create();
-        let company_to = make_company(&CompanyID::create(), CompanyType::Private, "sam's widgets", &now);
-        let company_from = make_company(&CompanyID::create(), CompanyType::Private, "jerry's widgets", &now);
+        let company_to = make_company(&CompanyID::create(), "sam's widgets", &now);
+        let company_from = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
         let member = make_member(&CompanyMemberID::create(), user.id(), company_to.id(), &OccupationID::create(), vec![CompanyPermission::AgreementCreate, CompanyPermission::AgreementUpdate], &now);
         let participants = vec![company_to.agent_id(), company_from.agent_id()];

--- a/src/transactions/commitment.rs
+++ b/src/transactions/commitment.rs
@@ -20,7 +20,7 @@ use crate::{
         agreement::Agreement,
         commitment::{Commitment, CommitmentID},
         company::{Company, Permission as CompanyPermission},
-        company_member::CompanyMember,
+        member::Member,
         lib::{
             agent::{Agent, AgentID},
             basis_model::Deletable,
@@ -37,7 +37,7 @@ use url::Url;
 use vf_rs::{vf, geo::SpatialThing};
 
 /// Create a new commitment
-pub fn create(caller: &User, member: &CompanyMember, company: &Company, agreement: &Agreement, id: CommitmentID, move_costs: Costs, action: OrderAction, agreed_in: Option<Url>, at_location: Option<SpatialThing>, created: Option<DateTime<Utc>>, due: Option<DateTime<Utc>>, effort_quantity: Option<Measure>, finished: Option<bool>, has_beginning: Option<DateTime<Utc>>, has_end: Option<DateTime<Utc>>, has_point_in_time: Option<DateTime<Utc>>, in_scope_of: Vec<AgentID>, input_of: Option<ProcessID>, name: Option<String>, note: Option<String>, output_of: Option<ProcessID>, provider: AgentID, receiver: AgentID, resource_conforms_to: Option<ResourceSpecID>, resource_inventoried_as: Option<ResourceID>, resource_quantity: Option<Measure>, active: bool, now: &DateTime<Utc>) -> Result<Modifications> {
+pub fn create(caller: &User, member: &Member, company: &Company, agreement: &Agreement, id: CommitmentID, move_costs: Costs, action: OrderAction, agreed_in: Option<Url>, at_location: Option<SpatialThing>, created: Option<DateTime<Utc>>, due: Option<DateTime<Utc>>, effort_quantity: Option<Measure>, finished: Option<bool>, has_beginning: Option<DateTime<Utc>>, has_end: Option<DateTime<Utc>>, has_point_in_time: Option<DateTime<Utc>>, in_scope_of: Vec<AgentID>, input_of: Option<ProcessID>, name: Option<String>, note: Option<String>, output_of: Option<ProcessID>, provider: AgentID, receiver: AgentID, resource_conforms_to: Option<ResourceSpecID>, resource_inventoried_as: Option<ResourceID>, resource_quantity: Option<Measure>, active: bool, now: &DateTime<Utc>) -> Result<Modifications> {
     caller.access_check(Permission::CompanyUpdateCommitments)?;
     member.access_check(caller.id(), company.id(), CompanyPermission::CommitmentCreate)?;
     if company.is_deleted() {
@@ -95,7 +95,7 @@ pub fn create(caller: &User, member: &CompanyMember, company: &Company, agreemen
 }
 
 /// Update a commitment
-pub fn update(caller: &User, member: &CompanyMember, company: &Company, mut subject: Commitment, move_costs: Option<Costs>, action: Option<OrderAction>, agreed_in: Option<Option<Url>>, at_location: Option<Option<SpatialThing>>, created: Option<Option<DateTime<Utc>>>, due: Option<Option<DateTime<Utc>>>, effort_quantity: Option<Option<Measure>>, finished: Option<Option<bool>>, has_beginning: Option<Option<DateTime<Utc>>>, has_end: Option<Option<DateTime<Utc>>>, has_point_in_time: Option<Option<DateTime<Utc>>>, in_scope_of: Option<Vec<AgentID>>, input_of: Option<Option<ProcessID>>, name: Option<Option<String>>, note: Option<Option<String>>, output_of: Option<Option<ProcessID>>, resource_conforms_to: Option<Option<ResourceSpecID>>, resource_inventoried_as: Option<Option<ResourceID>>, resource_quantity: Option<Option<Measure>>, active: Option<bool>, now: &DateTime<Utc>) -> Result<Modifications> {
+pub fn update(caller: &User, member: &Member, company: &Company, mut subject: Commitment, move_costs: Option<Costs>, action: Option<OrderAction>, agreed_in: Option<Option<Url>>, at_location: Option<Option<SpatialThing>>, created: Option<Option<DateTime<Utc>>>, due: Option<Option<DateTime<Utc>>>, effort_quantity: Option<Option<Measure>>, finished: Option<Option<bool>>, has_beginning: Option<Option<DateTime<Utc>>>, has_end: Option<Option<DateTime<Utc>>>, has_point_in_time: Option<Option<DateTime<Utc>>>, in_scope_of: Option<Vec<AgentID>>, input_of: Option<Option<ProcessID>>, name: Option<Option<String>>, note: Option<Option<String>>, output_of: Option<Option<ProcessID>>, resource_conforms_to: Option<Option<ResourceSpecID>>, resource_inventoried_as: Option<Option<ResourceID>>, resource_quantity: Option<Option<Measure>>, active: Option<bool>, now: &DateTime<Utc>) -> Result<Modifications> {
     caller.access_check(Permission::CompanyUpdateCommitments)?;
     member.access_check(caller.id(), company.id(), CompanyPermission::CommitmentUpdate)?;
     if company.is_deleted() {
@@ -174,7 +174,7 @@ pub fn update(caller: &User, member: &CompanyMember, company: &Company, mut subj
 }
 
 /// Delete a commitment
-pub fn delete(caller: &User, member: &CompanyMember, company: &Company, mut subject: Commitment, now: &DateTime<Utc>) -> Result<Modifications> {
+pub fn delete(caller: &User, member: &Member, company: &Company, mut subject: Commitment, now: &DateTime<Utc>) -> Result<Modifications> {
     caller.access_check(Permission::CompanyUpdateCommitments)?;
     member.access_check(caller.id(), company.id(), CompanyPermission::CommitmentDelete)?;
     if company.is_deleted() {
@@ -191,7 +191,7 @@ mod tests {
         models::{
             agreement::AgreementID,
             company::CompanyID,
-            company_member::CompanyMemberID,
+            member::MemberID,
             occupation::OccupationID,
             testutils::{make_agreement, make_user, make_company, make_member_worker, make_resource},
             user::UserID,
@@ -209,7 +209,7 @@ mod tests {
         let company_to = make_company(&CompanyID::create(), "larry's chairs", &now);
         let agreement = make_agreement(&AgreementID::create(), &vec![company_from.agent_id(), company_to.agent_id()], "order 111222", "UwU big order of widgetzzz", &now);
         let user = make_user(&UserID::create(), None, &now);
-        let member = make_member_worker(&CompanyMemberID::create(), user.id(), company_to.id(), &OccupationID::create(), vec![CompanyPermission::CommitmentCreate], &now);
+        let member = make_member_worker(&MemberID::create(), user.id(), company_to.id(), &OccupationID::create(), vec![CompanyPermission::CommitmentCreate], &now);
         let costs = Costs::new_with_labor("widgetmaker", 42);
         let resource = make_resource(&ResourceID::new("widget1"), company_from.id(), &Measure::new(dec!(30), Unit::One), &Costs::new_with_labor("widgetmaker", dec!(50)), &now);
         let loc = SpatialThing::builder()
@@ -283,7 +283,7 @@ mod tests {
         let company_to = make_company(&CompanyID::create(), "larry's chairs", &now);
         let agreement = make_agreement(&AgreementID::create(), &vec![company_from.agent_id(), company_to.agent_id()], "order 111222", "UwU big order of widgetzzz", &now);
         let user = make_user(&UserID::create(), None, &now);
-        let member = make_member_worker(&CompanyMemberID::create(), user.id(), company_to.id(), &OccupationID::create(), vec![CompanyPermission::CommitmentCreate, CompanyPermission::CommitmentUpdate], &now);
+        let member = make_member_worker(&MemberID::create(), user.id(), company_to.id(), &OccupationID::create(), vec![CompanyPermission::CommitmentCreate, CompanyPermission::CommitmentUpdate], &now);
         let costs1 = Costs::new_with_labor("widgetmaker", 42);
         let costs2 = Costs::new_with_labor("widgetmaker", 31);
         let resource = make_resource(&ResourceID::new("widget1"), company_from.id(), &Measure::new(dec!(30), Unit::One), &Costs::new_with_labor("widgetmaker", dec!(50)), &now);
@@ -350,7 +350,7 @@ mod tests {
         let company_to = make_company(&CompanyID::create(), "larry's dairies (outdoor outdoor. shutup parker. thank you parker, shutup. thank you.)", &now);
         let agreement = make_agreement(&AgreementID::create(), &vec![company_from.agent_id(), company_to.agent_id()], "order 111222", "UwU big order of widgetzzz", &now);
         let user = make_user(&UserID::create(), None, &now);
-        let member = make_member_worker(&CompanyMemberID::create(), user.id(), company_to.id(), &OccupationID::create(), vec![CompanyPermission::CommitmentCreate, CompanyPermission::CommitmentDelete], &now);
+        let member = make_member_worker(&MemberID::create(), user.id(), company_to.id(), &OccupationID::create(), vec![CompanyPermission::CommitmentCreate, CompanyPermission::CommitmentDelete], &now);
         let resource = make_resource(&ResourceID::new("widget1"), company_from.id(), &Measure::new(dec!(30), Unit::One), &Costs::new_with_labor("widgetmaker", dec!(50)), &now);
         let costs1 = Costs::new_with_labor("widgetmaker", 42);
         let loc = SpatialThing::builder()

--- a/src/transactions/commitment.rs
+++ b/src/transactions/commitment.rs
@@ -187,7 +187,7 @@ mod tests {
     use crate::{
         models::{
             agreement::AgreementID,
-            company::{CompanyID, CompanyType},
+            company::CompanyID,
             company_member::CompanyMemberID,
             occupation::OccupationID,
             testutils::{make_agreement, make_user, make_company, make_member, make_resource},
@@ -202,8 +202,8 @@ mod tests {
     fn can_create() {
         let now = util::time::now();
         let id = CommitmentID::create();
-        let company_from = make_company(&CompanyID::create(), CompanyType::Private, "bridget's widgets", &now);
-        let company_to = make_company(&CompanyID::create(), CompanyType::Private, "larry's chairs", &now);
+        let company_from = make_company(&CompanyID::create(), "bridget's widgets", &now);
+        let company_to = make_company(&CompanyID::create(), "larry's chairs", &now);
         let agreement = make_agreement(&AgreementID::create(), &vec![company_from.agent_id(), company_to.agent_id()], "order 111222", "UwU big order of widgetzzz", &now);
         let user = make_user(&UserID::create(), None, &now);
         let member = make_member(&CompanyMemberID::create(), user.id(), company_to.id(), &OccupationID::create(), vec![CompanyPermission::CommitmentCreate], &now);
@@ -276,8 +276,8 @@ mod tests {
     fn can_update() {
         let now = util::time::now();
         let id = CommitmentID::create();
-        let company_from = make_company(&CompanyID::create(), CompanyType::Private, "bridget's widgets", &now);
-        let company_to = make_company(&CompanyID::create(), CompanyType::Private, "larry's chairs", &now);
+        let company_from = make_company(&CompanyID::create(), "bridget's widgets", &now);
+        let company_to = make_company(&CompanyID::create(), "larry's chairs", &now);
         let agreement = make_agreement(&AgreementID::create(), &vec![company_from.agent_id(), company_to.agent_id()], "order 111222", "UwU big order of widgetzzz", &now);
         let user = make_user(&UserID::create(), None, &now);
         let member = make_member(&CompanyMemberID::create(), user.id(), company_to.id(), &OccupationID::create(), vec![CompanyPermission::CommitmentCreate, CompanyPermission::CommitmentUpdate], &now);
@@ -343,8 +343,8 @@ mod tests {
     fn can_delete() {
         let now = util::time::now();
         let id = CommitmentID::create();
-        let company_from = make_company(&CompanyID::create(), CompanyType::Private, "bridget's widgets", &now);
-        let company_to = make_company(&CompanyID::create(), CompanyType::Private, "larry's dairies (outdoor outdoor. shutup parker. thank you parker, shutup. thank you.)", &now);
+        let company_from = make_company(&CompanyID::create(), "bridget's widgets", &now);
+        let company_to = make_company(&CompanyID::create(), "larry's dairies (outdoor outdoor. shutup parker. thank you parker, shutup. thank you.)", &now);
         let agreement = make_agreement(&AgreementID::create(), &vec![company_from.agent_id(), company_to.agent_id()], "order 111222", "UwU big order of widgetzzz", &now);
         let user = make_user(&UserID::create(), None, &now);
         let member = make_member(&CompanyMemberID::create(), user.id(), company_to.id(), &OccupationID::create(), vec![CompanyPermission::CommitmentCreate, CompanyPermission::CommitmentDelete], &now);

--- a/src/transactions/commitment.rs
+++ b/src/transactions/commitment.rs
@@ -21,7 +21,10 @@ use crate::{
         commitment::{Commitment, CommitmentID},
         company::{Company, Permission as CompanyPermission},
         company_member::CompanyMember,
-        lib::agent::{Agent, AgentID},
+        lib::{
+            agent::{Agent, AgentID},
+            basis_model::Deletable,
+        },
         process::ProcessID,
         resource::ResourceID,
         resource_spec::ResourceSpecID,
@@ -190,7 +193,7 @@ mod tests {
             company::CompanyID,
             company_member::CompanyMemberID,
             occupation::OccupationID,
-            testutils::{make_agreement, make_user, make_company, make_member, make_resource},
+            testutils::{make_agreement, make_user, make_company, make_member_worker, make_resource},
             user::UserID,
         },
         util,
@@ -206,7 +209,7 @@ mod tests {
         let company_to = make_company(&CompanyID::create(), "larry's chairs", &now);
         let agreement = make_agreement(&AgreementID::create(), &vec![company_from.agent_id(), company_to.agent_id()], "order 111222", "UwU big order of widgetzzz", &now);
         let user = make_user(&UserID::create(), None, &now);
-        let member = make_member(&CompanyMemberID::create(), user.id(), company_to.id(), &OccupationID::create(), vec![CompanyPermission::CommitmentCreate], &now);
+        let member = make_member_worker(&CompanyMemberID::create(), user.id(), company_to.id(), &OccupationID::create(), vec![CompanyPermission::CommitmentCreate], &now);
         let costs = Costs::new_with_labor("widgetmaker", 42);
         let resource = make_resource(&ResourceID::new("widget1"), company_from.id(), &Measure::new(dec!(30), Unit::One), &Costs::new_with_labor("widgetmaker", dec!(50)), &now);
         let loc = SpatialThing::builder()
@@ -280,7 +283,7 @@ mod tests {
         let company_to = make_company(&CompanyID::create(), "larry's chairs", &now);
         let agreement = make_agreement(&AgreementID::create(), &vec![company_from.agent_id(), company_to.agent_id()], "order 111222", "UwU big order of widgetzzz", &now);
         let user = make_user(&UserID::create(), None, &now);
-        let member = make_member(&CompanyMemberID::create(), user.id(), company_to.id(), &OccupationID::create(), vec![CompanyPermission::CommitmentCreate, CompanyPermission::CommitmentUpdate], &now);
+        let member = make_member_worker(&CompanyMemberID::create(), user.id(), company_to.id(), &OccupationID::create(), vec![CompanyPermission::CommitmentCreate, CompanyPermission::CommitmentUpdate], &now);
         let costs1 = Costs::new_with_labor("widgetmaker", 42);
         let costs2 = Costs::new_with_labor("widgetmaker", 31);
         let resource = make_resource(&ResourceID::new("widget1"), company_from.id(), &Measure::new(dec!(30), Unit::One), &Costs::new_with_labor("widgetmaker", dec!(50)), &now);
@@ -347,7 +350,7 @@ mod tests {
         let company_to = make_company(&CompanyID::create(), "larry's dairies (outdoor outdoor. shutup parker. thank you parker, shutup. thank you.)", &now);
         let agreement = make_agreement(&AgreementID::create(), &vec![company_from.agent_id(), company_to.agent_id()], "order 111222", "UwU big order of widgetzzz", &now);
         let user = make_user(&UserID::create(), None, &now);
-        let member = make_member(&CompanyMemberID::create(), user.id(), company_to.id(), &OccupationID::create(), vec![CompanyPermission::CommitmentCreate, CompanyPermission::CommitmentDelete], &now);
+        let member = make_member_worker(&CompanyMemberID::create(), user.id(), company_to.id(), &OccupationID::create(), vec![CompanyPermission::CommitmentCreate, CompanyPermission::CommitmentDelete], &now);
         let resource = make_resource(&ResourceID::new("widget1"), company_from.id(), &Measure::new(dec!(30), Unit::One), &Costs::new_with_labor("widgetmaker", dec!(50)), &now);
         let costs1 = Costs::new_with_labor("widgetmaker", 42);
         let loc = SpatialThing::builder()

--- a/src/transactions/company.rs
+++ b/src/transactions/company.rs
@@ -26,7 +26,7 @@ use crate::{
 use vf_rs::vf;
 
 /// Creates a new private company
-pub fn create_private<T: Into<String>>(caller: &User, id: CompanyID, company_name: T, company_email: T, company_active: bool, founder_id: CompanyMemberID, founder_occupation_id: OccupationID, founder_active: bool, now: &DateTime<Utc>) -> Result<Modifications> {
+pub fn create<T: Into<String>>(caller: &User, id: CompanyID, company_name: T, company_email: T, company_active: bool, founder_id: CompanyMemberID, founder_occupation_id: OccupationID, founder_active: bool, now: &DateTime<Utc>) -> Result<Modifications> {
     caller.access_check(Permission::CompanyCreate)?;
     let company = Company::builder()
         .id(id.clone())
@@ -104,7 +104,7 @@ mod tests {
     };
 
     #[test]
-    fn can_create_private() {
+    fn can_create() {
         let id = CompanyID::create();
         let founder_id = CompanyMemberID::create();
         let occupation_id = OccupationID::new("CEO THE BEST CEO EVERYONE SAYS SO");
@@ -114,7 +114,7 @@ mod tests {
         // it was actually pretty fun. hey if you're free later maybe we could
         // make some widgets togethe...oh, you're busy? oh ok, that's cool, no
         // problem. hey, maybe next time.
-        let mods = create_private(&user, id.clone(), "jerry's widgets", "jerry@widgets.expert", true, founder_id.clone(), occupation_id.clone(), true, &now).unwrap().into_vec();
+        let mods = create(&user, id.clone(), "jerry's widgets", "jerry@widgets.expert", true, founder_id.clone(), occupation_id.clone(), true, &now).unwrap().into_vec();
         assert_eq!(mods.len(), 2);
 
         let company = mods[0].clone().expect_op::<Company>(Op::Create).unwrap();
@@ -142,7 +142,7 @@ mod tests {
         let occupation_id = OccupationID::new("CEO THE BEST CEO EVERYONE SAYS SO");
         let now = util::time::now();
         let mut user = make_user(&UserID::create(), Some(vec![Role::SuperAdmin]), &now);
-        let mods = create_private(&user, id.clone(), "jerry's widgets", "jerry@widgets.expert", true, founder_id.clone(), occupation_id.clone(), true, &now).unwrap().into_vec();
+        let mods = create(&user, id.clone(), "jerry's widgets", "jerry@widgets.expert", true, founder_id.clone(), occupation_id.clone(), true, &now).unwrap().into_vec();
         let company = mods[0].clone().expect_op::<Company>(Op::Create).unwrap();
         let founder = mods[1].clone().expect_op::<CompanyMember>(Op::Create).unwrap();
 
@@ -173,7 +173,7 @@ mod tests {
         let occupation_id = OccupationID::new("CEO THE BEST CEO EVERYONE SAYS SO");
         let now = util::time::now();
         let mut user = make_user(&UserID::create(), Some(vec![Role::SuperAdmin]), &now);
-        let mods = create_private(&user, id.clone(), "jerry's widgets", "jerry@widgets.expert", true, founder_id.clone(), occupation_id.clone(), true, &now).unwrap().into_vec();
+        let mods = create(&user, id.clone(), "jerry's widgets", "jerry@widgets.expert", true, founder_id.clone(), occupation_id.clone(), true, &now).unwrap().into_vec();
         let company = mods[0].clone().expect_op::<Company>(Op::Create).unwrap();
         let founder = mods[1].clone().expect_op::<CompanyMember>(Op::Create).unwrap();
 

--- a/src/transactions/company.rs
+++ b/src/transactions/company.rs
@@ -17,7 +17,7 @@ use crate::{
     models::{
         Op,
         Modifications,
-        company::{Company, CompanyID, CompanyType, Permission as CompanyPermission},
+        company::{Company, CompanyID, Permission as CompanyPermission},
         company_member::{CompanyMember, CompanyMemberID},
         occupation::OccupationID,
         user::User,
@@ -27,10 +27,9 @@ use vf_rs::vf;
 
 /// Creates a new private company
 pub fn create_private<T: Into<String>>(caller: &User, id: CompanyID, company_name: T, company_email: T, company_active: bool, founder_id: CompanyMemberID, founder_occupation_id: OccupationID, founder_active: bool, now: &DateTime<Utc>) -> Result<Modifications> {
-    caller.access_check(Permission::CompanyCreatePrivate)?;
+    caller.access_check(Permission::CompanyCreate)?;
     let company = Company::builder()
         .id(id.clone())
-        .ty(CompanyType::Private)
         .inner(
             vf::Agent::builder()
                 .name(company_name)
@@ -121,7 +120,6 @@ mod tests {
         let company = mods[0].clone().expect_op::<Company>(Op::Create).unwrap();
         let founder = mods[1].clone().expect_op::<CompanyMember>(Op::Create).unwrap();
         assert_eq!(company.id(), &id);
-        assert_eq!(company.ty(), &CompanyType::Private);
         assert_eq!(company.inner().name(), "jerry's widgets");
         assert_eq!(company.email(), "jerry@widgets.expert");
         assert_eq!(company.active(), &true);

--- a/src/transactions/company.rs
+++ b/src/transactions/company.rs
@@ -109,7 +109,7 @@ mod tests {
         let founder_id = CompanyMemberID::create();
         let occupation_id = OccupationID::new("CEO THE BEST CEO EVERYONE SAYS SO");
         let now = util::time::now();
-        let user = make_user(&UserID::create(), Some(vec![Role::SuperAdmin]), &now);
+        let user = make_user(&UserID::create(), Some(vec![Role::User]), &now);
         // just makin' some widgets, huh? that's cool. hey, I made a widget once,
         // it was actually pretty fun. hey if you're free later maybe we could
         // make some widgets togethe...oh, you're busy? oh ok, that's cool, no
@@ -141,7 +141,7 @@ mod tests {
         let founder_id = CompanyMemberID::create();
         let occupation_id = OccupationID::new("CEO THE BEST CEO EVERYONE SAYS SO");
         let now = util::time::now();
-        let mut user = make_user(&UserID::create(), Some(vec![Role::SuperAdmin]), &now);
+        let mut user = make_user(&UserID::create(), Some(vec![Role::User]), &now);
         let mods = create(&user, id.clone(), "jerry's widgets", "jerry@widgets.expert", true, founder_id.clone(), occupation_id.clone(), true, &now).unwrap().into_vec();
         let company = mods[0].clone().expect_op::<Company>(Op::Create).unwrap();
         let founder = mods[1].clone().expect_op::<CompanyMember>(Op::Create).unwrap();
@@ -172,7 +172,7 @@ mod tests {
         let founder_id = CompanyMemberID::create();
         let occupation_id = OccupationID::new("CEO THE BEST CEO EVERYONE SAYS SO");
         let now = util::time::now();
-        let mut user = make_user(&UserID::create(), Some(vec![Role::SuperAdmin]), &now);
+        let mut user = make_user(&UserID::create(), Some(vec![Role::User]), &now);
         let mods = create(&user, id.clone(), "jerry's widgets", "jerry@widgets.expert", true, founder_id.clone(), occupation_id.clone(), true, &now).unwrap().into_vec();
         let company = mods[0].clone().expect_op::<Company>(Op::Create).unwrap();
         let founder = mods[1].clone().expect_op::<CompanyMember>(Op::Create).unwrap();

--- a/src/transactions/company.rs
+++ b/src/transactions/company.rs
@@ -18,7 +18,7 @@ use crate::{
         Op,
         Modifications,
         company::{Company, CompanyID, Permission as CompanyPermission},
-        company_member::{CompanyMember, CompanyMemberID},
+        company_member::{CompanyMember, CompanyMemberID, MemberClass, MemberWorker},
         occupation::OccupationID,
         user::User,
     },
@@ -48,10 +48,11 @@ pub fn create<T: Into<String>>(caller: &User, id: CompanyID, company_name: T, co
             vf::AgentRelationship::builder()
                 .subject(caller.id().clone())
                 .object(id.clone())
-                .relationship(founder_occupation_id)
+                .relationship(())
                 .build()
                 .map_err(|e| Error::BuilderFailed(e))?
         )
+        .class(MemberClass::Worker(MemberWorker::new(founder_occupation_id, None)))
         .permissions(vec![CompanyPermission::All])
         .active(founder_active)
         .created(now.clone())
@@ -128,7 +129,7 @@ mod tests {
         assert_eq!(founder.id(), &founder_id);
         assert_eq!(founder.inner().subject(), &user.agent_id());
         assert_eq!(founder.inner().object(), &id.clone().into());
-        assert_eq!(founder.inner().relationship(), &occupation_id);
+        assert_eq!(founder.occupation_id(), Some(&occupation_id));
         assert_eq!(founder.permissions(), &vec![CompanyPermission::All]);
         assert_eq!(founder.active(), &true);
         assert_eq!(founder.created(), &now);

--- a/src/transactions/company_member.rs
+++ b/src/transactions/company_member.rs
@@ -103,7 +103,7 @@ mod tests {
     use crate::{
         models::{
             account::AccountID,
-            company::{CompanyID, CompanyType},
+            company::CompanyID,
             lib::agent::Agent,
             user::UserID,
             testutils::{make_user, make_company, make_member},
@@ -117,7 +117,7 @@ mod tests {
     fn can_create() {
         let now = util::time::now();
         let id = CompanyMemberID::create();
-        let company = make_company(&CompanyID::create(), CompanyType::Private, "jerry's widgets", &now);
+        let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let occupation_id = OccupationID::create();
         let agreement: Url = "https://mydoc.com/work_agreement_1".parse().unwrap();
         let user = make_user(&UserID::create(), None, &now);
@@ -163,7 +163,7 @@ mod tests {
     fn can_update() {
         let now = util::time::now();
         let id = CompanyMemberID::create();
-        let company = make_company(&CompanyID::create(), CompanyType::Private, "jerry's widgets", &now);
+        let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let occupation_id = OccupationID::create();
         let agreement: Url = "https://mydoc.com/work_agreement_1".parse().unwrap();
         let user = make_user(&UserID::create(), None, &now);
@@ -204,7 +204,7 @@ mod tests {
     fn can_set_permissions() {
         let now = util::time::now();
         let id = CompanyMemberID::create();
-        let company = make_company(&CompanyID::create(), CompanyType::Private, "jerry's widgets", &now);
+        let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let occupation_id = OccupationID::create();
         let user = make_user(&UserID::create(), None, &now);
         let new_user = make_user(&UserID::create(), None, &now);
@@ -237,7 +237,7 @@ mod tests {
     fn can_set_compensation() {
         let now = util::time::now();
         let id = CompanyMemberID::create();
-        let company = make_company(&CompanyID::create(), CompanyType::Private, "jerry's widgets", &now);
+        let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let occupation_id = OccupationID::create();
         let user = make_user(&UserID::create(), None, &now);
         let new_user = make_user(&UserID::create(), None, &now);
@@ -271,7 +271,7 @@ mod tests {
     fn can_delete() {
         let now = util::time::now();
         let id = CompanyMemberID::create();
-        let company = make_company(&CompanyID::create(), CompanyType::Private, "jerry's widgets", &now);
+        let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let occupation_id = OccupationID::create();
         let user = make_user(&UserID::create(), None, &now);
         let new_user = make_user(&UserID::create(), None, &now);

--- a/src/transactions/company_member.rs
+++ b/src/transactions/company_member.rs
@@ -13,7 +13,11 @@ use crate::{
         Op,
         Modifications,
         company::{Company, Permission as CompanyPermission},
-        company_member::{Compensation, CompanyMember, CompanyMemberID},
+        company_member::{Compensation, CompanyMember, CompanyMemberID, MemberClass},
+        lib::{
+            agent::Agent,
+            basis_model::Deletable,
+        },
         occupation::OccupationID,
         user::User,
     },
@@ -22,25 +26,26 @@ use url::Url;
 use vf_rs::vf;
 
 /// Create a new member.
-pub fn create(caller: &User, member: &CompanyMember, id: CompanyMemberID, user: User, company: Company, occupation_id: OccupationID, permissions: Vec<CompanyPermission>, agreement: Option<Url>, active: bool, now: &DateTime<Utc>) -> Result<Modifications> {
+pub fn create<T: Agent>(caller: &User, member: &CompanyMember, id: CompanyMemberID, agent_from: T, agent_to: Company, class: MemberClass, permissions: Vec<CompanyPermission>, agreement: Option<Url>, active: bool, now: &DateTime<Utc>) -> Result<Modifications> {
     caller.access_check(Permission::CompanyUpdateMembers)?;
-    member.access_check(caller.id(), company.id(), CompanyPermission::MemberCreate)?;
-    if user.is_deleted() {
-        Err(Error::UserIsDeleted)?;
+    member.access_check(caller.id(), agent_to.id(), CompanyPermission::MemberCreate)?;
+    if agent_from.is_deleted() {
+        Err(Error::ObjectIsDeleted("agent".into()))?;
     }
-    if company.is_deleted() {
+    if agent_to.is_deleted() {
         Err(Error::ObjectIsDeleted("company".into()))?;
     }
     let model = CompanyMember::builder()
         .id(id)
         .inner(
             vf::AgentRelationship::builder()
-                .subject(user.id().clone())
-                .object(company.id().clone())
-                .relationship(occupation_id)
+                .subject(agent_from.agent_id())
+                .object(agent_to.agent_id())
+                .relationship(())
                 .build()
                 .map_err(|e| Error::BuilderFailed(e))?
         )
+        .class(class)
         .permissions(permissions)
         .agreement(agreement)
         .active(active)
@@ -57,7 +62,12 @@ pub fn update(caller: &User, member: &CompanyMember, mut subject: CompanyMember,
     member.access_check(caller.id(), &subject.company_id()?, CompanyPermission::MemberUpdate)?;
 
     if let Some(occupation_id) = occupation_id {
-        subject.inner_mut().set_relationship(occupation_id);
+        match subject.class_mut() {
+            MemberClass::Worker(worker) => {
+                worker.set_occupation(occupation_id);
+            }
+            _ => Err(Error::MemberMustBeWorker)?,
+        }
     }
     if agreement.is_some() {
         subject.set_agreement(agreement);
@@ -79,12 +89,17 @@ pub fn set_permissions(caller: &User, member: &CompanyMember, mut subject: Compa
     Ok(Modifications::new_single(Op::Update, subject))
 }
 
-/// Set a member's company permissions.
+/// Set a member's compensation.
 pub fn set_compensation(caller: &User, member: &CompanyMember, mut subject: CompanyMember, compensation: Compensation, now: &DateTime<Utc>) -> Result<Modifications> {
     caller.access_check(Permission::CompanyUpdateMembers)?;
     member.access_check(caller.id(), &subject.company_id()?, CompanyPermission::MemberSetCompensation)?;
 
-    subject.set_compensation(Some(compensation));
+    match subject.class_mut() {
+        MemberClass::Worker(worker) => {
+            worker.set_compensation(Some(compensation));
+        }
+        _ => Err(Error::MemberMustBeWorker)?,
+    }
     subject.set_updated(now.clone());
     Ok(Modifications::new_single(Op::Update, subject))
 }
@@ -104,9 +119,13 @@ mod tests {
         models::{
             account::AccountID,
             company::CompanyID,
-            lib::agent::Agent,
+            company_member::MemberWorker,
+            lib::{
+                agent::Agent,
+                basis_model::ActiveState,
+            },
             user::UserID,
-            testutils::{make_user, make_company, make_member},
+            testutils::{make_user, make_company, make_member_worker},
         },
         util,
     };
@@ -122,15 +141,16 @@ mod tests {
         let agreement: Url = "https://mydoc.com/work_agreement_1".parse().unwrap();
         let user = make_user(&UserID::create(), None, &now);
         let new_user = make_user(&UserID::create(), None, &now);
-        let existing_member = make_member(&CompanyMemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::MemberCreate], &now);
+        let existing_member = make_member_worker(&CompanyMemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::MemberCreate], &now);
+        let new_class = MemberClass::Worker(MemberWorker::new(occupation_id.clone(), None));
 
-        let mods = create(&user, &existing_member, id.clone(), new_user.clone(), company.clone(), occupation_id.clone(), vec![], Some(agreement.clone()), true, &now).unwrap().into_vec();
+        let mods = create(&user, &existing_member, id.clone(), new_user.clone(), company.clone(), new_class.clone(), vec![], Some(agreement.clone()), true, &now).unwrap().into_vec();
         assert_eq!(mods.len(), 1);
         let member = mods[0].clone().expect_op::<CompanyMember>(Op::Create).unwrap();
         assert_eq!(member.id(), &id);
         assert_eq!(member.inner().subject(), &new_user.agent_id());
         assert_eq!(member.inner().object(), &company.agent_id());
-        assert_eq!(member.inner().relationship(), &occupation_id);
+        assert_eq!(member.occupation_id().unwrap(), &occupation_id);
         assert_eq!(member.permissions().len(), 0);
         assert_eq!(member.agreement(), &Some(agreement.clone()));
         assert_eq!(member.active(), &true);
@@ -141,22 +161,22 @@ mod tests {
         assert_eq!(member.is_deleted(), false);
 
         let user2 = make_user(user.id(), Some(vec![]), &now);
-        let res = create(&user2, &existing_member, id.clone(), new_user.clone(), company.clone(), occupation_id.clone(), vec![], Some(agreement.clone()), true, &now);
+        let res = create(&user2, &existing_member, id.clone(), new_user.clone(), company.clone(), new_class.clone(), vec![], Some(agreement.clone()), true, &now);
         assert_eq!(res, Err(Error::InsufficientPrivileges));
 
         let user3 = make_user(&UserID::create(), None, &now);
-        let res = create(&user3, &existing_member, id.clone(), new_user.clone(), company.clone(), occupation_id.clone(), vec![], Some(agreement.clone()), true, &now);
+        let res = create(&user3, &existing_member, id.clone(), new_user.clone(), company.clone(), new_class.clone(), vec![], Some(agreement.clone()), true, &now);
         assert_eq!(res, Err(Error::InsufficientPrivileges));
 
         let mut company2 = company.clone();
         company2.set_deleted(Some(now.clone()));
-        let res = create(&user, &existing_member, id.clone(), new_user.clone(), company2.clone(), occupation_id.clone(), vec![], Some(agreement.clone()), true, &now);
+        let res = create(&user, &existing_member, id.clone(), new_user.clone(), company2.clone(), new_class.clone(), vec![], Some(agreement.clone()), true, &now);
         assert_eq!(res, Err(Error::ObjectIsDeleted("company".into())));
 
         let mut new_user2 = new_user.clone();
         new_user2.set_deleted(Some(now.clone()));
-        let res = create(&user, &existing_member, id.clone(), new_user2.clone(), company.clone(), occupation_id.clone(), vec![], Some(agreement.clone()), true, &now);
-        assert_eq!(res, Err(Error::UserIsDeleted));
+        let res = create(&user, &existing_member, id.clone(), new_user2.clone(), company.clone(), new_class.clone(), vec![], Some(agreement.clone()), true, &now);
+        assert_eq!(res, Err(Error::ObjectIsDeleted("agent".into())));
     }
 
     #[test]
@@ -168,9 +188,10 @@ mod tests {
         let agreement: Url = "https://mydoc.com/work_agreement_1".parse().unwrap();
         let user = make_user(&UserID::create(), None, &now);
         let new_user = make_user(&UserID::create(), None, &now);
-        let mut existing_member = make_member(&CompanyMemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::MemberCreate], &now);
+        let mut existing_member = make_member_worker(&CompanyMemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::MemberCreate], &now);
+        let new_class = MemberClass::Worker(MemberWorker::new(occupation_id.clone(), None));
 
-        let mods = create(&user, &existing_member, id.clone(), new_user.clone(), company.clone(), occupation_id.clone(), vec![], None, true, &now).unwrap().into_vec();
+        let mods = create(&user, &existing_member, id.clone(), new_user.clone(), company.clone(), new_class.clone(), vec![], None, true, &now).unwrap().into_vec();
         let member = mods[0].clone().expect_op::<CompanyMember>(Op::Create).unwrap();
 
         // fails because existing_member doesn't have update perm
@@ -191,7 +212,7 @@ mod tests {
         assert!(member.agreement() != member2.agreement());
         assert_eq!(member2.agreement(), &Some(agreement.clone()));
         assert_eq!(member2.active(), &true);
-        assert_eq!(member2.inner().relationship(), &new_occupation);
+        assert_eq!(member2.occupation_id().unwrap(), &new_occupation);
 
         let res = update(&user, &member, member.clone(), Some(new_occupation.clone()), Some(agreement.clone()), None, &now2);
         assert_eq!(res, Err(Error::InsufficientPrivileges));
@@ -208,9 +229,10 @@ mod tests {
         let occupation_id = OccupationID::create();
         let user = make_user(&UserID::create(), None, &now);
         let new_user = make_user(&UserID::create(), None, &now);
-        let mut existing_member = make_member(&CompanyMemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::MemberCreate], &now);
+        let mut existing_member = make_member_worker(&CompanyMemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::MemberCreate], &now);
+        let new_class = MemberClass::Worker(MemberWorker::new(occupation_id.clone(), None));
 
-        let mods = create(&user, &existing_member, id.clone(), new_user.clone(), company.clone(), occupation_id.clone(), vec![], None, true, &now).unwrap().into_vec();
+        let mods = create(&user, &existing_member, id.clone(), new_user.clone(), company.clone(), new_class.clone(), vec![], None, true, &now).unwrap().into_vec();
         let member = mods[0].clone().expect_op::<CompanyMember>(Op::Create).unwrap();
 
         // fails because existing_member doesn't have set_perms perm
@@ -241,9 +263,10 @@ mod tests {
         let occupation_id = OccupationID::create();
         let user = make_user(&UserID::create(), None, &now);
         let new_user = make_user(&UserID::create(), None, &now);
-        let mut existing_member = make_member(&CompanyMemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::MemberCreate], &now);
+        let mut existing_member = make_member_worker(&CompanyMemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::MemberCreate], &now);
+        let new_class = MemberClass::Worker(MemberWorker::new(occupation_id.clone(), None));
 
-        let mods = create(&user, &existing_member, id.clone(), new_user.clone(), company.clone(), occupation_id.clone(), vec![], None, true, &now).unwrap().into_vec();
+        let mods = create(&user, &existing_member, id.clone(), new_user.clone(), company.clone(), new_class.clone(), vec![], None, true, &now).unwrap().into_vec();
         let member = mods[0].clone().expect_op::<CompanyMember>(Op::Create).unwrap();
 
         let compensation = Compensation::new_hourly(32 as u32, AccountID::create());
@@ -256,9 +279,9 @@ mod tests {
         let mods = set_compensation(&user, &existing_member, member.clone(), compensation.clone(), &now2).unwrap().into_vec();
         assert_eq!(mods.len(), 1);
         let member2 = mods[0].clone().expect_op::<CompanyMember>(Op::Update).unwrap();
-        assert_eq!(member.compensation(), &None);
-        assert_eq!(member2.compensation().as_ref().unwrap().wage(), &Measure::new(dec!(32), Unit::Hour));
-        assert_eq!(member2.compensation().as_ref().unwrap(), &compensation);
+        assert_eq!(member.compensation(), None);
+        assert_eq!(member2.compensation().unwrap().wage(), &Measure::new(dec!(32), Unit::Hour));
+        assert_eq!(member2.compensation().unwrap(), &compensation);
         assert_eq!(member2.updated(), &now2);
 
         let mut user2 = user.clone();
@@ -275,9 +298,10 @@ mod tests {
         let occupation_id = OccupationID::create();
         let user = make_user(&UserID::create(), None, &now);
         let new_user = make_user(&UserID::create(), None, &now);
-        let mut existing_member = make_member(&CompanyMemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::MemberCreate], &now);
+        let mut existing_member = make_member_worker(&CompanyMemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::MemberCreate], &now);
+        let new_class = MemberClass::Worker(MemberWorker::new(occupation_id.clone(), None));
 
-        let mods = create(&user, &existing_member, id.clone(), new_user.clone(), company.clone(), occupation_id.clone(), vec![], None, true, &now).unwrap().into_vec();
+        let mods = create(&user, &existing_member, id.clone(), new_user.clone(), company.clone(), new_class.clone(), vec![], None, true, &now).unwrap().into_vec();
         let member = mods[0].clone().expect_op::<CompanyMember>(Op::Create).unwrap();
 
         let now2 = util::time::now();

--- a/src/transactions/event/accounting.rs
+++ b/src/transactions/event/accounting.rs
@@ -15,6 +15,7 @@ use crate::{
         event::{Event, EventID, EventProcessState, MoveType},
         company::{Company, Permission as CompanyPermission},
         company_member::CompanyMember,
+        lib::basis_model::Deletable,
         process::Process,
         resource::Resource,
         user::User,
@@ -244,7 +245,7 @@ mod tests {
             occupation::OccupationID,
             process::{Process, ProcessID},
             resource::ResourceID,
-            testutils::{make_user, make_company, make_member, make_process, make_resource},
+            testutils::{make_user, make_company, make_member_worker, make_process, make_resource},
             user::UserID,
         },
         util,
@@ -259,7 +260,7 @@ mod tests {
         let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
         let occupation_id = OccupationID::new("machinist");
-        let member = make_member(&CompanyMemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
+        let member = make_member_worker(&CompanyMemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
         let resource = make_resource(&ResourceID::new("widget"), company.id(), &Measure::new(dec!(15), Unit::One), &Costs::new_with_labor("homemaker", 157), &now);
 
         let res = lower(&user, &member, &company, id.clone(), resource.clone(), 8, Some("my note".into()), &now);
@@ -325,7 +326,7 @@ mod tests {
         let company = make_company(&CompanyID::create(), "jerry's planks", &now);
         let user = make_user(&UserID::create(), None, &now);
         let occupation_id = OccupationID::new("lawyer");
-        let member = make_member(&CompanyMemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
+        let member = make_member_worker(&CompanyMemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
         let process_from = make_process(&ProcessID::create(), company.id(), "various lawyerings", &Costs::new_with_labor(occupation_id.clone(), dec!(177.25)), &now);
         let process_to = make_process(&ProcessID::create(), company.id(), "overflow labor", &Costs::new_with_labor(occupation_id.clone(), dec!(804)), &now);
 
@@ -401,7 +402,7 @@ mod tests {
         let company = make_company(&CompanyID::create(), "jerry's planks", &now);
         let user = make_user(&UserID::create(), None, &now);
         let occupation_id = OccupationID::new("machinist");
-        let member = make_member(&CompanyMemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
+        let member = make_member_worker(&CompanyMemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
         let resource = make_resource(&ResourceID::new("plank"), company.id(), &Measure::new(dec!(15), Unit::One), &Costs::new_with_labor("homemaker", 157), &now);
         let resource_to = make_resource(&ResourceID::new("plank"), company.id(), &Measure::new(dec!(3), Unit::One), &Costs::new_with_labor("homemaker", 2), &now);
         let loc = SpatialThing::builder()
@@ -532,7 +533,7 @@ mod tests {
         let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
         let occupation_id = OccupationID::new("machinist");
-        let member = make_member(&CompanyMemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
+        let member = make_member_worker(&CompanyMemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
         let resource = make_resource(&ResourceID::new("widget"), company.id(), &Measure::new(dec!(15), Unit::One), &Costs::new_with_labor("homemaker", 157), &now);
 
         let res = raise(&user, &member, &company, id.clone(), resource.clone(), 8, Some("toot".into()), &now);

--- a/src/transactions/event/accounting.rs
+++ b/src/transactions/event/accounting.rs
@@ -238,7 +238,7 @@ mod tests {
     use crate::{
         models::{
             lib::agent::Agent,
-            company::{CompanyID, CompanyType},
+            company::CompanyID,
             company_member::CompanyMemberID,
             event::{EventID, EventError},
             occupation::OccupationID,
@@ -256,7 +256,7 @@ mod tests {
     fn can_lower() {
         let now = util::time::now();
         let id = EventID::create();
-        let company = make_company(&CompanyID::create(), CompanyType::Private, "jerry's widgets", &now);
+        let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
         let occupation_id = OccupationID::new("machinist");
         let member = make_member(&CompanyMemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
@@ -322,7 +322,7 @@ mod tests {
     fn can_move_costs() {
         let now = util::time::now();
         let id = EventID::create();
-        let company = make_company(&CompanyID::create(), CompanyType::Private, "jerry's planks", &now);
+        let company = make_company(&CompanyID::create(), "jerry's planks", &now);
         let user = make_user(&UserID::create(), None, &now);
         let occupation_id = OccupationID::new("lawyer");
         let member = make_member(&CompanyMemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
@@ -398,7 +398,7 @@ mod tests {
     fn can_move_resource() {
         let now = util::time::now();
         let id = EventID::create();
-        let company = make_company(&CompanyID::create(), CompanyType::Private, "jerry's planks", &now);
+        let company = make_company(&CompanyID::create(), "jerry's planks", &now);
         let user = make_user(&UserID::create(), None, &now);
         let occupation_id = OccupationID::new("machinist");
         let member = make_member(&CompanyMemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
@@ -529,7 +529,7 @@ mod tests {
     fn can_raise() {
         let now = util::time::now();
         let id = EventID::create();
-        let company = make_company(&CompanyID::create(), CompanyType::Private, "jerry's widgets", &now);
+        let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
         let occupation_id = OccupationID::new("machinist");
         let member = make_member(&CompanyMemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);

--- a/src/transactions/event/delivery.rs
+++ b/src/transactions/event/delivery.rs
@@ -15,6 +15,7 @@ use crate::{
         event::{Event, EventID, EventProcessState},
         company::{Company, Permission as CompanyPermission},
         company_member::CompanyMember,
+        lib::basis_model::Deletable,
         process::Process,
         resource::Resource,
         user::User,
@@ -135,7 +136,7 @@ mod tests {
             occupation::OccupationID,
             process::ProcessID,
             resource::ResourceID,
-            testutils::{make_user, make_company, make_member, make_process, make_resource},
+            testutils::{make_user, make_company, make_member_worker, make_process, make_resource},
             user::UserID,
         },
         util,
@@ -150,7 +151,7 @@ mod tests {
         let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
         let occupation_id = OccupationID::new("trucker");
-        let member = make_member(&CompanyMemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
+        let member = make_member_worker(&CompanyMemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
         let resource = make_resource(&ResourceID::new("widget"), company.id(), &Measure::new(dec!(15), Unit::One), &Costs::new_with_labor("machinist", 157), &now);
         let costs = Costs::new_with_labor(occupation_id.clone(), dec!(42.2));
         let process = make_process(&ProcessID::create(), company.id(), "deliver widgets", &costs, &now);
@@ -237,7 +238,7 @@ mod tests {
         let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
         let occupation_id = OccupationID::new("machinist");
-        let member = make_member(&CompanyMemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
+        let member = make_member_worker(&CompanyMemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
         let resource = make_resource(&ResourceID::new("widget"), company.id(), &Measure::new(dec!(15), Unit::One), &Costs::new_with_labor("homemaker", 157), &now);
         let process = make_process(&ProcessID::create(), company.id(), "make widgets", &Costs::new(), &now);
 

--- a/src/transactions/event/delivery.rs
+++ b/src/transactions/event/delivery.rs
@@ -14,7 +14,7 @@ use crate::{
         Modifications,
         event::{Event, EventID, EventProcessState},
         company::{Company, Permission as CompanyPermission},
-        company_member::CompanyMember,
+        member::Member,
         lib::basis_model::Deletable,
         process::Process,
         resource::Resource,
@@ -28,7 +28,7 @@ use vf_rs::{vf, geo::SpatialThing};
 /// created.
 ///
 /// This operates on a whole resource.
-pub fn dropoff(caller: &User, member: &CompanyMember, company: &Company, id: EventID, process: Process, resource: Resource, move_costs: Costs, new_location: Option<SpatialThing>, note: Option<String>, now: &DateTime<Utc>) -> Result<Modifications> {
+pub fn dropoff(caller: &User, member: &Member, company: &Company, id: EventID, process: Process, resource: Resource, move_costs: Costs, new_location: Option<SpatialThing>, note: Option<String>, now: &DateTime<Utc>) -> Result<Modifications> {
     caller.access_check(Permission::EventCreate)?;
     member.access_check(caller.id(), company.id(), CompanyPermission::Dropoff)?;
     if company.is_deleted() {
@@ -79,7 +79,7 @@ pub fn dropoff(caller: &User, member: &CompanyMember, company: &Company, id: Eve
 /// `transfer-custody` event).
 ///
 /// This operates on a whole resource.
-pub fn pickup(caller: &User, member: &CompanyMember, company: &Company, id: EventID, resource: Resource, process: Process, note: Option<String>, now: &DateTime<Utc>) -> Result<Modifications> {
+pub fn pickup(caller: &User, member: &Member, company: &Company, id: EventID, resource: Resource, process: Process, note: Option<String>, now: &DateTime<Utc>) -> Result<Modifications> {
     caller.access_check(Permission::EventCreate)?;
     member.access_check(caller.id(), company.id(), CompanyPermission::Pickup)?;
     if company.is_deleted() {
@@ -130,7 +130,7 @@ mod tests {
     use crate::{
         models::{
             company::CompanyID,
-            company_member::CompanyMemberID,
+            member::MemberID,
             event::{EventError, EventID},
             lib::agent::Agent,
             occupation::OccupationID,
@@ -151,7 +151,7 @@ mod tests {
         let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
         let occupation_id = OccupationID::new("trucker");
-        let member = make_member_worker(&CompanyMemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
+        let member = make_member_worker(&MemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
         let resource = make_resource(&ResourceID::new("widget"), company.id(), &Measure::new(dec!(15), Unit::One), &Costs::new_with_labor("machinist", 157), &now);
         let costs = Costs::new_with_labor(occupation_id.clone(), dec!(42.2));
         let process = make_process(&ProcessID::create(), company.id(), "deliver widgets", &costs, &now);
@@ -238,7 +238,7 @@ mod tests {
         let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
         let occupation_id = OccupationID::new("machinist");
-        let member = make_member_worker(&CompanyMemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
+        let member = make_member_worker(&MemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
         let resource = make_resource(&ResourceID::new("widget"), company.id(), &Measure::new(dec!(15), Unit::One), &Costs::new_with_labor("homemaker", 157), &now);
         let process = make_process(&ProcessID::create(), company.id(), "make widgets", &Costs::new(), &now);
 

--- a/src/transactions/event/delivery.rs
+++ b/src/transactions/event/delivery.rs
@@ -128,7 +128,7 @@ mod tests {
     use super::*;
     use crate::{
         models::{
-            company::{CompanyID, CompanyType},
+            company::CompanyID,
             company_member::CompanyMemberID,
             event::{EventError, EventID},
             lib::agent::Agent,
@@ -147,7 +147,7 @@ mod tests {
     fn can_dropoff() {
         let now = util::time::now();
         let id = EventID::create();
-        let company = make_company(&CompanyID::create(), CompanyType::Private, "jerry's widgets", &now);
+        let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
         let occupation_id = OccupationID::new("trucker");
         let member = make_member(&CompanyMemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
@@ -234,7 +234,7 @@ mod tests {
     fn can_pickup() {
         let now = util::time::now();
         let id = EventID::create();
-        let company = make_company(&CompanyID::create(), CompanyType::Private, "jerry's widgets", &now);
+        let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
         let occupation_id = OccupationID::new("machinist");
         let member = make_member(&CompanyMemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);

--- a/src/transactions/event/modification.rs
+++ b/src/transactions/event/modification.rs
@@ -136,7 +136,7 @@ mod tests {
     use super::*;
     use crate::{
         models::{
-            company::{CompanyID, CompanyType},
+            company::CompanyID,
             company_member::CompanyMemberID,
             event::{EventError, EventID},
             lib::agent::Agent,
@@ -155,7 +155,7 @@ mod tests {
     fn can_accept() {
         let now = util::time::now();
         let id = EventID::create();
-        let company = make_company(&CompanyID::create(), CompanyType::Private, "jerry's widgets", &now);
+        let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
         let occupation_id = OccupationID::new("mechanic");
         let member = make_member(&CompanyMemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
@@ -229,7 +229,7 @@ mod tests {
     fn can_modify() {
         let now = util::time::now();
         let id = EventID::create();
-        let company = make_company(&CompanyID::create(), CompanyType::Private, "jerry's widgets", &now);
+        let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
         let occupation_id = OccupationID::new("mechanic");
         let member = make_member(&CompanyMemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);

--- a/src/transactions/event/modification.rs
+++ b/src/transactions/event/modification.rs
@@ -14,7 +14,7 @@ use crate::{
         Modifications,
         event::{Event, EventID, EventProcessState},
         company::{Company, Permission as CompanyPermission},
-        company_member::CompanyMember,
+        member::Member,
         lib::basis_model::Deletable,
         process::Process,
         resource::Resource,
@@ -28,7 +28,7 @@ use vf_rs::vf;
 ///
 /// Effectively, you `accept` a resource into a repair process, and the output
 /// of that process would be `modify`.
-pub fn accept<T: Into<NumericUnion>>(caller: &User, member: &CompanyMember, company: &Company, id: EventID, resource: Resource, process: Process, resource_measure: T, note: Option<String>, now: &DateTime<Utc>) -> Result<Modifications> {
+pub fn accept<T: Into<NumericUnion>>(caller: &User, member: &Member, company: &Company, id: EventID, resource: Resource, process: Process, resource_measure: T, note: Option<String>, now: &DateTime<Utc>) -> Result<Modifications> {
     caller.access_check(Permission::EventCreate)?;
     member.access_check(caller.id(), company.id(), CompanyPermission::Accept)?;
     if company.is_deleted() {
@@ -82,7 +82,7 @@ pub fn accept<T: Into<NumericUnion>>(caller: &User, member: &CompanyMember, comp
 ///
 /// Effectively, you `accept` a resource into a repair process, and the output
 /// of that process would be `modify`.
-pub fn modify<T: Into<NumericUnion>>(caller: &User, member: &CompanyMember, company: &Company, id: EventID, process: Process, resource: Resource, move_costs: Costs, resource_measure: T, note: Option<String>, now: &DateTime<Utc>) -> Result<Modifications> {
+pub fn modify<T: Into<NumericUnion>>(caller: &User, member: &Member, company: &Company, id: EventID, process: Process, resource: Resource, move_costs: Costs, resource_measure: T, note: Option<String>, now: &DateTime<Utc>) -> Result<Modifications> {
     caller.access_check(Permission::EventCreate)?;
     member.access_check(caller.id(), company.id(), CompanyPermission::Modify)?;
     if company.is_deleted() {
@@ -138,7 +138,7 @@ mod tests {
     use crate::{
         models::{
             company::CompanyID,
-            company_member::CompanyMemberID,
+            member::MemberID,
             event::{EventError, EventID},
             lib::agent::Agent,
             occupation::OccupationID,
@@ -159,7 +159,7 @@ mod tests {
         let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
         let occupation_id = OccupationID::new("mechanic");
-        let member = make_member_worker(&CompanyMemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
+        let member = make_member_worker(&MemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
         let resource = make_resource(&ResourceID::new("widget"), company.id(), &Measure::new(dec!(15), Unit::One), &Costs::new_with_resource("steel", 157), &now);
         let process = make_process(&ProcessID::create(), company.id(), "make widgets", &Costs::new(), &now);
 
@@ -233,7 +233,7 @@ mod tests {
         let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
         let occupation_id = OccupationID::new("mechanic");
-        let member = make_member_worker(&CompanyMemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
+        let member = make_member_worker(&MemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
         let resource = make_resource(&ResourceID::new("car"), company.id(), &Measure::new(dec!(3), Unit::One), &Costs::new_with_resource("steel", 157), &now);
         let costs = Costs::new_with_labor(occupation_id.clone(), dec!(102.3));
         let process = make_process(&ProcessID::create(), company.id(), "repair car", &costs, &now);

--- a/src/transactions/event/modification.rs
+++ b/src/transactions/event/modification.rs
@@ -15,6 +15,7 @@ use crate::{
         event::{Event, EventID, EventProcessState},
         company::{Company, Permission as CompanyPermission},
         company_member::CompanyMember,
+        lib::basis_model::Deletable,
         process::Process,
         resource::Resource,
         user::User,
@@ -143,7 +144,7 @@ mod tests {
             occupation::OccupationID,
             process::ProcessID,
             resource::ResourceID,
-            testutils::{make_user, make_company, make_member, make_process, make_resource},
+            testutils::{make_user, make_company, make_member_worker, make_process, make_resource},
             user::UserID,
         },
         util,
@@ -158,7 +159,7 @@ mod tests {
         let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
         let occupation_id = OccupationID::new("mechanic");
-        let member = make_member(&CompanyMemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
+        let member = make_member_worker(&CompanyMemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
         let resource = make_resource(&ResourceID::new("widget"), company.id(), &Measure::new(dec!(15), Unit::One), &Costs::new_with_resource("steel", 157), &now);
         let process = make_process(&ProcessID::create(), company.id(), "make widgets", &Costs::new(), &now);
 
@@ -232,7 +233,7 @@ mod tests {
         let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
         let occupation_id = OccupationID::new("mechanic");
-        let member = make_member(&CompanyMemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
+        let member = make_member_worker(&CompanyMemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
         let resource = make_resource(&ResourceID::new("car"), company.id(), &Measure::new(dec!(3), Unit::One), &Costs::new_with_resource("steel", 157), &now);
         let costs = Costs::new_with_labor(occupation_id.clone(), dec!(102.3));
         let process = make_process(&ProcessID::create(), company.id(), "repair car", &costs, &now);

--- a/src/transactions/event/production.rs
+++ b/src/transactions/event/production.rs
@@ -259,7 +259,7 @@ mod tests {
     use super::*;
     use crate::{
         models::{
-            company::{CompanyID, CompanyType},
+            company::CompanyID,
             company_member::CompanyMemberID,
             event::{EventError, EventID},
             lib::agent::Agent,
@@ -278,7 +278,7 @@ mod tests {
     fn can_cite() {
         let now = util::time::now();
         let id = EventID::create();
-        let company = make_company(&CompanyID::create(), CompanyType::Private, "jerry's widgets", &now);
+        let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
         let occupation_id = OccupationID::new("machinist");
         let member = make_member(&CompanyMemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
@@ -363,7 +363,7 @@ mod tests {
     fn can_consume() {
         let now = util::time::now();
         let id = EventID::create();
-        let company = make_company(&CompanyID::create(), CompanyType::Private, "jerry's widgets", &now);
+        let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
         let occupation_id = OccupationID::new("machinist");
         let member = make_member(&CompanyMemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
@@ -448,7 +448,7 @@ mod tests {
     fn can_produce() {
         let now = util::time::now();
         let id = EventID::create();
-        let company = make_company(&CompanyID::create(), CompanyType::Private, "jerry's widgets", &now);
+        let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
         let occupation_id = OccupationID::new("machinist");
         let member = make_member(&CompanyMemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
@@ -534,7 +534,7 @@ mod tests {
     fn can_use() {
         let now = util::time::now();
         let id = EventID::create();
-        let company = make_company(&CompanyID::create(), CompanyType::Private, "jerry's widgets", &now);
+        let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
         let occupation_id = OccupationID::new("machinist");
         let member = make_member(&CompanyMemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);

--- a/src/transactions/event/production.rs
+++ b/src/transactions/event/production.rs
@@ -12,7 +12,7 @@ use crate::{
         Modifications,
         event::{Event, EventID, EventProcessState},
         company::{Company, Permission as CompanyPermission},
-        company_member::CompanyMember,
+        member::Member,
         lib::basis_model::Deletable,
         process::Process,
         resource::Resource,
@@ -31,7 +31,7 @@ use vf_rs::vf;
 /// Note that the resource *can* have a cost, and those costs can be moved by
 /// citing. For instance, if it took a year of research to derive a formula,
 /// the costs of that research would be imbued in the formula.
-pub fn cite(caller: &User, member: &CompanyMember, company: &Company, id: EventID, resource: Resource, process: Process, move_costs: Costs, note: Option<String>, now: &DateTime<Utc>) -> Result<Modifications> {
+pub fn cite(caller: &User, member: &Member, company: &Company, id: EventID, resource: Resource, process: Process, move_costs: Costs, note: Option<String>, now: &DateTime<Utc>) -> Result<Modifications> {
     caller.access_check(Permission::EventCreate)?;
     member.access_check(caller.id(), company.id(), CompanyPermission::Cite)?;
     if company.is_deleted() {
@@ -82,7 +82,7 @@ pub fn cite(caller: &User, member: &CompanyMember, company: &Company, id: EventI
 /// If you make widgets out of steel, then steel is the resource, and the
 /// process would be the fabrication that "consumes" steel (with the output,
 /// ie `produce`, of a widget).
-pub fn consume<T: Into<NumericUnion>>(caller: &User, member: &CompanyMember, company: &Company, id: EventID, resource: Resource, process: Process, move_costs: Costs, move_measure: T, note: Option<String>, now: &DateTime<Utc>) -> Result<Modifications> {
+pub fn consume<T: Into<NumericUnion>>(caller: &User, member: &Member, company: &Company, id: EventID, resource: Resource, process: Process, move_costs: Costs, move_measure: T, note: Option<String>, now: &DateTime<Utc>) -> Result<Modifications> {
     caller.access_check(Permission::EventCreate)?;
     member.access_check(caller.id(), company.id(), CompanyPermission::Consume)?;
     if company.is_deleted() {
@@ -139,7 +139,7 @@ pub fn consume<T: Into<NumericUnion>>(caller: &User, member: &CompanyMember, com
 ///
 /// For instance, a process might `consume` steel and have a `work` input and
 /// then `produce` a widget.
-pub fn produce<T: Into<NumericUnion>>(caller: &User, member: &CompanyMember, company: &Company, id: EventID, process: Process, resource: Resource, move_costs: Costs, produce_measure: T, note: Option<String>, now: &DateTime<Utc>) -> Result<Modifications> {
+pub fn produce<T: Into<NumericUnion>>(caller: &User, member: &Member, company: &Company, id: EventID, process: Process, resource: Resource, move_costs: Costs, produce_measure: T, note: Option<String>, now: &DateTime<Utc>) -> Result<Modifications> {
     caller.access_check(Permission::EventCreate)?;
     member.access_check(caller.id(), company.id(), CompanyPermission::Produce)?;
     if company.is_deleted() {
@@ -209,7 +209,7 @@ pub fn produce<T: Into<NumericUnion>>(caller: &User, member: &CompanyMember, com
 /// If you're trying to express some resource being "used up" (for instance
 /// screws being used to build a chair) then you'll probably want `consume`
 /// instead of `use`.
-pub fn useeee(caller: &User, member: &CompanyMember, company: &Company, id: EventID, resource: Resource, process: Process, move_costs: Costs, effort_quantity: Option<Measure>, note: Option<String>, now: &DateTime<Utc>) -> Result<Modifications> {
+pub fn useeee(caller: &User, member: &Member, company: &Company, id: EventID, resource: Resource, process: Process, move_costs: Costs, effort_quantity: Option<Measure>, note: Option<String>, now: &DateTime<Utc>) -> Result<Modifications> {
     caller.access_check(Permission::EventCreate)?;
     member.access_check(caller.id(), company.id(), CompanyPermission::Use)?;
     if company.is_deleted() {
@@ -261,7 +261,7 @@ mod tests {
     use crate::{
         models::{
             company::CompanyID,
-            company_member::CompanyMemberID,
+            member::MemberID,
             event::{EventError, EventID},
             lib::agent::Agent,
             occupation::OccupationID,
@@ -282,7 +282,7 @@ mod tests {
         let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
         let occupation_id = OccupationID::new("machinist");
-        let member = make_member_worker(&CompanyMemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
+        let member = make_member_worker(&MemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
         let resource = make_resource(&ResourceID::new("widget"), company.id(), &Measure::new(dec!(15), Unit::One), &Costs::new_with_labor("homemaker", 157), &now);
         let mut costs = Costs::new();
         costs.track_labor(occupation_id.clone(), dec!(42.2));
@@ -367,7 +367,7 @@ mod tests {
         let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
         let occupation_id = OccupationID::new("machinist");
-        let member = make_member_worker(&CompanyMemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
+        let member = make_member_worker(&MemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
         let resource = make_resource(&ResourceID::new("widget"), company.id(), &Measure::new(dec!(15), Unit::One), &Costs::new_with_labor("homemaker", 157), &now);
         let mut costs = Costs::new();
         costs.track_labor(occupation_id.clone(), dec!(42.2));
@@ -452,7 +452,7 @@ mod tests {
         let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
         let occupation_id = OccupationID::new("machinist");
-        let member = make_member_worker(&CompanyMemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
+        let member = make_member_worker(&MemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
         let resource = make_resource(&ResourceID::new("widget"), company.id(), &Measure::new(dec!(15), Unit::One), &Costs::new_with_labor("homemaker", 157), &now);
         let mut costs = Costs::new();
         costs.track_labor(occupation_id.clone(), dec!(42.2));
@@ -538,7 +538,7 @@ mod tests {
         let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
         let occupation_id = OccupationID::new("machinist");
-        let member = make_member_worker(&CompanyMemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
+        let member = make_member_worker(&MemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
         let resource = make_resource(&ResourceID::new("widget"), company.id(), &Measure::new(dec!(15), Unit::One), &Costs::new_with_labor("homemaker", 157), &now);
         let mut costs = Costs::new();
         costs.track_labor(occupation_id.clone(), dec!(42.2));

--- a/src/transactions/event/production.rs
+++ b/src/transactions/event/production.rs
@@ -13,6 +13,7 @@ use crate::{
         event::{Event, EventID, EventProcessState},
         company::{Company, Permission as CompanyPermission},
         company_member::CompanyMember,
+        lib::basis_model::Deletable,
         process::Process,
         resource::Resource,
         user::User,
@@ -266,7 +267,7 @@ mod tests {
             occupation::OccupationID,
             process::ProcessID,
             resource::ResourceID,
-            testutils::{make_user, make_company, make_member, make_process, make_resource},
+            testutils::{make_user, make_company, make_member_worker, make_process, make_resource},
             user::UserID,
         },
         util,
@@ -281,7 +282,7 @@ mod tests {
         let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
         let occupation_id = OccupationID::new("machinist");
-        let member = make_member(&CompanyMemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
+        let member = make_member_worker(&CompanyMemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
         let resource = make_resource(&ResourceID::new("widget"), company.id(), &Measure::new(dec!(15), Unit::One), &Costs::new_with_labor("homemaker", 157), &now);
         let mut costs = Costs::new();
         costs.track_labor(occupation_id.clone(), dec!(42.2));
@@ -366,7 +367,7 @@ mod tests {
         let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
         let occupation_id = OccupationID::new("machinist");
-        let member = make_member(&CompanyMemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
+        let member = make_member_worker(&CompanyMemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
         let resource = make_resource(&ResourceID::new("widget"), company.id(), &Measure::new(dec!(15), Unit::One), &Costs::new_with_labor("homemaker", 157), &now);
         let mut costs = Costs::new();
         costs.track_labor(occupation_id.clone(), dec!(42.2));
@@ -451,7 +452,7 @@ mod tests {
         let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
         let occupation_id = OccupationID::new("machinist");
-        let member = make_member(&CompanyMemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
+        let member = make_member_worker(&CompanyMemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
         let resource = make_resource(&ResourceID::new("widget"), company.id(), &Measure::new(dec!(15), Unit::One), &Costs::new_with_labor("homemaker", 157), &now);
         let mut costs = Costs::new();
         costs.track_labor(occupation_id.clone(), dec!(42.2));
@@ -537,7 +538,7 @@ mod tests {
         let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
         let occupation_id = OccupationID::new("machinist");
-        let member = make_member(&CompanyMemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
+        let member = make_member_worker(&CompanyMemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
         let resource = make_resource(&ResourceID::new("widget"), company.id(), &Measure::new(dec!(15), Unit::One), &Costs::new_with_labor("homemaker", 157), &now);
         let mut costs = Costs::new();
         costs.track_labor(occupation_id.clone(), dec!(42.2));

--- a/src/transactions/event/service.rs
+++ b/src/transactions/event/service.rs
@@ -15,7 +15,10 @@ use crate::{
         event::{Event, EventID, EventProcessState},
         company::{Company, Permission as CompanyPermission},
         company_member::CompanyMember,
-        lib::agent::Agent,
+        lib::{
+            agent::Agent,
+            basis_model::Deletable,
+        },
         process::Process,
         user::User,
     },
@@ -91,7 +94,7 @@ mod tests {
             lib::agent::Agent,
             occupation::OccupationID,
             process::{Process, ProcessID},
-            testutils::{make_agreement, make_user, make_company, make_member, make_process},
+            testutils::{make_agreement, make_user, make_company, make_member_worker, make_process},
             user::UserID,
         },
         util,
@@ -108,7 +111,7 @@ mod tests {
         let agreed_in: Url = "https://legalzoom.com/my-dad-is-suing-your-dad-the-agreement".parse().unwrap();
         let user = make_user(&UserID::create(), None, &now);
         let occupation_id = OccupationID::new("lawyer");
-        let member = make_member(&CompanyMemberID::create(), user.id(), company_from.id(), &occupation_id, vec![], &now);
+        let member = make_member_worker(&CompanyMemberID::create(), user.id(), company_from.id(), &occupation_id, vec![], &now);
         let process_from = make_process(&ProcessID::create(), company_from.id(), "various lawyerings", &Costs::new_with_labor(occupation_id.clone(), dec!(177.25)), &now);
         let process_to = make_process(&ProcessID::create(), company_to.id(), "employee legal agreement drafting", &Costs::new_with_labor(occupation_id.clone(), dec!(804)), &now);
 

--- a/src/transactions/event/service.rs
+++ b/src/transactions/event/service.rs
@@ -14,7 +14,7 @@ use crate::{
         agreement::Agreement,
         event::{Event, EventID, EventProcessState},
         company::{Company, Permission as CompanyPermission},
-        company_member::CompanyMember,
+        member::Member,
         lib::{
             agent::Agent,
             basis_model::Deletable,
@@ -27,7 +27,7 @@ use url::Url;
 use vf_rs::vf;
 
 /// Provide a service to another agent, moving costs along the way.
-pub fn deliver_service(caller: &User, member: &CompanyMember, company_from: &Company, company_to: &Company, agreement: &Agreement, id: EventID, process_from: Process, process_to: Process, move_costs: Costs, agreed_in: Option<Url>, note: Option<String>, now: &DateTime<Utc>) -> Result<Modifications> {
+pub fn deliver_service(caller: &User, member: &Member, company_from: &Company, company_to: &Company, agreement: &Agreement, id: EventID, process_from: Process, process_to: Process, move_costs: Costs, agreed_in: Option<Url>, note: Option<String>, now: &DateTime<Utc>) -> Result<Modifications> {
     caller.access_check(Permission::EventCreate)?;
     member.access_check(caller.id(), company_from.id(), CompanyPermission::DeliverService)?;
     if company_from.is_deleted() {
@@ -89,7 +89,7 @@ mod tests {
         models::{
             agreement::AgreementID,
             company::CompanyID,
-            company_member::CompanyMemberID,
+            member::MemberID,
             event::{EventID, EventError},
             lib::agent::Agent,
             occupation::OccupationID,
@@ -111,7 +111,7 @@ mod tests {
         let agreed_in: Url = "https://legalzoom.com/my-dad-is-suing-your-dad-the-agreement".parse().unwrap();
         let user = make_user(&UserID::create(), None, &now);
         let occupation_id = OccupationID::new("lawyer");
-        let member = make_member_worker(&CompanyMemberID::create(), user.id(), company_from.id(), &occupation_id, vec![], &now);
+        let member = make_member_worker(&MemberID::create(), user.id(), company_from.id(), &occupation_id, vec![], &now);
         let process_from = make_process(&ProcessID::create(), company_from.id(), "various lawyerings", &Costs::new_with_labor(occupation_id.clone(), dec!(177.25)), &now);
         let process_to = make_process(&ProcessID::create(), company_to.id(), "employee legal agreement drafting", &Costs::new_with_labor(occupation_id.clone(), dec!(804)), &now);
 

--- a/src/transactions/event/service.rs
+++ b/src/transactions/event/service.rs
@@ -85,7 +85,7 @@ mod tests {
     use crate::{
         models::{
             agreement::AgreementID,
-            company::{CompanyID, CompanyType},
+            company::CompanyID,
             company_member::CompanyMemberID,
             event::{EventID, EventError},
             lib::agent::Agent,
@@ -102,8 +102,8 @@ mod tests {
     fn can_deliver_service() {
         let now = util::time::now();
         let id = EventID::create();
-        let company_from = make_company(&CompanyID::create(), CompanyType::Private, "jerry's planks", &now);
-        let company_to = make_company(&CompanyID::create(), CompanyType::Private, "jinkey's skateboards", &now);
+        let company_from = make_company(&CompanyID::create(), "jerry's planks", &now);
+        let company_to = make_company(&CompanyID::create(), "jinkey's skateboards", &now);
         let agreement = make_agreement(&AgreementID::create(), &vec![company_from.agent_id(), company_to.agent_id()], "order 1234", "gotta make some planks", &now);
         let agreed_in: Url = "https://legalzoom.com/my-dad-is-suing-your-dad-the-agreement".parse().unwrap();
         let user = make_user(&UserID::create(), None, &now);

--- a/src/transactions/event/transfer.rs
+++ b/src/transactions/event/transfer.rs
@@ -240,7 +240,7 @@ mod tests {
     use crate::{
         models::{
             agreement::AgreementID,
-            company::{CompanyID, CompanyType},
+            company::CompanyID,
             company_member::CompanyMemberID,
             event::{EventID, EventError},
             lib::agent::Agent,
@@ -258,8 +258,8 @@ mod tests {
     fn can_transfer() {
         let now = util::time::now();
         let id = EventID::create();
-        let company = make_company(&CompanyID::create(), CompanyType::Private, "jerry's planks", &now);
-        let company2 = make_company(&CompanyID::create(), CompanyType::Private, "jinkey's skateboards", &now);
+        let company = make_company(&CompanyID::create(), "jerry's planks", &now);
+        let company2 = make_company(&CompanyID::create(), "jinkey's skateboards", &now);
         let agreement = make_agreement(&AgreementID::create(), &vec![company.agent_id(), company2.agent_id()], "order 1234", "gotta get some planks", &now);
         let agreed_in: Url = "https://legalzoom.com/standard-boilerplate-hereto-notwithstanding-each-of-them-damage-to-the-hood-ornament-alone".parse().unwrap();
         let user = make_user(&UserID::create(), None, &now);
@@ -393,8 +393,8 @@ mod tests {
     fn can_transfer_all_rights() {
         let now = util::time::now();
         let id = EventID::create();
-        let company = make_company(&CompanyID::create(), CompanyType::Private, "jerry's planks", &now);
-        let company2 = make_company(&CompanyID::create(), CompanyType::Private, "jinkey's skateboards", &now);
+        let company = make_company(&CompanyID::create(), "jerry's planks", &now);
+        let company2 = make_company(&CompanyID::create(), "jinkey's skateboards", &now);
         let agreement = make_agreement(&AgreementID::create(), &vec![company.agent_id(), company2.agent_id()], "order 1234", "gotta get some planks", &now);
         let agreed_in: Url = "https://legalzoom.com/is-it-too-much-to-ask-for-todays-pedestrian-to-wear-at-least-one-piece-of-reflective-clothing".parse().unwrap();
         let user = make_user(&UserID::create(), None, &now);
@@ -521,8 +521,8 @@ mod tests {
     fn can_transfer_custody() {
         let now = util::time::now();
         let id = EventID::create();
-        let company = make_company(&CompanyID::create(), CompanyType::Private, "jerry's planks", &now);
-        let company2 = make_company(&CompanyID::create(), CompanyType::Private, "jinkey's skateboards", &now);
+        let company = make_company(&CompanyID::create(), "jerry's planks", &now);
+        let company2 = make_company(&CompanyID::create(), "jinkey's skateboards", &now);
         let agreement = make_agreement(&AgreementID::create(), &vec![company.agent_id(), company2.agent_id()], "order 1234", "gotta get some planks", &now);
         let agreed_in: Url = "https://legaldoom.com/trade-secrets-trade-secrets".parse().unwrap();
         let user = make_user(&UserID::create(), None, &now);

--- a/src/transactions/event/transfer.rs
+++ b/src/transactions/event/transfer.rs
@@ -15,7 +15,10 @@ use crate::{
         Modifications,
         agreement::Agreement,
         event::{Event, EventID, EventProcessState},
-        lib::agent::Agent,
+        lib::{
+            agent::Agent,
+            basis_model::Deletable,
+        },
         company::{Company, Permission as CompanyPermission},
         company_member::CompanyMember,
         resource::Resource,
@@ -246,7 +249,7 @@ mod tests {
             lib::agent::Agent,
             occupation::OccupationID,
             resource::ResourceID,
-            testutils::{make_agreement, make_user, make_company, make_member, make_resource},
+            testutils::{make_agreement, make_user, make_company, make_member_worker, make_resource},
             user::UserID,
         },
         util,
@@ -264,7 +267,7 @@ mod tests {
         let agreed_in: Url = "https://legalzoom.com/standard-boilerplate-hereto-notwithstanding-each-of-them-damage-to-the-hood-ornament-alone".parse().unwrap();
         let user = make_user(&UserID::create(), None, &now);
         let occupation_id = OccupationID::new("machinist");
-        let member = make_member(&CompanyMemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
+        let member = make_member_worker(&CompanyMemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
         let resource = make_resource(&ResourceID::new("plank"), company.id(), &Measure::new(dec!(15), Unit::One), &Costs::new_with_labor("homemaker", 157), &now);
         let resource_to = make_resource(&ResourceID::new("plank"), company2.id(), &Measure::new(dec!(3), Unit::One), &Costs::new_with_labor("homemaker", 2), &now);
 
@@ -399,7 +402,7 @@ mod tests {
         let agreed_in: Url = "https://legalzoom.com/is-it-too-much-to-ask-for-todays-pedestrian-to-wear-at-least-one-piece-of-reflective-clothing".parse().unwrap();
         let user = make_user(&UserID::create(), None, &now);
         let occupation_id = OccupationID::new("machinist");
-        let member = make_member(&CompanyMemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
+        let member = make_member_worker(&CompanyMemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
         let resource = make_resource(&ResourceID::new("plank"), company.id(), &Measure::new(dec!(15), Unit::One), &Costs::new_with_labor("homemaker", 157), &now);
         let resource_to = make_resource(&ResourceID::new("plank"), company2.id(), &Measure::new(dec!(3), Unit::One), &Costs::new_with_labor("homemaker", 2), &now);
 
@@ -527,7 +530,7 @@ mod tests {
         let agreed_in: Url = "https://legaldoom.com/trade-secrets-trade-secrets".parse().unwrap();
         let user = make_user(&UserID::create(), None, &now);
         let occupation_id = OccupationID::new("machinist");
-        let member = make_member(&CompanyMemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
+        let member = make_member_worker(&CompanyMemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
         let resource = make_resource(&ResourceID::new("plank"), company.id(), &Measure::new(dec!(15), Unit::One), &Costs::new_with_labor("homemaker", 157), &now);
         let resource_to = make_resource(&ResourceID::new("plank"), company2.id(), &Measure::new(dec!(3), Unit::One), &Costs::new_with_labor("homemaker", 2), &now);
 

--- a/src/transactions/event/transfer.rs
+++ b/src/transactions/event/transfer.rs
@@ -20,7 +20,7 @@ use crate::{
             basis_model::Deletable,
         },
         company::{Company, Permission as CompanyPermission},
-        company_member::CompanyMember,
+        member::Member,
         resource::Resource,
         user::User,
     },
@@ -32,7 +32,7 @@ use vf_rs::vf;
 
 /// Transfer a resource (custody and ownership) from one company to another,
 /// moving a set of costs with it.
-pub fn transfer<T: Into<NumericUnion>>(caller: &User, member: &CompanyMember, company_from: &Company, company_to: &Company, agreement: &Agreement, id: EventID, resource_from: Resource, resource_to: ResourceMover, move_costs: Costs, move_measure: T, agreed_in: Option<Url>, note: Option<String>, now: &DateTime<Utc>) -> Result<Modifications> {
+pub fn transfer<T: Into<NumericUnion>>(caller: &User, member: &Member, company_from: &Company, company_to: &Company, agreement: &Agreement, id: EventID, resource_from: Resource, resource_to: ResourceMover, move_costs: Costs, move_measure: T, agreed_in: Option<Url>, note: Option<String>, now: &DateTime<Utc>) -> Result<Modifications> {
     caller.access_check(Permission::EventCreate)?;
     member.access_check(caller.id(), company_from.id(), CompanyPermission::Transfer)?;
     if company_from.is_deleted() {
@@ -101,7 +101,7 @@ pub fn transfer<T: Into<NumericUnion>>(caller: &User, member: &CompanyMember, co
 
 /// Transfer ownership (but not custody) of a resource from one company to
 /// another, moving a set of costs with it.
-pub fn transfer_all_rights<T: Into<NumericUnion>>(caller: &User, member: &CompanyMember, company_from: &Company, company_to: &Company, agreement: &Agreement, id: EventID, resource_from: Resource, resource_to: ResourceMover, move_costs: Costs, move_measure: T, agreed_in: Option<Url>, note: Option<String>, now: &DateTime<Utc>) -> Result<Modifications> {
+pub fn transfer_all_rights<T: Into<NumericUnion>>(caller: &User, member: &Member, company_from: &Company, company_to: &Company, agreement: &Agreement, id: EventID, resource_from: Resource, resource_to: ResourceMover, move_costs: Costs, move_measure: T, agreed_in: Option<Url>, note: Option<String>, now: &DateTime<Utc>) -> Result<Modifications> {
     caller.access_check(Permission::EventCreate)?;
     member.access_check(caller.id(), company_from.id(), CompanyPermission::Transfer)?;
     if company_from.is_deleted() {
@@ -170,7 +170,7 @@ pub fn transfer_all_rights<T: Into<NumericUnion>>(caller: &User, member: &Compan
 
 /// Transfer custody (but not ownership) of a resource from one company to
 /// another, moving a set of costs with it.
-pub fn transfer_custody<T: Into<NumericUnion>>(caller: &User, member: &CompanyMember, company_from: &Company, company_to: &Company, agreement: &Agreement, id: EventID, resource_from: Resource, resource_to: ResourceMover, move_costs: Costs, move_measure: T, agreed_in: Option<Url>, note: Option<String>, now: &DateTime<Utc>) -> Result<Modifications> {
+pub fn transfer_custody<T: Into<NumericUnion>>(caller: &User, member: &Member, company_from: &Company, company_to: &Company, agreement: &Agreement, id: EventID, resource_from: Resource, resource_to: ResourceMover, move_costs: Costs, move_measure: T, agreed_in: Option<Url>, note: Option<String>, now: &DateTime<Utc>) -> Result<Modifications> {
     caller.access_check(Permission::EventCreate)?;
     member.access_check(caller.id(), company_from.id(), CompanyPermission::Transfer)?;
     if company_from.is_deleted() {
@@ -244,7 +244,7 @@ mod tests {
         models::{
             agreement::AgreementID,
             company::CompanyID,
-            company_member::CompanyMemberID,
+            member::MemberID,
             event::{EventID, EventError},
             lib::agent::Agent,
             occupation::OccupationID,
@@ -267,7 +267,7 @@ mod tests {
         let agreed_in: Url = "https://legalzoom.com/standard-boilerplate-hereto-notwithstanding-each-of-them-damage-to-the-hood-ornament-alone".parse().unwrap();
         let user = make_user(&UserID::create(), None, &now);
         let occupation_id = OccupationID::new("machinist");
-        let member = make_member_worker(&CompanyMemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
+        let member = make_member_worker(&MemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
         let resource = make_resource(&ResourceID::new("plank"), company.id(), &Measure::new(dec!(15), Unit::One), &Costs::new_with_labor("homemaker", 157), &now);
         let resource_to = make_resource(&ResourceID::new("plank"), company2.id(), &Measure::new(dec!(3), Unit::One), &Costs::new_with_labor("homemaker", 2), &now);
 
@@ -402,7 +402,7 @@ mod tests {
         let agreed_in: Url = "https://legalzoom.com/is-it-too-much-to-ask-for-todays-pedestrian-to-wear-at-least-one-piece-of-reflective-clothing".parse().unwrap();
         let user = make_user(&UserID::create(), None, &now);
         let occupation_id = OccupationID::new("machinist");
-        let member = make_member_worker(&CompanyMemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
+        let member = make_member_worker(&MemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
         let resource = make_resource(&ResourceID::new("plank"), company.id(), &Measure::new(dec!(15), Unit::One), &Costs::new_with_labor("homemaker", 157), &now);
         let resource_to = make_resource(&ResourceID::new("plank"), company2.id(), &Measure::new(dec!(3), Unit::One), &Costs::new_with_labor("homemaker", 2), &now);
 
@@ -530,7 +530,7 @@ mod tests {
         let agreed_in: Url = "https://legaldoom.com/trade-secrets-trade-secrets".parse().unwrap();
         let user = make_user(&UserID::create(), None, &now);
         let occupation_id = OccupationID::new("machinist");
-        let member = make_member_worker(&CompanyMemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
+        let member = make_member_worker(&MemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
         let resource = make_resource(&ResourceID::new("plank"), company.id(), &Measure::new(dec!(15), Unit::One), &Costs::new_with_labor("homemaker", 157), &now);
         let resource_to = make_resource(&ResourceID::new("plank"), company2.id(), &Measure::new(dec!(3), Unit::One), &Costs::new_with_labor("homemaker", 2), &now);
 

--- a/src/transactions/event/work.rs
+++ b/src/transactions/event/work.rs
@@ -103,7 +103,7 @@ mod tests {
     use crate::{
         models::{
             company::CompanyID,
-            member::MemberID,
+            member::*,
             event::{Event, EventID, EventError},
             lib::agent::Agent,
             occupation::OccupationID,
@@ -215,6 +215,14 @@ mod tests {
         process3.set_company_id(CompanyID::new("zing"));
         let res = work(&user, &member2, &company, id.clone(), worker2.clone(), process3.clone(), Some(dec!(78.4)), now.clone(), now2.clone(), Some("just doing some work".into()), &now2);
         assert_eq!(res, Err(Error::Event(EventError::ProcessOwnerMismatch)));
+
+        let mut worker3 = worker2.clone();
+        worker3.set_class(MemberClass::User(MemberUser::new()));
+        let res = work(&user, &member2, &company, id.clone(), worker3.clone(), process.clone(), Some(dec!(78.4)), now.clone(), now2.clone(), Some("just doing some work".into()), &now2);
+        assert_eq!(res, Err(Error::MemberMustBeWorker));
+        worker3.set_class(MemberClass::Company(MemberCompany::new()));
+        let res = work(&user, &member2, &company, id.clone(), worker3.clone(), process.clone(), Some(dec!(78.4)), now.clone(), now2.clone(), Some("just doing some work".into()), &now2);
+        assert_eq!(res, Err(Error::MemberMustBeWorker));
     }
 }
 

--- a/src/transactions/event/work.rs
+++ b/src/transactions/event/work.rs
@@ -100,7 +100,7 @@ mod tests {
     use super::*;
     use crate::{
         models::{
-            company::{CompanyID, CompanyType},
+            company::CompanyID,
             company_member::CompanyMemberID,
             event::{Event, EventID, EventError},
             lib::agent::Agent,
@@ -117,7 +117,7 @@ mod tests {
         let now: DateTime<Utc> = "2018-06-06T00:00:00Z".parse().unwrap();
         let now2: DateTime<Utc> = "2018-06-06T06:52:00Z".parse().unwrap();
         let id = EventID::create();
-        let company = make_company(&CompanyID::create(), CompanyType::Private, "jerry's widgets", &now);
+        let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
         let occupation_id = OccupationID::new("machinist");
         let member = make_member(&CompanyMemberID::create(), user.id(), company.id(), &occupation_id, vec![CompanyPermission::Work], &now);

--- a/src/transactions/event/work.rs
+++ b/src/transactions/event/work.rs
@@ -13,7 +13,7 @@ use crate::{
         Modifications,
         event::{Event, EventID, EventProcessState},
         company::{Company, Permission as CompanyPermission},
-        company_member::CompanyMember,
+        member::Member,
         lib::basis_model::Deletable,
         process::Process,
         user::User,
@@ -34,7 +34,7 @@ use vf_rs::vf;
 ///
 /// Note that this creates a full work event with a defined start and end. This
 /// function cannot create pending work events.
-pub fn work(caller: &User, member: &CompanyMember, company: &Company, id: EventID, worker: CompanyMember, process: Process, wage_cost: Option<Decimal>, begin: DateTime<Utc>, end: DateTime<Utc>, note: Option<String>, now: &DateTime<Utc>) -> Result<Modifications> {
+pub fn work(caller: &User, member: &Member, company: &Company, id: EventID, worker: Member, process: Process, wage_cost: Option<Decimal>, begin: DateTime<Utc>, end: DateTime<Utc>, note: Option<String>, now: &DateTime<Utc>) -> Result<Modifications> {
     caller.access_check(Permission::EventCreate)?;
     // if we're recording our own work event, we can just check the regular
     // `Work` permission, otherwise we need admin privs
@@ -103,7 +103,7 @@ mod tests {
     use crate::{
         models::{
             company::CompanyID,
-            company_member::CompanyMemberID,
+            member::MemberID,
             event::{Event, EventID, EventError},
             lib::agent::Agent,
             occupation::OccupationID,
@@ -122,7 +122,7 @@ mod tests {
         let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
         let occupation_id = OccupationID::new("machinist");
-        let member = make_member_worker(&CompanyMemberID::create(), user.id(), company.id(), &occupation_id, vec![CompanyPermission::Work], &now);
+        let member = make_member_worker(&MemberID::create(), user.id(), company.id(), &occupation_id, vec![CompanyPermission::Work], &now);
         let worker = member.clone();
         let process = make_process(&ProcessID::create(), company.id(), "make widgets", &Costs::new_with_labor(occupation_id.clone(), dec!(177.5)), &now);
 
@@ -166,7 +166,7 @@ mod tests {
 
         // test worker != member
         let mut worker2 = worker.clone();
-        worker2.set_id(CompanyMemberID::create());
+        worker2.set_id(MemberID::create());
         let res = work(&user, &member, &company, id.clone(), worker2.clone(), process.clone(), Some(dec!(78.4)), now.clone(), now2.clone(), Some("just doing some work".into()), &now2);
         assert_eq!(res, Err(Error::InsufficientPrivileges));
 

--- a/src/transactions/intent.rs
+++ b/src/transactions/intent.rs
@@ -17,7 +17,7 @@ use crate::{
         Op,
         Modifications,
         company::{Company, Permission as CompanyPermission},
-        company_member::CompanyMember,
+        member::Member,
         lib::{
             agent::{Agent, AgentID},
             basis_model::Deletable,
@@ -34,7 +34,7 @@ use url::Url;
 use vf_rs::{vf, geo::SpatialThing};
 
 /// Create a new intent
-pub fn create(caller: &User, member: &CompanyMember, company: &Company, id: IntentID, move_costs: Option<Costs>, action: OrderAction, agreed_in: Option<Url>, at_location: Option<SpatialThing>, available_quantity: Option<Measure>, due: Option<DateTime<Utc>>, effort_quantity: Option<Measure>, finished: Option<bool>, has_beginning: Option<DateTime<Utc>>, has_end: Option<DateTime<Utc>>, has_point_in_time: Option<DateTime<Utc>>, in_scope_of: Vec<AgentID>, name: Option<String>, note: Option<String>, provider: Option<AgentID>, receiver: Option<AgentID>, resource_conforms_to: Option<ResourceSpecID>, resource_inventoried_as: Option<ResourceID>, resource_quantity: Option<Measure>, active: bool, now: &DateTime<Utc>) -> Result<Modifications> {
+pub fn create(caller: &User, member: &Member, company: &Company, id: IntentID, move_costs: Option<Costs>, action: OrderAction, agreed_in: Option<Url>, at_location: Option<SpatialThing>, available_quantity: Option<Measure>, due: Option<DateTime<Utc>>, effort_quantity: Option<Measure>, finished: Option<bool>, has_beginning: Option<DateTime<Utc>>, has_end: Option<DateTime<Utc>>, has_point_in_time: Option<DateTime<Utc>>, in_scope_of: Vec<AgentID>, name: Option<String>, note: Option<String>, provider: Option<AgentID>, receiver: Option<AgentID>, resource_conforms_to: Option<ResourceSpecID>, resource_inventoried_as: Option<ResourceID>, resource_quantity: Option<Measure>, active: bool, now: &DateTime<Utc>) -> Result<Modifications> {
     caller.access_check(Permission::CompanyUpdateIntents)?;
     member.access_check(caller.id(), company.id(), CompanyPermission::IntentCreate)?;
     if company.is_deleted() {
@@ -89,7 +89,7 @@ pub fn create(caller: &User, member: &CompanyMember, company: &Company, id: Inte
 }
 
 /// Update an intent
-pub fn update(caller: &User, member: &CompanyMember, company: &Company, mut subject: Intent, move_costs: Option<Option<Costs>>, action: Option<OrderAction>, agreed_in: Option<Option<Url>>, at_location: Option<Option<SpatialThing>>, available_quantity: Option<Option<Measure>>, due: Option<Option<DateTime<Utc>>>, effort_quantity: Option<Option<Measure>>, finished: Option<Option<bool>>, has_beginning: Option<Option<DateTime<Utc>>>, has_end: Option<Option<DateTime<Utc>>>, has_point_in_time: Option<Option<DateTime<Utc>>>, in_scope_of: Option<Vec<AgentID>>, name: Option<Option<String>>, note: Option<Option<String>>, provider: Option<Option<AgentID>>, receiver: Option<Option<AgentID>>, resource_conforms_to: Option<Option<ResourceSpecID>>, resource_inventoried_as: Option<Option<ResourceID>>, resource_quantity: Option<Option<Measure>>, active: Option<bool>, now: &DateTime<Utc>) -> Result<Modifications> {
+pub fn update(caller: &User, member: &Member, company: &Company, mut subject: Intent, move_costs: Option<Option<Costs>>, action: Option<OrderAction>, agreed_in: Option<Option<Url>>, at_location: Option<Option<SpatialThing>>, available_quantity: Option<Option<Measure>>, due: Option<Option<DateTime<Utc>>>, effort_quantity: Option<Option<Measure>>, finished: Option<Option<bool>>, has_beginning: Option<Option<DateTime<Utc>>>, has_end: Option<Option<DateTime<Utc>>>, has_point_in_time: Option<Option<DateTime<Utc>>>, in_scope_of: Option<Vec<AgentID>>, name: Option<Option<String>>, note: Option<Option<String>>, provider: Option<Option<AgentID>>, receiver: Option<Option<AgentID>>, resource_conforms_to: Option<Option<ResourceSpecID>>, resource_inventoried_as: Option<Option<ResourceID>>, resource_quantity: Option<Option<Measure>>, active: Option<bool>, now: &DateTime<Utc>) -> Result<Modifications> {
     caller.access_check(Permission::CompanyUpdateIntents)?;
     member.access_check(caller.id(), company.id(), CompanyPermission::IntentUpdate)?;
     if company.is_deleted() {
@@ -182,7 +182,7 @@ pub fn update(caller: &User, member: &CompanyMember, company: &Company, mut subj
 }
 
 /// Delete an intent
-pub fn delete(caller: &User, member: &CompanyMember, company: &Company, mut subject: Intent, now: &DateTime<Utc>) -> Result<Modifications> {
+pub fn delete(caller: &User, member: &Member, company: &Company, mut subject: Intent, now: &DateTime<Utc>) -> Result<Modifications> {
     caller.access_check(Permission::CompanyUpdateIntents)?;
     member.access_check(caller.id(), company.id(), CompanyPermission::IntentDelete)?;
     if company.is_deleted() {
@@ -198,7 +198,7 @@ mod tests {
     use crate::{
         models::{
             company::CompanyID,
-            company_member::CompanyMemberID,
+            member::MemberID,
             occupation::OccupationID,
             testutils::{make_user, make_company, make_member_worker},
             user::UserID,
@@ -213,7 +213,7 @@ mod tests {
         let id = IntentID::create();
         let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
-        let member = make_member_worker(&CompanyMemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::IntentCreate], &now);
+        let member = make_member_worker(&MemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::IntentCreate], &now);
         let costs = Costs::new_with_labor("widgetmaker", 42);
         let loc = SpatialThing::builder()
             .mappable_address(Some("444 Checkmate lane, LOGIC and FACTS, MN, 33133".into()))
@@ -280,7 +280,7 @@ mod tests {
         let id = IntentID::create();
         let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
-        let member = make_member_worker(&CompanyMemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::IntentCreate, CompanyPermission::IntentUpdate], &now);
+        let member = make_member_worker(&MemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::IntentCreate, CompanyPermission::IntentUpdate], &now);
         let costs1 = Costs::new_with_labor("widgetmaker", 42);
         let costs2 = Costs::new_with_labor("widgetmaker", 41);
         let loc = SpatialThing::builder()
@@ -350,7 +350,7 @@ mod tests {
         let id = IntentID::create();
         let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
-        let member = make_member_worker(&CompanyMemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::IntentCreate, CompanyPermission::IntentDelete], &now);
+        let member = make_member_worker(&MemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::IntentCreate, CompanyPermission::IntentDelete], &now);
         let costs = Costs::new_with_labor("widgetmaker", 42);
         let loc = SpatialThing::builder()
             .mappable_address(Some("444 Checkmate lane, LOGIC and FACTS, MN, 33133".into()))

--- a/src/transactions/intent.rs
+++ b/src/transactions/intent.rs
@@ -18,7 +18,10 @@ use crate::{
         Modifications,
         company::{Company, Permission as CompanyPermission},
         company_member::CompanyMember,
-        lib::agent::{Agent, AgentID},
+        lib::{
+            agent::{Agent, AgentID},
+            basis_model::Deletable,
+        },
         intent::{Intent, IntentID},
         resource::ResourceID,
         resource_spec::ResourceSpecID,
@@ -197,7 +200,7 @@ mod tests {
             company::CompanyID,
             company_member::CompanyMemberID,
             occupation::OccupationID,
-            testutils::{make_user, make_company, make_member},
+            testutils::{make_user, make_company, make_member_worker},
             user::UserID,
         },
         util,
@@ -210,7 +213,7 @@ mod tests {
         let id = IntentID::create();
         let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
-        let member = make_member(&CompanyMemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::IntentCreate], &now);
+        let member = make_member_worker(&CompanyMemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::IntentCreate], &now);
         let costs = Costs::new_with_labor("widgetmaker", 42);
         let loc = SpatialThing::builder()
             .mappable_address(Some("444 Checkmate lane, LOGIC and FACTS, MN, 33133".into()))
@@ -277,7 +280,7 @@ mod tests {
         let id = IntentID::create();
         let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
-        let member = make_member(&CompanyMemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::IntentCreate, CompanyPermission::IntentUpdate], &now);
+        let member = make_member_worker(&CompanyMemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::IntentCreate, CompanyPermission::IntentUpdate], &now);
         let costs1 = Costs::new_with_labor("widgetmaker", 42);
         let costs2 = Costs::new_with_labor("widgetmaker", 41);
         let loc = SpatialThing::builder()
@@ -347,7 +350,7 @@ mod tests {
         let id = IntentID::create();
         let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
-        let member = make_member(&CompanyMemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::IntentCreate, CompanyPermission::IntentDelete], &now);
+        let member = make_member_worker(&CompanyMemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::IntentCreate, CompanyPermission::IntentDelete], &now);
         let costs = Costs::new_with_labor("widgetmaker", 42);
         let loc = SpatialThing::builder()
             .mappable_address(Some("444 Checkmate lane, LOGIC and FACTS, MN, 33133".into()))

--- a/src/transactions/intent.rs
+++ b/src/transactions/intent.rs
@@ -194,7 +194,7 @@ mod tests {
     use super::*;
     use crate::{
         models::{
-            company::{CompanyID, CompanyType},
+            company::CompanyID,
             company_member::CompanyMemberID,
             occupation::OccupationID,
             testutils::{make_user, make_company, make_member},
@@ -208,7 +208,7 @@ mod tests {
     fn can_create() {
         let now = util::time::now();
         let id = IntentID::create();
-        let company = make_company(&CompanyID::create(), CompanyType::Private, "jerry's widgets", &now);
+        let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
         let member = make_member(&CompanyMemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::IntentCreate], &now);
         let costs = Costs::new_with_labor("widgetmaker", 42);
@@ -275,7 +275,7 @@ mod tests {
     fn can_update() {
         let now = util::time::now();
         let id = IntentID::create();
-        let company = make_company(&CompanyID::create(), CompanyType::Private, "jerry's widgets", &now);
+        let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
         let member = make_member(&CompanyMemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::IntentCreate, CompanyPermission::IntentUpdate], &now);
         let costs1 = Costs::new_with_labor("widgetmaker", 42);
@@ -345,7 +345,7 @@ mod tests {
     fn can_delete() {
         let now = util::time::now();
         let id = IntentID::create();
-        let company = make_company(&CompanyID::create(), CompanyType::Private, "jerry's widgets", &now);
+        let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
         let member = make_member(&CompanyMemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::IntentCreate, CompanyPermission::IntentDelete], &now);
         let costs = Costs::new_with_labor("widgetmaker", 42);

--- a/src/transactions/member.rs
+++ b/src/transactions/member.rs
@@ -119,7 +119,7 @@ mod tests {
         models::{
             account::AccountID,
             company::CompanyID,
-            member::MemberWorker,
+            member::*,
             lib::{
                 agent::Agent,
                 basis_model::ActiveState,
@@ -219,6 +219,14 @@ mod tests {
 
         let res = update(&new_user, &existing_member, member.clone(), Some(new_occupation.clone()), Some(agreement.clone()), None, &now2);
         assert_eq!(res, Err(Error::InsufficientPrivileges));
+
+        let mut member3 = member2.clone();
+        member3.set_class(MemberClass::User(MemberUser::new()));
+        let res = update(&user, &existing_member, member3.clone(), Some(new_occupation.clone()), Some(agreement.clone()), None, &now2);
+        assert_eq!(res, Err(Error::MemberMustBeWorker));
+        member3.set_class(MemberClass::Company(MemberCompany::new()));
+        let res = update(&user, &existing_member, member3.clone(), Some(new_occupation.clone()), Some(agreement.clone()), None, &now2);
+        assert_eq!(res, Err(Error::MemberMustBeWorker));
     }
 
     #[test]
@@ -253,6 +261,14 @@ mod tests {
         user2.set_roles(vec![]);
         let res = set_permissions(&user2, &existing_member, member.clone(), vec![CompanyPermission::ResourceSpecCreate], &now2);
         assert_eq!(res, Err(Error::InsufficientPrivileges));
+
+        let mut member3 = member2.clone();
+        member3.set_class(MemberClass::User(MemberUser::new()));
+        let res = set_permissions(&user, &existing_member, member3.clone(), vec![CompanyPermission::ResourceSpecCreate], &now2);
+        assert!(res.is_ok());
+        member3.set_class(MemberClass::Company(MemberCompany::new()));
+        let res = set_permissions(&user, &existing_member, member3.clone(), vec![CompanyPermission::ResourceSpecCreate], &now2);
+        assert!(res.is_ok());
     }
 
     #[test]
@@ -288,6 +304,14 @@ mod tests {
         user2.set_roles(vec![]);
         let res = set_compensation(&user2, &existing_member, member.clone(), compensation.clone(), &now2);
         assert_eq!(res, Err(Error::InsufficientPrivileges));
+
+        let mut member3 = member2.clone();
+        member3.set_class(MemberClass::User(MemberUser::new()));
+        let res = set_compensation(&user, &existing_member, member3.clone(), compensation.clone(), &now2);
+        assert_eq!(res, Err(Error::MemberMustBeWorker));
+        member3.set_class(MemberClass::Company(MemberCompany::new()));
+        let res = set_compensation(&user, &existing_member, member3.clone(), compensation.clone(), &now2);
+        assert_eq!(res, Err(Error::MemberMustBeWorker));
     }
 
     #[test]

--- a/src/transactions/mod.rs
+++ b/src/transactions/mod.rs
@@ -27,7 +27,7 @@ pub enum OrderAction {
 pub mod agreement;
 pub mod commitment;
 pub mod company;
-pub mod company_member;
+pub mod member;
 //pub mod currency;
 pub mod event;
 pub mod intent;

--- a/src/transactions/process.rs
+++ b/src/transactions/process.rs
@@ -26,7 +26,7 @@ use crate::{
         Op,
         Modifications,
         company::{Company, Permission as CompanyPermission},
-        company_member::CompanyMember,
+        member::Member,
         lib::{
             agent::AgentID,
             basis_model::Deletable,
@@ -40,7 +40,7 @@ use url::Url;
 use vf_rs::vf;
 
 /// Create a new process
-pub fn create<T: Into<String>>(caller: &User, member: &CompanyMember, company: &Company, id: ProcessID, spec_id: ProcessSpecID, name: T, note: T, classifications: Vec<Url>, has_beginning: Option<DateTime<Utc>>, has_end: Option<DateTime<Utc>>, in_scope_of: Vec<AgentID>, active: bool, now: &DateTime<Utc>) -> Result<Modifications> {
+pub fn create<T: Into<String>>(caller: &User, member: &Member, company: &Company, id: ProcessID, spec_id: ProcessSpecID, name: T, note: T, classifications: Vec<Url>, has_beginning: Option<DateTime<Utc>>, has_end: Option<DateTime<Utc>>, in_scope_of: Vec<AgentID>, active: bool, now: &DateTime<Utc>) -> Result<Modifications> {
     caller.access_check(Permission::CompanyUpdateProcesses)?;
     member.access_check(caller.id(), company.id(), CompanyPermission::ProcessCreate)?;
     if company.is_deleted() {
@@ -71,7 +71,7 @@ pub fn create<T: Into<String>>(caller: &User, member: &CompanyMember, company: &
 }
 
 /// Update a process
-pub fn update(caller: &User, member: &CompanyMember, company: &Company, mut subject: Process, name: Option<String>, note: Option<String>, classifications: Option<Vec<Url>>, finished: Option<bool>, has_beginning: Option<DateTime<Utc>>, has_end: Option<DateTime<Utc>>, in_scope_of: Option<Vec<AgentID>>, active: Option<bool>, now: &DateTime<Utc>) -> Result<Modifications> {
+pub fn update(caller: &User, member: &Member, company: &Company, mut subject: Process, name: Option<String>, note: Option<String>, classifications: Option<Vec<Url>>, finished: Option<bool>, has_beginning: Option<DateTime<Utc>>, has_end: Option<DateTime<Utc>>, in_scope_of: Option<Vec<AgentID>>, active: Option<bool>, now: &DateTime<Utc>) -> Result<Modifications> {
     caller.access_check(Permission::CompanyUpdateProcesses)?;
     member.access_check(caller.id(), company.id(), CompanyPermission::ProcessUpdate)?;
     if company.is_deleted() {
@@ -106,7 +106,7 @@ pub fn update(caller: &User, member: &CompanyMember, company: &Company, mut subj
 }
 
 /// Delete a process
-pub fn delete(caller: &User, member: &CompanyMember, company: &Company, mut subject: Process, now: &DateTime<Utc>) -> Result<Modifications> {
+pub fn delete(caller: &User, member: &Member, company: &Company, mut subject: Process, now: &DateTime<Utc>) -> Result<Modifications> {
     caller.access_check(Permission::CompanyUpdateProcesses)?;
     member.access_check(caller.id(), company.id(), CompanyPermission::ProcessDelete)?;
     if company.is_deleted() {
@@ -125,7 +125,7 @@ mod tests {
     use crate::{
         models::{
             company::CompanyID,
-            company_member::CompanyMemberID,
+            member::MemberID,
             lib::agent::Agent,
             occupation::OccupationID,
             process_spec::ProcessSpecID,
@@ -141,7 +141,7 @@ mod tests {
         let id = ProcessID::create();
         let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
-        let member = make_member_worker(&CompanyMemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::ProcessCreate], &now);
+        let member = make_member_worker(&MemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::ProcessCreate], &now);
         let spec = make_process_spec(&ProcessSpecID::create(), company.id(), "Make Gazelle Freestyle", true, &now);
 
         let mods = create(&user, &member, &company, id.clone(), spec.id().clone(), "Gazelle Freestyle Marathon", "tony making me build five of these stupid things", vec!["https://www.wikidata.org/wiki/Q1141557".parse().unwrap()], Some(now.clone()), None, vec![], true, &now).unwrap().into_vec();
@@ -185,7 +185,7 @@ mod tests {
         let id = ProcessID::create();
         let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
-        let mut member = make_member_worker(&CompanyMemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::ProcessCreate], &now);
+        let mut member = make_member_worker(&MemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::ProcessCreate], &now);
         let spec = make_process_spec(&ProcessSpecID::create(), company.id(), "Make Gazelle Freestyle", true, &now);
         let mods = create(&user, &member, &company, id.clone(), spec.id().clone(), "Gazelle Freestyle Marathon", "tony making me build five of these stupid things", vec!["https://www.wikidata.org/wiki/Q1141557".parse().unwrap()], Some(now.clone()), None, vec![], true, &now).unwrap().into_vec();
         let process = mods[0].clone().expect_op::<Process>(Op::Create).unwrap();
@@ -231,7 +231,7 @@ mod tests {
         let id = ProcessID::create();
         let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
-        let mut member = make_member_worker(&CompanyMemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::ProcessCreate], &now);
+        let mut member = make_member_worker(&MemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::ProcessCreate], &now);
         let spec = make_process_spec(&ProcessSpecID::create(), company.id(), "Make Gazelle Freestyle", true, &now);
         let mods = create(&user, &member, &company, id.clone(), spec.id().clone(), "Gazelle Freestyle Marathon", "tony making me build five of these stupid things", vec!["https://www.wikidata.org/wiki/Q1141557".parse().unwrap()], Some(now.clone()), None, vec![], true, &now).unwrap().into_vec();
         let process = mods[0].clone().expect_op::<Process>(Op::Create).unwrap();

--- a/src/transactions/process.rs
+++ b/src/transactions/process.rs
@@ -121,7 +121,7 @@ mod tests {
     use super::*;
     use crate::{
         models::{
-            company::{CompanyID, CompanyType},
+            company::CompanyID,
             company_member::CompanyMemberID,
             lib::agent::Agent,
             occupation::OccupationID,
@@ -136,7 +136,7 @@ mod tests {
     fn can_create() {
         let now = util::time::now();
         let id = ProcessID::create();
-        let company = make_company(&CompanyID::create(), CompanyType::Private, "jerry's widgets", &now);
+        let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
         let member = make_member(&CompanyMemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::ProcessCreate], &now);
         let spec = make_process_spec(&ProcessSpecID::create(), company.id(), "Make Gazelle Freestyle", true, &now);
@@ -180,7 +180,7 @@ mod tests {
     fn can_update() {
         let now = util::time::now();
         let id = ProcessID::create();
-        let company = make_company(&CompanyID::create(), CompanyType::Private, "jerry's widgets", &now);
+        let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
         let mut member = make_member(&CompanyMemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::ProcessCreate], &now);
         let spec = make_process_spec(&ProcessSpecID::create(), company.id(), "Make Gazelle Freestyle", true, &now);
@@ -226,7 +226,7 @@ mod tests {
     fn can_delete() {
         let now = util::time::now();
         let id = ProcessID::create();
-        let company = make_company(&CompanyID::create(), CompanyType::Private, "jerry's widgets", &now);
+        let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
         let mut member = make_member(&CompanyMemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::ProcessCreate], &now);
         let spec = make_process_spec(&ProcessSpecID::create(), company.id(), "Make Gazelle Freestyle", true, &now);

--- a/src/transactions/process.rs
+++ b/src/transactions/process.rs
@@ -27,7 +27,10 @@ use crate::{
         Modifications,
         company::{Company, Permission as CompanyPermission},
         company_member::CompanyMember,
-        lib::agent::AgentID,
+        lib::{
+            agent::AgentID,
+            basis_model::Deletable,
+        },
         process::{Process, ProcessID},
         process_spec::ProcessSpecID,
         user::User,
@@ -126,7 +129,7 @@ mod tests {
             lib::agent::Agent,
             occupation::OccupationID,
             process_spec::ProcessSpecID,
-            testutils::{make_user, make_company, make_member, make_process_spec},
+            testutils::{make_user, make_company, make_member_worker, make_process_spec},
             user::UserID,
         },
         util,
@@ -138,7 +141,7 @@ mod tests {
         let id = ProcessID::create();
         let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
-        let member = make_member(&CompanyMemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::ProcessCreate], &now);
+        let member = make_member_worker(&CompanyMemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::ProcessCreate], &now);
         let spec = make_process_spec(&ProcessSpecID::create(), company.id(), "Make Gazelle Freestyle", true, &now);
 
         let mods = create(&user, &member, &company, id.clone(), spec.id().clone(), "Gazelle Freestyle Marathon", "tony making me build five of these stupid things", vec!["https://www.wikidata.org/wiki/Q1141557".parse().unwrap()], Some(now.clone()), None, vec![], true, &now).unwrap().into_vec();
@@ -182,7 +185,7 @@ mod tests {
         let id = ProcessID::create();
         let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
-        let mut member = make_member(&CompanyMemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::ProcessCreate], &now);
+        let mut member = make_member_worker(&CompanyMemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::ProcessCreate], &now);
         let spec = make_process_spec(&ProcessSpecID::create(), company.id(), "Make Gazelle Freestyle", true, &now);
         let mods = create(&user, &member, &company, id.clone(), spec.id().clone(), "Gazelle Freestyle Marathon", "tony making me build five of these stupid things", vec!["https://www.wikidata.org/wiki/Q1141557".parse().unwrap()], Some(now.clone()), None, vec![], true, &now).unwrap().into_vec();
         let process = mods[0].clone().expect_op::<Process>(Op::Create).unwrap();
@@ -228,7 +231,7 @@ mod tests {
         let id = ProcessID::create();
         let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
-        let mut member = make_member(&CompanyMemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::ProcessCreate], &now);
+        let mut member = make_member_worker(&CompanyMemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::ProcessCreate], &now);
         let spec = make_process_spec(&ProcessSpecID::create(), company.id(), "Make Gazelle Freestyle", true, &now);
         let mods = create(&user, &member, &company, id.clone(), spec.id().clone(), "Gazelle Freestyle Marathon", "tony making me build five of these stupid things", vec!["https://www.wikidata.org/wiki/Q1141557".parse().unwrap()], Some(now.clone()), None, vec![], true, &now).unwrap().into_vec();
         let process = mods[0].clone().expect_op::<Process>(Op::Create).unwrap();

--- a/src/transactions/process_spec.rs
+++ b/src/transactions/process_spec.rs
@@ -17,7 +17,7 @@ use crate::{
         Op,
         Modifications,
         company::{Company, Permission as CompanyPermission},
-        company_member::CompanyMember,
+        member::Member,
         lib::basis_model::Deletable,
         process_spec::{ProcessSpec, ProcessSpecID},
         user::User,
@@ -26,7 +26,7 @@ use crate::{
 use vf_rs::vf;
 
 /// Create a new ProcessSpec
-pub fn create<T: Into<String>>(caller: &User, member: &CompanyMember, company: &Company, id: ProcessSpecID, name: T, note: T, active: bool, now: &DateTime<Utc>) -> Result<Modifications> {
+pub fn create<T: Into<String>>(caller: &User, member: &Member, company: &Company, id: ProcessSpecID, name: T, note: T, active: bool, now: &DateTime<Utc>) -> Result<Modifications> {
     caller.access_check(Permission::CompanyUpdateProcessSpecs)?;
     member.access_check(caller.id(), company.id(), CompanyPermission::ProcessSpecCreate)?;
     if company.is_deleted() {
@@ -51,7 +51,7 @@ pub fn create<T: Into<String>>(caller: &User, member: &CompanyMember, company: &
 }
 
 /// Update a resource spec
-pub fn update(caller: &User, member: &CompanyMember, company: &Company, mut subject: ProcessSpec, name: Option<String>, note: Option<String>, active: Option<bool>, now: &DateTime<Utc>) -> Result<Modifications> {
+pub fn update(caller: &User, member: &Member, company: &Company, mut subject: ProcessSpec, name: Option<String>, note: Option<String>, active: Option<bool>, now: &DateTime<Utc>) -> Result<Modifications> {
     caller.access_check(Permission::CompanyUpdateProcessSpecs)?;
     member.access_check(caller.id(), company.id(), CompanyPermission::ProcessSpecUpdate)?;
     if company.is_deleted() {
@@ -71,7 +71,7 @@ pub fn update(caller: &User, member: &CompanyMember, company: &Company, mut subj
 }
 
 /// Delete a resource spec
-pub fn delete(caller: &User, member: &CompanyMember, company: &Company, mut subject: ProcessSpec, now: &DateTime<Utc>) -> Result<Modifications> {
+pub fn delete(caller: &User, member: &Member, company: &Company, mut subject: ProcessSpec, now: &DateTime<Utc>) -> Result<Modifications> {
     caller.access_check(Permission::CompanyUpdateProcessSpecs)?;
     member.access_check(caller.id(), company.id(), CompanyPermission::ProcessSpecDelete)?;
     if company.is_deleted() {
@@ -87,7 +87,7 @@ mod tests {
     use crate::{
         models::{
             company::CompanyID,
-            company_member::CompanyMemberID,
+            member::MemberID,
             occupation::OccupationID,
             process_spec::{ProcessSpec, ProcessSpecID},
             testutils::{make_user, make_company, make_member_worker},
@@ -102,7 +102,7 @@ mod tests {
         let id = ProcessSpecID::create();
         let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
-        let member = make_member_worker(&CompanyMemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::ProcessSpecCreate], &now);
+        let member = make_member_worker(&MemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::ProcessSpecCreate], &now);
 
         let mods = create(&user, &member, &company, id.clone(), "SEIZE THE MEANS OF PRODUCTION", "our first process", true, &now).unwrap().into_vec();
         assert_eq!(mods.len(), 1);
@@ -139,7 +139,7 @@ mod tests {
         let id = ProcessSpecID::create();
         let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
-        let mut member = make_member_worker(&CompanyMemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::ProcessSpecCreate], &now);
+        let mut member = make_member_worker(&MemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::ProcessSpecCreate], &now);
         let mods = create(&user, &member, &company, id.clone(), "SEIZE THE MEANS OF PRODUCTION", "our first process", true, &now).unwrap().into_vec();
         let recspec = mods[0].clone().expect_op::<ProcessSpec>(Op::Create).unwrap();
 
@@ -178,7 +178,7 @@ mod tests {
         let id = ProcessSpecID::create();
         let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
-        let mut member = make_member_worker(&CompanyMemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::ProcessSpecCreate], &now);
+        let mut member = make_member_worker(&MemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::ProcessSpecCreate], &now);
         let mods = create(&user, &member, &company, id.clone(), "SEIZE THE MEANS OF PRODUCTION", "our first process", true, &now).unwrap().into_vec();
         let recspec = mods[0].clone().expect_op::<ProcessSpec>(Op::Create).unwrap();
 

--- a/src/transactions/process_spec.rs
+++ b/src/transactions/process_spec.rs
@@ -18,6 +18,7 @@ use crate::{
         Modifications,
         company::{Company, Permission as CompanyPermission},
         company_member::CompanyMember,
+        lib::basis_model::Deletable,
         process_spec::{ProcessSpec, ProcessSpecID},
         user::User,
     },
@@ -89,7 +90,7 @@ mod tests {
             company_member::CompanyMemberID,
             occupation::OccupationID,
             process_spec::{ProcessSpec, ProcessSpecID},
-            testutils::{make_user, make_company, make_member},
+            testutils::{make_user, make_company, make_member_worker},
             user::UserID,
         },
         util,
@@ -101,7 +102,7 @@ mod tests {
         let id = ProcessSpecID::create();
         let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
-        let member = make_member(&CompanyMemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::ProcessSpecCreate], &now);
+        let member = make_member_worker(&CompanyMemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::ProcessSpecCreate], &now);
 
         let mods = create(&user, &member, &company, id.clone(), "SEIZE THE MEANS OF PRODUCTION", "our first process", true, &now).unwrap().into_vec();
         assert_eq!(mods.len(), 1);
@@ -138,7 +139,7 @@ mod tests {
         let id = ProcessSpecID::create();
         let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
-        let mut member = make_member(&CompanyMemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::ProcessSpecCreate], &now);
+        let mut member = make_member_worker(&CompanyMemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::ProcessSpecCreate], &now);
         let mods = create(&user, &member, &company, id.clone(), "SEIZE THE MEANS OF PRODUCTION", "our first process", true, &now).unwrap().into_vec();
         let recspec = mods[0].clone().expect_op::<ProcessSpec>(Op::Create).unwrap();
 
@@ -177,7 +178,7 @@ mod tests {
         let id = ProcessSpecID::create();
         let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
-        let mut member = make_member(&CompanyMemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::ProcessSpecCreate], &now);
+        let mut member = make_member_worker(&CompanyMemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::ProcessSpecCreate], &now);
         let mods = create(&user, &member, &company, id.clone(), "SEIZE THE MEANS OF PRODUCTION", "our first process", true, &now).unwrap().into_vec();
         let recspec = mods[0].clone().expect_op::<ProcessSpec>(Op::Create).unwrap();
 

--- a/src/transactions/process_spec.rs
+++ b/src/transactions/process_spec.rs
@@ -85,7 +85,7 @@ mod tests {
     use super::*;
     use crate::{
         models::{
-            company::{CompanyID, CompanyType},
+            company::CompanyID,
             company_member::CompanyMemberID,
             occupation::OccupationID,
             process_spec::{ProcessSpec, ProcessSpecID},
@@ -99,7 +99,7 @@ mod tests {
     fn can_create() {
         let now = util::time::now();
         let id = ProcessSpecID::create();
-        let company = make_company(&CompanyID::create(), CompanyType::Private, "jerry's widgets", &now);
+        let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
         let member = make_member(&CompanyMemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::ProcessSpecCreate], &now);
 
@@ -136,7 +136,7 @@ mod tests {
     fn can_update() {
         let now = util::time::now();
         let id = ProcessSpecID::create();
-        let company = make_company(&CompanyID::create(), CompanyType::Private, "jerry's widgets", &now);
+        let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
         let mut member = make_member(&CompanyMemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::ProcessSpecCreate], &now);
         let mods = create(&user, &member, &company, id.clone(), "SEIZE THE MEANS OF PRODUCTION", "our first process", true, &now).unwrap().into_vec();
@@ -175,7 +175,7 @@ mod tests {
     fn can_delete() {
         let now = util::time::now();
         let id = ProcessSpecID::create();
-        let company = make_company(&CompanyID::create(), CompanyType::Private, "jerry's widgets", &now);
+        let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
         let mut member = make_member(&CompanyMemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::ProcessSpecCreate], &now);
         let mods = create(&user, &member, &company, id.clone(), "SEIZE THE MEANS OF PRODUCTION", "our first process", true, &now).unwrap().into_vec();

--- a/src/transactions/resource.rs
+++ b/src/transactions/resource.rs
@@ -113,7 +113,7 @@ mod tests {
     use super::*;
     use crate::{
         models::{
-            company::{CompanyID, CompanyType},
+            company::CompanyID,
             company_member::CompanyMemberID,
             occupation::OccupationID,
             resource_spec::ResourceSpecID,
@@ -127,7 +127,7 @@ mod tests {
     fn can_create() {
         let now = util::time::now();
         let id = ResourceID::create();
-        let company = make_company(&CompanyID::create(), CompanyType::Private, "jerry's widgets", &now);
+        let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
         let member = make_member(&CompanyMemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::ResourceCreate], &now);
         let spec = make_resource_spec(&ResourceSpecID::create(), company.id(), "widgets, baby", &now);
@@ -174,7 +174,7 @@ mod tests {
     fn can_update() {
         let now = util::time::now();
         let id = ResourceID::create();
-        let company = make_company(&CompanyID::create(), CompanyType::Private, "jerry's widgets", &now);
+        let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
         let mut member = make_member(&CompanyMemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::ResourceCreate], &now);
         let spec = make_resource_spec(&ResourceSpecID::create(), company.id(), "widgets, baby", &now);
@@ -222,7 +222,7 @@ mod tests {
     fn can_delete() {
         let now = util::time::now();
         let id = ResourceID::create();
-        let company = make_company(&CompanyID::create(), CompanyType::Private, "jerry's widgets", &now);
+        let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
         let mut member = make_member(&CompanyMemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::ResourceCreate], &now);
         let spec = make_resource_spec(&ResourceSpecID::create(), company.id(), "widgets, baby", &now);

--- a/src/transactions/resource.rs
+++ b/src/transactions/resource.rs
@@ -19,7 +19,7 @@ use crate::{
         Op,
         Modifications,
         company::{Company, Permission as CompanyPermission},
-        company_member::CompanyMember,
+        member::Member,
         lib::{
             agent::Agent,
             basis_model::Deletable,
@@ -34,7 +34,7 @@ use url::Url;
 use vf_rs::{vf, dfc};
 
 /// Create a new resource
-pub fn create(caller: &User, member: &CompanyMember, company: &Company, id: ResourceID, spec_id: ResourceSpecID, lot: Option<dfc::ProductBatch>, name: Option<String>, tracking_id: Option<String>, classifications: Vec<Url>, note: Option<String>, unit_of_effort: Option<Unit>, active: bool, now: &DateTime<Utc>) -> Result<Modifications> {
+pub fn create(caller: &User, member: &Member, company: &Company, id: ResourceID, spec_id: ResourceSpecID, lot: Option<dfc::ProductBatch>, name: Option<String>, tracking_id: Option<String>, classifications: Vec<Url>, note: Option<String>, unit_of_effort: Option<Unit>, active: bool, now: &DateTime<Utc>) -> Result<Modifications> {
     caller.access_check(Permission::CompanyUpdateResources)?;
     member.access_check(caller.id(), company.id(), CompanyPermission::ResourceCreate)?;
     if company.is_deleted() {
@@ -66,7 +66,7 @@ pub fn create(caller: &User, member: &CompanyMember, company: &Company, id: Reso
 }
 
 /// Update a resource
-pub fn update(caller: &User, member: &CompanyMember, company: &Company, mut subject: Resource, lot: Option<dfc::ProductBatch>, name: Option<String>, tracking_id: Option<String>, classifications: Option<Vec<Url>>, note: Option<String>, unit_of_effort: Option<Unit>, active: Option<bool>, now: &DateTime<Utc>) -> Result<Modifications> {
+pub fn update(caller: &User, member: &Member, company: &Company, mut subject: Resource, lot: Option<dfc::ProductBatch>, name: Option<String>, tracking_id: Option<String>, classifications: Option<Vec<Url>>, note: Option<String>, unit_of_effort: Option<Unit>, active: Option<bool>, now: &DateTime<Utc>) -> Result<Modifications> {
     caller.access_check(Permission::CompanyUpdateResources)?;
     member.access_check(caller.id(), company.id(), CompanyPermission::ResourceUpdate)?;
     if company.is_deleted() {
@@ -98,7 +98,7 @@ pub fn update(caller: &User, member: &CompanyMember, company: &Company, mut subj
 }
 
 /// Delete a resource
-pub fn delete(caller: &User, member: &CompanyMember, company: &Company, mut subject: Resource, now: &DateTime<Utc>) -> Result<Modifications> {
+pub fn delete(caller: &User, member: &Member, company: &Company, mut subject: Resource, now: &DateTime<Utc>) -> Result<Modifications> {
     caller.access_check(Permission::CompanyUpdateResources)?;
     member.access_check(caller.id(), company.id(), CompanyPermission::ResourceDelete)?;
     if company.is_deleted() {
@@ -117,7 +117,7 @@ mod tests {
     use crate::{
         models::{
             company::CompanyID,
-            company_member::CompanyMemberID,
+            member::MemberID,
             occupation::OccupationID,
             resource_spec::ResourceSpecID,
             testutils::{make_user, make_company, make_member_worker, make_resource_spec},
@@ -132,7 +132,7 @@ mod tests {
         let id = ResourceID::create();
         let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
-        let member = make_member_worker(&CompanyMemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::ResourceCreate], &now);
+        let member = make_member_worker(&MemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::ResourceCreate], &now);
         let spec = make_resource_spec(&ResourceSpecID::create(), company.id(), "widgets, baby", &now);
         let lot = dfc::ProductBatch::builder()
             .batch_number("123")
@@ -179,7 +179,7 @@ mod tests {
         let id = ResourceID::create();
         let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
-        let mut member = make_member_worker(&CompanyMemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::ResourceCreate], &now);
+        let mut member = make_member_worker(&MemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::ResourceCreate], &now);
         let spec = make_resource_spec(&ResourceSpecID::create(), company.id(), "widgets, baby", &now);
         let lot = dfc::ProductBatch::builder()
             .batch_number("123")
@@ -227,7 +227,7 @@ mod tests {
         let id = ResourceID::create();
         let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
-        let mut member = make_member_worker(&CompanyMemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::ResourceCreate], &now);
+        let mut member = make_member_worker(&MemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::ResourceCreate], &now);
         let spec = make_resource_spec(&ResourceSpecID::create(), company.id(), "widgets, baby", &now);
         let lot = dfc::ProductBatch::builder()
             .batch_number("123")

--- a/src/transactions/resource.rs
+++ b/src/transactions/resource.rs
@@ -20,7 +20,10 @@ use crate::{
         Modifications,
         company::{Company, Permission as CompanyPermission},
         company_member::CompanyMember,
-        lib::agent::Agent,
+        lib::{
+            agent::Agent,
+            basis_model::Deletable,
+        },
         resource::{Resource, ResourceID},
         resource_spec::ResourceSpecID,
         user::User,
@@ -117,7 +120,7 @@ mod tests {
             company_member::CompanyMemberID,
             occupation::OccupationID,
             resource_spec::ResourceSpecID,
-            testutils::{make_user, make_company, make_member, make_resource_spec},
+            testutils::{make_user, make_company, make_member_worker, make_resource_spec},
             user::UserID,
         },
         util,
@@ -129,7 +132,7 @@ mod tests {
         let id = ResourceID::create();
         let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
-        let member = make_member(&CompanyMemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::ResourceCreate], &now);
+        let member = make_member_worker(&CompanyMemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::ResourceCreate], &now);
         let spec = make_resource_spec(&ResourceSpecID::create(), company.id(), "widgets, baby", &now);
         let lot = dfc::ProductBatch::builder()
             .batch_number("123")
@@ -176,7 +179,7 @@ mod tests {
         let id = ResourceID::create();
         let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
-        let mut member = make_member(&CompanyMemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::ResourceCreate], &now);
+        let mut member = make_member_worker(&CompanyMemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::ResourceCreate], &now);
         let spec = make_resource_spec(&ResourceSpecID::create(), company.id(), "widgets, baby", &now);
         let lot = dfc::ProductBatch::builder()
             .batch_number("123")
@@ -224,7 +227,7 @@ mod tests {
         let id = ResourceID::create();
         let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
-        let mut member = make_member(&CompanyMemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::ResourceCreate], &now);
+        let mut member = make_member_worker(&CompanyMemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::ResourceCreate], &now);
         let spec = make_resource_spec(&ResourceSpecID::create(), company.id(), "widgets, baby", &now);
         let lot = dfc::ProductBatch::builder()
             .batch_number("123")

--- a/src/transactions/resource_spec.rs
+++ b/src/transactions/resource_spec.rs
@@ -18,7 +18,7 @@ use crate::{
         Op,
         Modifications,
         company::{Company, Permission as CompanyPermission},
-        company_member::CompanyMember,
+        member::Member,
         lib::basis_model::Deletable,
         resource_spec::{ResourceSpec, ResourceSpecID},
         user::User,
@@ -29,7 +29,7 @@ use url::Url;
 use vf_rs::vf;
 
 /// Create a new ResourceSpec
-pub fn create<T: Into<String>>(caller: &User, member: &CompanyMember, company: &Company, id: ResourceSpecID, name: T, note: T, classifications: Vec<Url>, default_unit_of_effort: Option<Unit>, default_unit_of_resource: Option<Unit>, active: bool, now: &DateTime<Utc>) -> Result<Modifications> {
+pub fn create<T: Into<String>>(caller: &User, member: &Member, company: &Company, id: ResourceSpecID, name: T, note: T, classifications: Vec<Url>, default_unit_of_effort: Option<Unit>, default_unit_of_resource: Option<Unit>, active: bool, now: &DateTime<Utc>) -> Result<Modifications> {
     caller.access_check(Permission::CompanyUpdateResourceSpecs)?;
     member.access_check(caller.id(), company.id(), CompanyPermission::ResourceSpecCreate)?;
     if company.is_deleted() {
@@ -57,7 +57,7 @@ pub fn create<T: Into<String>>(caller: &User, member: &CompanyMember, company: &
 }
 
 /// Update a resource spec
-pub fn update(caller: &User, member: &CompanyMember, company: &Company, mut subject: ResourceSpec, name: Option<String>, note: Option<String>, classifications: Option<Vec<Url>>, default_unit_of_effort: Option<Unit>, default_unit_of_resource: Option<Unit>, active: Option<bool>, now: &DateTime<Utc>) -> Result<Modifications> {
+pub fn update(caller: &User, member: &Member, company: &Company, mut subject: ResourceSpec, name: Option<String>, note: Option<String>, classifications: Option<Vec<Url>>, default_unit_of_effort: Option<Unit>, default_unit_of_resource: Option<Unit>, active: Option<bool>, now: &DateTime<Utc>) -> Result<Modifications> {
     caller.access_check(Permission::CompanyUpdateResourceSpecs)?;
     member.access_check(caller.id(), company.id(), CompanyPermission::ResourceSpecUpdate)?;
     if company.is_deleted() {
@@ -86,7 +86,7 @@ pub fn update(caller: &User, member: &CompanyMember, company: &Company, mut subj
 }
 
 /// Delete a resource spec
-pub fn delete(caller: &User, member: &CompanyMember, company: &Company, mut subject: ResourceSpec, now: &DateTime<Utc>) -> Result<Modifications> {
+pub fn delete(caller: &User, member: &Member, company: &Company, mut subject: ResourceSpec, now: &DateTime<Utc>) -> Result<Modifications> {
     caller.access_check(Permission::CompanyUpdateResourceSpecs)?;
     member.access_check(caller.id(), company.id(), CompanyPermission::ResourceSpecDelete)?;
     if company.is_deleted() {
@@ -102,7 +102,7 @@ mod tests {
     use crate::{
         models::{
             company::CompanyID,
-            company_member::CompanyMemberID,
+            member::MemberID,
             occupation::OccupationID,
             resource_spec::{ResourceSpec, ResourceSpecID},
             testutils::{make_user, make_company, make_member_worker},
@@ -117,7 +117,7 @@ mod tests {
         let id = ResourceSpecID::create();
         let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
-        let member = make_member_worker(&CompanyMemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::ResourceSpecCreate], &now);
+        let member = make_member_worker(&MemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::ResourceSpecCreate], &now);
 
         let mods = create(&user, &member, &company, id.clone(), "Beans", "yummy", vec!["https://www.wikidata.org/wiki/Q379813".parse().unwrap()], Some(Unit::Hour), Some(Unit::Kilogram), true, &now).unwrap().into_vec();
         assert_eq!(mods.len(), 1);
@@ -157,7 +157,7 @@ mod tests {
         let id = ResourceSpecID::create();
         let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
-        let mut member = make_member_worker(&CompanyMemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::ResourceSpecCreate], &now);
+        let mut member = make_member_worker(&MemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::ResourceSpecCreate], &now);
         let mods = create(&user, &member, &company, id.clone(), "Beans", "yummy", vec!["https://www.wikidata.org/wiki/Q379813".parse().unwrap()], Some(Unit::Hour), Some(Unit::Kilogram), true, &now).unwrap().into_vec();
         let recspec = mods[0].clone().expect_op::<ResourceSpec>(Op::Create).unwrap();
 
@@ -199,7 +199,7 @@ mod tests {
         let id = ResourceSpecID::create();
         let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
-        let mut member = make_member_worker(&CompanyMemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::ResourceSpecCreate], &now);
+        let mut member = make_member_worker(&MemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::ResourceSpecCreate], &now);
         let mods = create(&user, &member, &company, id.clone(), "Beans", "yummy", vec!["https://www.wikidata.org/wiki/Q379813".parse().unwrap()], Some(Unit::Hour), Some(Unit::Kilogram), true, &now).unwrap().into_vec();
         let recspec = mods[0].clone().expect_op::<ResourceSpec>(Op::Create).unwrap();
 

--- a/src/transactions/resource_spec.rs
+++ b/src/transactions/resource_spec.rs
@@ -19,6 +19,7 @@ use crate::{
         Modifications,
         company::{Company, Permission as CompanyPermission},
         company_member::CompanyMember,
+        lib::basis_model::Deletable,
         resource_spec::{ResourceSpec, ResourceSpecID},
         user::User,
     },
@@ -104,7 +105,7 @@ mod tests {
             company_member::CompanyMemberID,
             occupation::OccupationID,
             resource_spec::{ResourceSpec, ResourceSpecID},
-            testutils::{make_user, make_company, make_member},
+            testutils::{make_user, make_company, make_member_worker},
             user::UserID,
         },
         util,
@@ -116,7 +117,7 @@ mod tests {
         let id = ResourceSpecID::create();
         let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
-        let member = make_member(&CompanyMemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::ResourceSpecCreate], &now);
+        let member = make_member_worker(&CompanyMemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::ResourceSpecCreate], &now);
 
         let mods = create(&user, &member, &company, id.clone(), "Beans", "yummy", vec!["https://www.wikidata.org/wiki/Q379813".parse().unwrap()], Some(Unit::Hour), Some(Unit::Kilogram), true, &now).unwrap().into_vec();
         assert_eq!(mods.len(), 1);
@@ -156,7 +157,7 @@ mod tests {
         let id = ResourceSpecID::create();
         let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
-        let mut member = make_member(&CompanyMemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::ResourceSpecCreate], &now);
+        let mut member = make_member_worker(&CompanyMemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::ResourceSpecCreate], &now);
         let mods = create(&user, &member, &company, id.clone(), "Beans", "yummy", vec!["https://www.wikidata.org/wiki/Q379813".parse().unwrap()], Some(Unit::Hour), Some(Unit::Kilogram), true, &now).unwrap().into_vec();
         let recspec = mods[0].clone().expect_op::<ResourceSpec>(Op::Create).unwrap();
 
@@ -198,7 +199,7 @@ mod tests {
         let id = ResourceSpecID::create();
         let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
-        let mut member = make_member(&CompanyMemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::ResourceSpecCreate], &now);
+        let mut member = make_member_worker(&CompanyMemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::ResourceSpecCreate], &now);
         let mods = create(&user, &member, &company, id.clone(), "Beans", "yummy", vec!["https://www.wikidata.org/wiki/Q379813".parse().unwrap()], Some(Unit::Hour), Some(Unit::Kilogram), true, &now).unwrap().into_vec();
         let recspec = mods[0].clone().expect_op::<ResourceSpec>(Op::Create).unwrap();
 

--- a/src/transactions/resource_spec.rs
+++ b/src/transactions/resource_spec.rs
@@ -100,7 +100,7 @@ mod tests {
     use super::*;
     use crate::{
         models::{
-            company::{CompanyID, CompanyType},
+            company::CompanyID,
             company_member::CompanyMemberID,
             occupation::OccupationID,
             resource_spec::{ResourceSpec, ResourceSpecID},
@@ -114,7 +114,7 @@ mod tests {
     fn can_create() {
         let now = util::time::now();
         let id = ResourceSpecID::create();
-        let company = make_company(&CompanyID::create(), CompanyType::Private, "jerry's widgets", &now);
+        let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
         let member = make_member(&CompanyMemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::ResourceSpecCreate], &now);
 
@@ -154,7 +154,7 @@ mod tests {
     fn can_update() {
         let now = util::time::now();
         let id = ResourceSpecID::create();
-        let company = make_company(&CompanyID::create(), CompanyType::Private, "jerry's widgets", &now);
+        let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
         let mut member = make_member(&CompanyMemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::ResourceSpecCreate], &now);
         let mods = create(&user, &member, &company, id.clone(), "Beans", "yummy", vec!["https://www.wikidata.org/wiki/Q379813".parse().unwrap()], Some(Unit::Hour), Some(Unit::Kilogram), true, &now).unwrap().into_vec();
@@ -196,7 +196,7 @@ mod tests {
     fn can_delete() {
         let now = util::time::now();
         let id = ResourceSpecID::create();
-        let company = make_company(&CompanyID::create(), CompanyType::Private, "jerry's widgets", &now);
+        let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
         let user = make_user(&UserID::create(), None, &now);
         let mut member = make_member(&CompanyMemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::ResourceSpecCreate], &now);
         let mods = create(&user, &member, &company, id.clone(), "Beans", "yummy", vec!["https://www.wikidata.org/wiki/Q379813".parse().unwrap()], Some(Unit::Hour), Some(Unit::Kilogram), true, &now).unwrap().into_vec();


### PR DESCRIPTION
Previously, company members could just be workers.

Now, companies can have three membership classes (oops!!): `Company`, `User`, `Worker`. In effect we've gone from a flat system that was going to be organized by a one-level-up regional container to a completely fluid system of exitable hierarchies of groups. In effect, the old regional system could be easily modeled by the new system, should participants choose to do so, but other setups are possible as well.

All tests passing, although admittedly the `Company` and `User` types have only been added to tests in places where `Error::MemberMustBeWorker` is implemented.

There were some other things in basisproject/tracker#99 like enforcing no circular links in companies or caching all members, but ultimately both of these are really only possible (or at least much more feasible) in the storage layer.