### PR TITLE
Using is_active() where approriate instead of is_deleted()

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -60,6 +60,10 @@ pub enum Error {
     /// attached to the deleted object).
     #[error("object {0} is deleted")]
     ObjectIsDeleted(String),
+    /// When we try to update an object that is inactive (or an object attached
+    /// to the inactive object).
+    #[error("object {0} is inactive")]
+    ObjectIsInactive(String),
     /// When we try to modify an object that is now in a read-only state.
     #[error("object {0} is read-only")]
     ObjectIsReadOnly(String),

--- a/src/models/lib/agent.rs
+++ b/src/models/lib/agent.rs
@@ -3,7 +3,7 @@ use crate::{
     models::{
         company::CompanyID,
         member::MemberID,
-        lib::basis_model::Deletable,
+        lib::basis_model::ActiveState,
         user::UserID,
     },
 };
@@ -12,7 +12,7 @@ use std::convert::TryFrom;
 
 /// A trait that holds common agent functionality, generally applied to models
 /// with ID types implemented in `AgentID`.
-pub trait Agent: Deletable {
+pub trait Agent: ActiveState {
     /// Convert the model's ID to and AgentID.
     fn agent_id(&self) -> AgentID;
 }

--- a/src/models/member.rs
+++ b/src/models/member.rs
@@ -211,6 +211,16 @@ basis_model! {
 }
 
 impl Member {
+    /// Grab the the member's agent id for this member record
+    pub fn member_id(&self) -> &AgentID {
+        self.inner().subject()
+    }
+
+    /// Grab the the groups's agent id for this member record
+    pub fn group_id(&self) -> &AgentID {
+        self.inner().object()
+    }
+
     /// Determines if a member can perform an action (base on their permissions
     /// list). Note that we don't use roles here, the idea is that companies
     /// manage their own roles and permissions are assigned to users directly.
@@ -224,20 +234,10 @@ impl Member {
 
     /// Check if this member can perform an action on a company.
     pub fn access_check(&self, user_id: &UserID, company_id: &CompanyID, permission: Permission) -> Result<()> {
-        if self.inner().subject() != &user_id.clone().into() || self.inner().object() != &company_id.clone().into() || !self.can(&permission) {
+        if self.member_id() != &user_id.clone().into() || self.group_id() != &company_id.clone().into() || !self.can(&permission) {
             Err(Error::InsufficientPrivileges)?;
         }
         Ok(())
-    }
-
-    /// Grab the the member's agent id for this member record
-    pub fn member_id(&self) -> &AgentID {
-        self.inner().subject()
-    }
-
-    /// Grab the the groups's agent id for this member record
-    pub fn group_id(&self) -> &AgentID {
-        self.inner().object()
     }
 
     /// Try and get a `CompanyID` from this member's group id.

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -302,6 +302,7 @@ pub(crate) mod testutils {
             .inner(vf::Process::builder().name(name).build().unwrap())
             .company_id(company_id.clone())
             .costs(costs.clone())
+            .active(true)
             .created(now.clone())
             .updated(now.clone())
             .build().unwrap()

--- a/src/transactions/intent.rs
+++ b/src/transactions/intent.rs
@@ -20,7 +20,7 @@ use crate::{
         member::Member,
         lib::{
             agent::{Agent, AgentID},
-            basis_model::Deletable,
+            basis_model::{ActiveState, Deletable},
         },
         intent::{Intent, IntentID},
         resource::ResourceID,
@@ -37,8 +37,8 @@ use vf_rs::{vf, geo::SpatialThing};
 pub fn create(caller: &User, member: &Member, company: &Company, id: IntentID, move_costs: Option<Costs>, action: OrderAction, agreed_in: Option<Url>, at_location: Option<SpatialThing>, available_quantity: Option<Measure>, due: Option<DateTime<Utc>>, effort_quantity: Option<Measure>, finished: Option<bool>, has_beginning: Option<DateTime<Utc>>, has_end: Option<DateTime<Utc>>, has_point_in_time: Option<DateTime<Utc>>, in_scope_of: Vec<AgentID>, name: Option<String>, note: Option<String>, provider: Option<AgentID>, receiver: Option<AgentID>, resource_conforms_to: Option<ResourceSpecID>, resource_inventoried_as: Option<ResourceID>, resource_quantity: Option<Measure>, active: bool, now: &DateTime<Utc>) -> Result<Modifications> {
     caller.access_check(Permission::CompanyUpdateIntents)?;
     member.access_check(caller.id(), company.id(), CompanyPermission::IntentCreate)?;
-    if company.is_deleted() {
-        Err(Error::ObjectIsDeleted("company".into()))?;
+    if !company.is_active() {
+        Err(Error::ObjectIsInactive("company".into()))?;
     }
     let company_agent_id = company.agent_id();
     if provider.is_none() && receiver.is_none() {
@@ -92,8 +92,8 @@ pub fn create(caller: &User, member: &Member, company: &Company, id: IntentID, m
 pub fn update(caller: &User, member: &Member, company: &Company, mut subject: Intent, move_costs: Option<Option<Costs>>, action: Option<OrderAction>, agreed_in: Option<Option<Url>>, at_location: Option<Option<SpatialThing>>, available_quantity: Option<Option<Measure>>, due: Option<Option<DateTime<Utc>>>, effort_quantity: Option<Option<Measure>>, finished: Option<Option<bool>>, has_beginning: Option<Option<DateTime<Utc>>>, has_end: Option<Option<DateTime<Utc>>>, has_point_in_time: Option<Option<DateTime<Utc>>>, in_scope_of: Option<Vec<AgentID>>, name: Option<Option<String>>, note: Option<Option<String>>, provider: Option<Option<AgentID>>, receiver: Option<Option<AgentID>>, resource_conforms_to: Option<Option<ResourceSpecID>>, resource_inventoried_as: Option<Option<ResourceID>>, resource_quantity: Option<Option<Measure>>, active: Option<bool>, now: &DateTime<Utc>) -> Result<Modifications> {
     caller.access_check(Permission::CompanyUpdateIntents)?;
     member.access_check(caller.id(), company.id(), CompanyPermission::IntentUpdate)?;
-    if company.is_deleted() {
-        Err(Error::ObjectIsDeleted("company".into()))?;
+    if !company.is_active() {
+        Err(Error::ObjectIsInactive("company".into()))?;
     }
     let company_agent_id = company.agent_id();
     if provider == Some(None) && receiver == Some(None) {
@@ -185,8 +185,11 @@ pub fn update(caller: &User, member: &Member, company: &Company, mut subject: In
 pub fn delete(caller: &User, member: &Member, company: &Company, mut subject: Intent, now: &DateTime<Utc>) -> Result<Modifications> {
     caller.access_check(Permission::CompanyUpdateIntents)?;
     member.access_check(caller.id(), company.id(), CompanyPermission::IntentDelete)?;
-    if company.is_deleted() {
-        Err(Error::ObjectIsDeleted("company".into()))?;
+    if !company.is_active() {
+        Err(Error::ObjectIsInactive("company".into()))?;
+    }
+    if subject.is_deleted() {
+        Err(Error::ObjectIsDeleted("intent".into()))?;
     }
     subject.set_deleted(Some(now.clone()));
     Ok(Modifications::new_single(Op::Delete, subject))
@@ -200,7 +203,7 @@ mod tests {
             company::CompanyID,
             member::MemberID,
             occupation::OccupationID,
-            testutils::{make_user, make_company, make_member_worker},
+            testutils::{deleted_company_tester, make_user, make_company, make_member_worker},
             user::UserID,
         },
         util,
@@ -258,10 +261,9 @@ mod tests {
         let res = create(&user2, &member, &company, id.clone(), Some(costs.clone()), OrderAction::Transfer, None, Some(loc.clone()), Some(Measure::new(10, Unit::One)), None, None, Some(false), Some(now.clone()), None, None, vec![company.agent_id()], Some("buy my widget".into()), Some("gee willickers i hope someone buys my widget".into()), Some(company.agent_id()), None, None, Some(ResourceID::new("widget1")), None, true, &now);
         assert_eq!(res, Err(Error::InsufficientPrivileges));
 
-        let mut company2 = company.clone();
-        company2.set_deleted(Some(now.clone()));
-        let res = create(&user, &member, &company2, id.clone(), Some(costs.clone()), OrderAction::Transfer, None, Some(loc.clone()), Some(Measure::new(10, Unit::One)), None, None, Some(false), Some(now.clone()), None, None, vec![company.agent_id()], Some("buy my widget".into()), Some("gee willickers i hope someone buys my widget".into()), Some(company.agent_id()), None, None, Some(ResourceID::new("widget1")), None, true, &now);
-        assert_eq!(res, Err(Error::ObjectIsDeleted("company".into())));
+        deleted_company_tester(company.clone(), &now, |company: Company| {
+            create(&user, &member, &company, id.clone(), Some(costs.clone()), OrderAction::Transfer, None, Some(loc.clone()), Some(Measure::new(10, Unit::One)), None, None, Some(false), Some(now.clone()), None, None, vec![company.agent_id()], Some("buy my widget".into()), Some("gee willickers i hope someone buys my widget".into()), Some(company.agent_id()), None, None, Some(ResourceID::new("widget1")), None, true, &now)
+        });
 
         let mut company3 = company.clone();
         company3.set_id(CompanyID::new("bill's company"));
@@ -328,10 +330,9 @@ mod tests {
         let res = update(&user2, &member, &company, intent1.clone(), Some(Some(costs2.clone())), None, None, Some(None), None, None, None, None, None, None, None, Some(vec![]), Some(Some("buy widget".into())), None, None, None, None, None, None, Some(false), &now2);
         assert_eq!(res, Err(Error::InsufficientPrivileges));
 
-        let mut company2 = company.clone();
-        company2.set_deleted(Some(now.clone()));
-        let res = update(&user, &member, &company2, intent1.clone(), Some(Some(costs2.clone())), None, None, Some(None), None, None, None, None, None, None, None, Some(vec![]), Some(Some("buy widget".into())), None, None, None, None, None, None, Some(false), &now2);
-        assert_eq!(res, Err(Error::ObjectIsDeleted("company".into())));
+        deleted_company_tester(company.clone(), &now2, |company: Company| {
+            update(&user, &member, &company, intent1.clone(), Some(Some(costs2.clone())), None, None, Some(None), None, None, None, None, None, None, None, Some(vec![]), Some(Some("buy widget".into())), None, None, None, None, None, None, Some(false), &now2)
+        });
 
         let mut company3 = company.clone();
         company3.set_id(CompanyID::new("bill's company"));
@@ -399,10 +400,9 @@ mod tests {
         let res = delete(&user2, &member, &company, intent1.clone(), &now2);
         assert_eq!(res, Err(Error::InsufficientPrivileges));
 
-        let mut company2 = company.clone();
-        company2.set_deleted(Some(now2.clone()));
-        let res = delete(&user, &member, &company2, intent1.clone(), &now2);
-        assert_eq!(res, Err(Error::ObjectIsDeleted("company".into())));
+        deleted_company_tester(company.clone(), &now2, |company: Company| {
+            delete(&user, &member, &company, intent1.clone(), &now2)
+        });
     }
 }
 

--- a/src/transactions/process_spec.rs
+++ b/src/transactions/process_spec.rs
@@ -18,7 +18,7 @@ use crate::{
         Modifications,
         company::{Company, Permission as CompanyPermission},
         member::Member,
-        lib::basis_model::Deletable,
+        lib::basis_model::{ActiveState, Deletable},
         process_spec::{ProcessSpec, ProcessSpecID},
         user::User,
     },
@@ -29,8 +29,8 @@ use vf_rs::vf;
 pub fn create<T: Into<String>>(caller: &User, member: &Member, company: &Company, id: ProcessSpecID, name: T, note: T, active: bool, now: &DateTime<Utc>) -> Result<Modifications> {
     caller.access_check(Permission::CompanyUpdateProcessSpecs)?;
     member.access_check(caller.id(), company.id(), CompanyPermission::ProcessSpecCreate)?;
-    if company.is_deleted() {
-        Err(Error::ObjectIsDeleted("company".into()))?;
+    if !company.is_active() {
+        Err(Error::ObjectIsInactive("company".into()))?;
     }
     let model = ProcessSpec::builder()
         .id(id)
@@ -54,8 +54,8 @@ pub fn create<T: Into<String>>(caller: &User, member: &Member, company: &Company
 pub fn update(caller: &User, member: &Member, company: &Company, mut subject: ProcessSpec, name: Option<String>, note: Option<String>, active: Option<bool>, now: &DateTime<Utc>) -> Result<Modifications> {
     caller.access_check(Permission::CompanyUpdateProcessSpecs)?;
     member.access_check(caller.id(), company.id(), CompanyPermission::ProcessSpecUpdate)?;
-    if company.is_deleted() {
-        Err(Error::ObjectIsDeleted("company".into()))?;
+    if !company.is_active() {
+        Err(Error::ObjectIsInactive("company".into()))?;
     }
     if let Some(name) = name {
         subject.inner_mut().set_name(name);
@@ -74,8 +74,11 @@ pub fn update(caller: &User, member: &Member, company: &Company, mut subject: Pr
 pub fn delete(caller: &User, member: &Member, company: &Company, mut subject: ProcessSpec, now: &DateTime<Utc>) -> Result<Modifications> {
     caller.access_check(Permission::CompanyUpdateProcessSpecs)?;
     member.access_check(caller.id(), company.id(), CompanyPermission::ProcessSpecDelete)?;
-    if company.is_deleted() {
-        Err(Error::ObjectIsDeleted("company".into()))?;
+    if !company.is_active() {
+        Err(Error::ObjectIsInactive("company".into()))?;
+    }
+    if subject.is_deleted() {
+        Err(Error::ObjectIsDeleted("process_spec".into()))?;
     }
     subject.set_deleted(Some(now.clone()));
     Ok(Modifications::new_single(Op::Delete, subject))
@@ -90,7 +93,7 @@ mod tests {
             member::MemberID,
             occupation::OccupationID,
             process_spec::{ProcessSpec, ProcessSpecID},
-            testutils::{make_user, make_company, make_member_worker},
+            testutils::{deleted_company_tester, make_user, make_company, make_member_worker},
             user::UserID,
         },
         util,
@@ -127,10 +130,9 @@ mod tests {
         let res = create(&user2, &member, &company, id.clone(), "SEIZE THE MEANS OF PRODUCTION", "our first process", true, &now);
         assert_eq!(res, Err(Error::InsufficientPrivileges));
 
-        let mut company2 = company.clone();
-        company2.set_deleted(Some(now.clone()));
-        let res = create(&user, &member, &company2, id.clone(), "SEIZE THE MEANS OF PRODUCTION", "our first process", true, &now);
-        assert_eq!(res, Err(Error::ObjectIsDeleted("company".into())));
+        deleted_company_tester(company.clone(), &now, |company: Company| {
+            create(&user, &member, &company, id.clone(), "SEIZE THE MEANS OF PRODUCTION", "our first process", true, &now)
+        });
     }
 
     #[test]
@@ -166,10 +168,9 @@ mod tests {
         let res = update(&user2, &member, &company, recspec.clone(), Some("best widget".into()), None, Some(false), &now2);
         assert_eq!(res, Err(Error::InsufficientPrivileges));
 
-        let mut company2 = company.clone();
-        company2.set_deleted(Some(now2.clone()));
-        let res = update(&user, &member, &company2, recspec.clone(), Some("best widget".into()), None, Some(false), &now2);
-        assert_eq!(res, Err(Error::ObjectIsDeleted("company".into())));
+        deleted_company_tester(company.clone(), &now2, |company: Company| {
+            update(&user, &member, &company, recspec.clone(), Some("best widget".into()), None, Some(false), &now2)
+        });
     }
 
     #[test]
@@ -204,10 +205,9 @@ mod tests {
         let res = delete(&user2, &member, &company, recspec.clone(), &now2);
         assert_eq!(res, Err(Error::InsufficientPrivileges));
 
-        let mut company2 = company.clone();
-        company2.set_deleted(Some(now2.clone()));
-        let res = delete(&user, &member, &company2, recspec.clone(), &now2);
-        assert_eq!(res, Err(Error::ObjectIsDeleted("company".into())));
+        deleted_company_tester(company.clone(), &now2, |company: Company| {
+            delete(&user, &member, &company, recspec.clone(), &now2)
+        });
     }
 }
 


### PR DESCRIPTION
Effectively implementing an active state. Active state is ephemeral, where deleted state is permanent. All needed tests updated. Closes basisproject/tracker#104