### PR TITLE
Standardize transaction tests and convert member transactions to use company

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@ pub mod error;
 mod util;
 #[macro_use]
 pub mod access;
+#[macro_use]
 pub mod models;
 pub mod costs;
 pub mod transactions;

--- a/src/models/company.rs
+++ b/src/models/company.rs
@@ -201,9 +201,8 @@ mod tests {
         models::{
             process::ProcessID,
             resource::ResourceID,
-            testutils::{make_company, make_process, make_resource},
         },
-        util,
+        util::{self, test::*},
     };
     use om2::{Measure, Unit};
     use rust_decimal_macros::*;

--- a/src/models/event.rs
+++ b/src/models/event.rs
@@ -30,7 +30,7 @@ use crate::{
         member::{Member},
         lib::{
             agent::{Agent, AgentID},
-            basis_model::ActiveState,
+            basis_model::Model,
         },
         process::{Process, ProcessID},
         resource::{Resource, ResourceID},

--- a/src/models/lib/agent.rs
+++ b/src/models/lib/agent.rs
@@ -3,7 +3,7 @@ use crate::{
     models::{
         company::CompanyID,
         member::MemberID,
-        lib::basis_model::ActiveState,
+        lib::basis_model::Model,
         user::UserID,
     },
 };
@@ -12,7 +12,7 @@ use std::convert::TryFrom;
 
 /// A trait that holds common agent functionality, generally applied to models
 /// with ID types implemented in `AgentID`.
-pub trait Agent: ActiveState {
+pub trait Agent: Model {
     /// Convert the model's ID to and AgentID.
     fn agent_id(&self) -> AgentID;
 }

--- a/src/models/lib/basis_model.rs
+++ b/src/models/lib/basis_model.rs
@@ -1,17 +1,12 @@
 /// A trait that all model IDs implement.
 pub trait ModelID: Into<String> + From<String> + Clone + PartialEq + Eq + std::hash::Hash {}
 
-/// A trait that describes an object that can be deleted.
-pub trait Deletable {
-    /// Checks whether or not this object has been deleted.
+/// A trait that all models implement which handles common functionality
+pub trait Model {
+    /// Checks whether or not this model has been deleted.
     fn is_deleted(&self) -> bool;
-}
-
-/// A trait that describes and object that can be in an (de)actived state.
-pub trait ActiveState: Deletable {
-    /// Determine if this model is active. This also reads the `deleted` field
-    /// and will return false if the model has been deleted, so this method is
-    /// the canonical place to check if the model can be used.
+    /// Determine if this model is active. This checks both the `active` and
+    /// `deleted` fields for the model.
     fn is_active(&self) -> bool;
 }
 
@@ -75,7 +70,6 @@ macro_rules! basis_model {
 
         pub(crate) mod inner {
             use super::*;
-            use crate::models::lib::basis_model::Deletable;
 
             basis_model_inner! {
                 $(#[$struct_meta])*
@@ -109,13 +103,12 @@ macro_rules! basis_model {
                 }
             }
 
-            impl crate::models::lib::basis_model::Deletable for $model {
+
+            impl crate::models::lib::basis_model::Model for $model {
                 fn is_deleted(&self) -> bool {
                     self.deleted.is_some()
                 }
-            }
 
-            impl crate::models::lib::basis_model::ActiveState for $model {
                 fn is_active(&self) -> bool {
                     self.active && !self.is_deleted()
                 }

--- a/src/models/lib/basis_model.rs
+++ b/src/models/lib/basis_model.rs
@@ -2,7 +2,7 @@
 pub trait ModelID: Into<String> + From<String> + Clone + PartialEq + Eq + std::hash::Hash {}
 
 /// A trait that all models implement which handles common functionality
-pub trait Model {
+pub trait Model: Clone + PartialEq {
     /// Checks whether or not this model has been deleted.
     fn is_deleted(&self) -> bool;
 

--- a/src/models/lib/basis_model.rs
+++ b/src/models/lib/basis_model.rs
@@ -5,9 +5,16 @@ pub trait ModelID: Into<String> + From<String> + Clone + PartialEq + Eq + std::h
 pub trait Model {
     /// Checks whether or not this model has been deleted.
     fn is_deleted(&self) -> bool;
+
     /// Determine if this model is active. This checks both the `active` and
     /// `deleted` fields for the model.
     fn is_active(&self) -> bool;
+
+    /// Set the model's deleted value
+    fn set_deleted(&mut self, deleted: Option<chrono::DateTime<chrono::Utc>>);
+
+    /// Set the model's active value
+    fn set_active(&mut self, active: bool);
 }
 
 macro_rules! basis_model {
@@ -111,6 +118,14 @@ macro_rules! basis_model {
 
                 fn is_active(&self) -> bool {
                     self.active && !self.is_deleted()
+                }
+
+                fn set_deleted(&mut self, deleted: Option<chrono::DateTime<chrono::Utc>>) {
+                    $model::set_deleted(self, deleted);
+                }
+
+                fn set_active(&mut self, active: bool) {
+                    $model::set_active(self, active);
                 }
             }
 

--- a/src/models/member.rs
+++ b/src/models/member.rs
@@ -274,9 +274,8 @@ mod test {
         models::{
             company::{CompanyID, Permission as CompanyPermission},
             user::UserID,
-            testutils::make_member_worker,
         },
-        util,
+        util::{self, test::*},
     };
     use std::convert::TryInto;
     use super::*;

--- a/src/models/member.rs
+++ b/src/models/member.rs
@@ -28,7 +28,7 @@ use crate::{
         company::{CompanyID, Permission},
         lib::{
             agent::{Agent, AgentID},
-            basis_model::ActiveState,
+            basis_model::Model,
         },
         occupation::OccupationID,
         user::UserID,

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -225,6 +225,7 @@ mod tests {
     }
 }
 
+#[macro_use]
 #[cfg(test)]
 pub(crate) mod testutils {
     //! Some model-making utilities to make unit testing easier. The full
@@ -396,6 +397,15 @@ pub(crate) mod testutils {
         company4.set_active(false);
         let res = testfn(company4);
         assert_eq!(res, Err(Error::ObjectIsInactive("company".into())));
+    }
+
+    macro_rules! double_deleted_tester {
+        ($model:ident, $ty:expr, $deletefn:expr) => {
+            let mut model2 = $model.clone();
+            model2.set_deleted(Some(crate::util::time::now()));
+            let res: crate::error::Result<crate::models::Modifications> = $deletefn(model2);
+            assert_eq!(res, Err(crate::error::Error::ObjectIsDeleted($ty.into())));
+        }
     }
 }
 

--- a/src/models/process.rs
+++ b/src/models/process.rs
@@ -52,9 +52,8 @@ mod tests {
     use crate::{
         models::{
             company::CompanyID,
-            testutils::make_process,
         },
-        util,
+        util::{self, test::*},
     };
     use rust_decimal_macros::*;
 

--- a/src/models/resource.rs
+++ b/src/models/resource.rs
@@ -72,9 +72,8 @@ mod tests {
     use crate::{
         models::{
             company::CompanyID,
-            testutils::make_resource,
         },
-        util,
+        util::{self, test::*},
     };
     use om2::{Measure, Unit};
     use rust_decimal_macros::*;

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -10,7 +10,7 @@ use crate::{
     models::{
         lib::{
             agent::{Agent, AgentID},
-            basis_model::ActiveState,
+            basis_model::Model,
         },
     },
     error::{Error, Result},

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -66,9 +66,8 @@ mod tests {
         access::{Permission, Role},
         models::{
             user::UserID,
-            testutils::make_user,
         },
-        util,
+        util::{self, test::*},
     };
 
     #[test]

--- a/src/transactions/agreement.rs
+++ b/src/transactions/agreement.rs
@@ -92,10 +92,10 @@ mod tests {
             company::CompanyID,
             member::MemberID,
             occupation::OccupationID,
-            testutils::{deleted_company_tester, make_user, make_company, make_member_worker},
+            testutils::{make_user, make_company, make_member_worker},
             user::UserID,
         },
-        util,
+        util::{self, test},
     };
 
     #[test]
@@ -108,7 +108,12 @@ mod tests {
         let member = make_member_worker(&MemberID::create(), user.id(), company_to.id(), &OccupationID::create(), vec![CompanyPermission::AgreementCreate], &now);
         let participants = vec![company_to.agent_id(), company_from.agent_id()];
 
-        let mods = create(&user, &member, &company_to, id.clone(), participants.clone(), "order 1234141", "hi i'm jerry. just going to order some widgets. don't mind me, just ordering widgets.", Some(now.clone()), true, &now).unwrap().into_vec();
+        let testfn = |user, member, company, _: Option<Agreement>| {
+            create(&user, &member, &company, id.clone(), participants.clone(), "order 1234141", "hi i'm jerry. just going to order some widgets. don't mind me, just ordering widgets.", Some(now.clone()), true, &now)
+        };
+        test::standard_transaction_tests(user.clone(), member.clone(), company_to.clone(), None, testfn.clone());
+
+        let mods = testfn(user.clone(), member.clone(), company_to.clone(), None).unwrap().into_vec();
         assert_eq!(mods.len(), 1);
 
         let agreement = mods[0].clone().expect_op::<Agreement>(Op::Create).unwrap();
@@ -121,20 +126,6 @@ mod tests {
         assert_eq!(agreement.created(), &now);
         assert_eq!(agreement.updated(), &now);
         assert_eq!(agreement.deleted(), &None);
-
-        let mut member2 = member.clone();
-        member2.set_permissions(vec![CompanyPermission::AgreementUpdate]);
-        let res = create(&user, &member2, &company_to, id.clone(), participants.clone(), "order 1234141", "hi i'm jerry. just going to order some widgets. don't mind me, just ordering widgets.", Some(now.clone()), true, &now);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
-
-        let mut user2 = user.clone();
-        user2.set_roles(vec![]);
-        let res = create(&user2, &member, &company_to, id.clone(), participants.clone(), "order 1234141", "hi i'm jerry. just going to order some widgets. don't mind me, just ordering widgets.", Some(now.clone()), true, &now);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
-
-        deleted_company_tester(company_to.clone(), &now, |company: Company| {
-            create(&user, &member, &company, id.clone(), participants.clone(), "order 1234141", "hi i'm jerry. just going to order some widgets. don't mind me, just ordering widgets.", Some(now.clone()), true, &now)
-        });
     }
 
     #[test]
@@ -150,6 +141,12 @@ mod tests {
         let mods = create(&user, &member, &company_to, id.clone(), participants.clone(), "order 1234141", "hi i'm jerry. just going to order some widgets. don't mind me, just ordering widgets.", Some(now.clone()), true, &now).unwrap().into_vec();
         let agreement1 = mods[0].clone().expect_op::<Agreement>(Op::Create).unwrap();
         let now2 = util::time::now();
+
+        let testfn = |user, member, company, _: Option<Agreement>| {
+            update(&user, &member, &company, agreement1.clone(), Some(vec![company_from.agent_id()]), Some("order 1111222".into()), Some("jerry's long-winded order".into()), None, None, &now2)
+        };
+        test::standard_transaction_tests(user.clone(), member.clone(), company_to.clone(), None, testfn.clone());
+
         let mods = update(&user, &member, &company_to, agreement1.clone(), Some(vec![company_from.agent_id()]), Some("order 1111222".into()), Some("jerry's long-winded order".into()), None, None, &now2).unwrap().into_vec();
         let agreement2 = mods[0].clone().expect_op::<Agreement>(Op::Update).unwrap();
 
@@ -162,20 +159,6 @@ mod tests {
         assert_eq!(agreement2.created(), agreement1.created());
         assert_eq!(agreement2.updated(), &now2);
         assert_eq!(agreement2.deleted(), &None);
-
-        let mut member2 = member.clone();
-        member2.set_permissions(vec![CompanyPermission::AgreementCreate]);
-        let res = update(&user, &member2, &company_to, agreement1.clone(), None, Some("order 1111222".into()), Some("jerry's long-winded order".into()), None, None, &now2);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
-
-        let mut user2 = user.clone();
-        user2.set_roles(vec![]);
-        let res = update(&user2, &member, &company_to, agreement1.clone(), None, Some("order 1111222".into()), Some("jerry's long-winded order".into()), None, None, &now2);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
-
-        deleted_company_tester(company_to.clone(), &now2, |company: Company| {
-            update(&user, &member, &company, agreement1.clone(), None, Some("order 1111222".into()), Some("jerry's long-winded order".into()), None, None, &now2)
-        });
     }
 }
 

--- a/src/transactions/agreement.rs
+++ b/src/transactions/agreement.rs
@@ -16,7 +16,7 @@ use crate::{
         Modifications,
         lib::{
             agent::AgentID,
-            basis_model::ActiveState,
+            basis_model::Model,
         },
         agreement::{Agreement, AgreementID},
         company::{Company, Permission as CompanyPermission},

--- a/src/transactions/commitment.rs
+++ b/src/transactions/commitment.rs
@@ -23,7 +23,7 @@ use crate::{
         member::Member,
         lib::{
             agent::{Agent, AgentID},
-            basis_model::{ActiveState, Deletable},
+            basis_model::Model,
         },
         process::ProcessID,
         resource::ResourceID,
@@ -196,7 +196,7 @@ mod tests {
             company::CompanyID,
             member::MemberID,
             occupation::OccupationID,
-            testutils::{deleted_company_tester, make_agreement, make_user, make_company, make_member_worker, make_resource},
+            testutils::{make_agreement, make_user, make_company, make_member_worker, make_resource},
             user::UserID,
         },
         util::{self, test},

--- a/src/transactions/commitment.rs
+++ b/src/transactions/commitment.rs
@@ -219,12 +219,12 @@ mod tests {
             .mappable_address(Some("444 Checkmate lane, LOGIC and FACTS, MN, 33133".into()))
             .build().unwrap();
 
-        let testfn = |user, member, company| {
+        let testfn = |user, member, company, _: Option<Commitment>| {
             create(&user, &member, &company, &agreement, id.clone(), costs.clone(), OrderAction::Transfer, None, Some(loc.clone()), Some(now.clone()), None, None, Some(false), None, None, None, vec![], None, Some("widgetzz".into()), Some("sending widgets to larry".into()), None, company_from.agent_id(), company_to.agent_id(), None, Some(resource.id().clone()), Some(Measure::new(dec!(10), Unit::One)), true, &now)
         };
-        test::standard_transaction_tests(user.clone(), member.clone(), company_to.clone(), testfn.clone());
+        test::standard_transaction_tests(user.clone(), member.clone(), company_to.clone(), None, testfn.clone());
 
-        let mods = testfn(user.clone(), member.clone(), company_to.clone()).unwrap().into_vec();
+        let mods = testfn(user.clone(), member.clone(), company_to.clone(), None).unwrap().into_vec();
         assert_eq!(mods.len(), 1);
 
         let commitment = mods[0].clone().expect_op::<Commitment>(Op::Create).unwrap();
@@ -289,11 +289,11 @@ mod tests {
         let commitment1 = mods[0].clone().expect_op::<Commitment>(Op::Create).unwrap();
         let now2 = util::time::now();
 
-        let testfn = |user, member, company| {
+        let testfn = |user, member, company, _: Option<Commitment>| {
             update(&user, &member, &company, commitment1.clone(), Some(costs2.clone()), None, Some(Some(agreement_url.clone())), None, Some(Some(now2.clone())), None, None, Some(Some(true)), Some(Some(now.clone())), None, None, Some(vec![company_from.agent_id()]), None, None, Some(Some("here, larry".into())), None, None, None, Some(Some(Measure::new(dec!(50), Unit::One))), None, &now2)
         };
-        test::standard_transaction_tests(user.clone(), member.clone(), company_to.clone(), testfn.clone());
-        let mods = testfn(user.clone(), member.clone(), company_to.clone()).unwrap().into_vec();
+        test::standard_transaction_tests(user.clone(), member.clone(), company_to.clone(), None, testfn.clone());
+        let mods = testfn(user.clone(), member.clone(), company_to.clone(), None).unwrap().into_vec();
         let commitment2 = mods[0].clone().expect_op::<Commitment>(Op::Update).unwrap();
 
         assert_eq!(commitment2.id(), commitment1.id());
@@ -344,13 +344,13 @@ mod tests {
         let commitment1 = mods[0].clone().expect_op::<Commitment>(Op::Create).unwrap();
         let now2 = util::time::now();
 
-        let testfn = |user, member, company| {
-            delete(&user, &member, &company, commitment1.clone(), &now2)
+        let testfn = |user, member, company, subject: Option<Commitment>| {
+            delete(&user, &member, &company, subject.unwrap_or(commitment1.clone()), &now2)
         };
-        test::standard_transaction_tests(user.clone(), member.clone(), company_to.clone(), testfn.clone());
-        double_deleted_tester!(commitment1, "commitment", |subject| delete(&user, &member, &company_to, subject, &now));
+        test::standard_transaction_tests(user.clone(), member.clone(), company_to.clone(), None, testfn.clone());
+        test::double_deleted_tester(user.clone(), member.clone(), company_to.clone(), commitment1.clone(), "commitment", testfn.clone());
 
-        let mods = testfn(user.clone(), member.clone(), company_to.clone()).unwrap().into_vec();
+        let mods = testfn(user.clone(), member.clone(), company_to.clone(), None).unwrap().into_vec();
         assert_eq!(mods.len(), 1);
 
         let commitment2 = mods[0].clone().expect_op::<Commitment>(Op::Delete).unwrap();

--- a/src/transactions/commitment.rs
+++ b/src/transactions/commitment.rs
@@ -408,10 +408,7 @@ mod tests {
             delete(&user, &member, &company, commitment1.clone(), &now2)
         });
 
-        let mut commitment3 = commitment1.clone();
-        commitment3.set_deleted(Some(now2.clone()));
-        let res = delete(&user, &member, &company_to, commitment3.clone(), &now2);
-        assert_eq!(res, Err(Error::ObjectIsDeleted("commitment".into())));
+        double_deleted_tester!(commitment1, "commitment", |subject| delete(&user, &member, &company_to, subject, &now));
     }
 }
 

--- a/src/transactions/commitment.rs
+++ b/src/transactions/commitment.rs
@@ -194,12 +194,8 @@ mod tests {
         models::{
             agreement::AgreementID,
             company::CompanyID,
-            member::MemberID,
-            occupation::OccupationID,
-            testutils::{make_agreement, make_user, make_company, make_member_worker, make_resource},
-            user::UserID,
         },
-        util::{self, test},
+        util::{self, test::{self, *}},
     };
     use om2::Unit;
     use rust_decimal_macros::*;
@@ -208,23 +204,22 @@ mod tests {
     fn can_create() {
         let now = util::time::now();
         let id = CommitmentID::create();
+        let state = TestState::standard(vec![CompanyPermission::CommitmentCreate, CompanyPermission::CommitmentUpdate], &now);
+        let company_to = state.company().clone();
         let company_from = make_company(&CompanyID::create(), "bridget's widgets", &now);
-        let company_to = make_company(&CompanyID::create(), "larry's chairs", &now);
-        let agreement = make_agreement(&AgreementID::create(), &vec![company_from.agent_id(), company_to.agent_id()], "order 111222", "UwU big order of widgetzzz", &now);
-        let user = make_user(&UserID::create(), None, &now);
-        let member = make_member_worker(&MemberID::create(), user.id(), company_to.id(), &OccupationID::create(), vec![CompanyPermission::CommitmentCreate], &now);
+        let agreement = make_agreement(&AgreementID::create(), &vec![company_from.agent_id(), state.company().agent_id()], "order 111222", "UwU big order of widgetzzz", &now);
         let costs = Costs::new_with_labor("widgetmaker", 42);
         let resource = make_resource(&ResourceID::new("widget1"), company_from.id(), &Measure::new(dec!(30), Unit::One), &Costs::new_with_labor("widgetmaker", dec!(50)), &now);
-        let loc = SpatialThing::builder()
-            .mappable_address(Some("444 Checkmate lane, LOGIC and FACTS, MN, 33133".into()))
-            .build().unwrap();
 
-        let testfn = |user, member, company, _: Option<Commitment>| {
-            create(&user, &member, &company, &agreement, id.clone(), costs.clone(), OrderAction::Transfer, None, Some(loc.clone()), Some(now.clone()), None, None, Some(false), None, None, None, vec![], None, Some("widgetzz".into()), Some("sending widgets to larry".into()), None, company_from.agent_id(), company_to.agent_id(), None, Some(resource.id().clone()), Some(Measure::new(dec!(10), Unit::One)), true, &now)
+        let testfn_inner = |state: &TestState<Commitment, Commitment>, agreement: &Agreement, company_from: &Company, company_to: &Company| {
+            create(state.user(), state.member(), state.company(), &agreement, id.clone(), costs.clone(), OrderAction::Transfer, None, Some(state.loc().clone()), Some(now.clone()), None, None, Some(false), None, None, None, vec![], None, Some("widgetzz".into()), Some("sending widgets to larry".into()), None, company_from.agent_id(), company_to.agent_id(), None, Some(resource.id().clone()), Some(Measure::new(dec!(10), Unit::One)), true, &now)
         };
-        test::standard_transaction_tests(user.clone(), member.clone(), company_to.clone(), None, testfn.clone());
+        let testfn = |state: &TestState<Commitment, Commitment>| {
+            testfn_inner(state, &agreement, &company_from, &company_to)
+        };
+        test::standard_transaction_tests(&state, &testfn);
 
-        let mods = testfn(user.clone(), member.clone(), company_to.clone(), None).unwrap().into_vec();
+        let mods = testfn(&state).unwrap().into_vec();
         assert_eq!(mods.len(), 1);
 
         let commitment = mods[0].clone().expect_op::<Commitment>(Op::Create).unwrap();
@@ -232,7 +227,7 @@ mod tests {
         assert_eq!(commitment.move_costs(), &costs.clone());
         assert_eq!(commitment.inner().action(), &vf::Action::Transfer);
         assert_eq!(commitment.inner().agreed_in(), &None);
-        assert_eq!(commitment.inner().at_location(), &Some(loc.clone()));
+        assert_eq!(commitment.inner().at_location(), &Some(state.loc().clone()));
         assert_eq!(commitment.inner().created(), &Some(now.clone()));
         assert_eq!(commitment.inner().due(), &None);
         assert_eq!(commitment.inner().effort_quantity(), &None);
@@ -246,7 +241,7 @@ mod tests {
         assert_eq!(commitment.inner().note(), &Some("sending widgets to larry".into()));
         assert_eq!(commitment.inner().output_of(), &None);
         assert_eq!(commitment.inner().provider(), &company_from.agent_id());
-        assert_eq!(commitment.inner().receiver(), &company_to.agent_id());
+        assert_eq!(commitment.inner().receiver(), &state.company().agent_id());
         assert_eq!(commitment.inner().resource_conforms_to(), &None);
         assert_eq!(commitment.inner().resource_inventoried_as(), &Some(ResourceID::new("widget1")));
         assert_eq!(commitment.inner().resource_quantity(), &Some(Measure::new(dec!(10), Unit::One)));
@@ -255,16 +250,16 @@ mod tests {
         assert_eq!(commitment.updated(), &now);
         assert_eq!(commitment.deleted(), &None);
 
-        let mut company3 = company_to.clone();
-        let mut company4 = company_to.clone();
+        let mut company3 = state.company().clone();
+        let mut company4 = state.company().clone();
         company3.set_id(CompanyID::new("bill's zingers, get your premium zings here. got a friend who constantly pranks you? turn the tables and zing that doofus in front of everyone!!"));
         company4.set_id(CompanyID::new("jill's zingers, get the best zings here. turn that lame party into a laugh fest with some classic zingers. don't buy at bill's, he sucks."));
-        let res = create(&user, &member, &company_to, &agreement, id.clone(), costs.clone(), OrderAction::Transfer, None, Some(loc.clone()), Some(now.clone()), None, None, Some(false), None, None, None, vec![], None, Some("widgetzz".into()), Some("sending widgets to larry".into()), None, company3.agent_id(), company4.agent_id(), None, Some(resource.id().clone()), Some(Measure::new(dec!(10), Unit::One)), true, &now);
+        let res = testfn_inner(&state, &agreement, &company3, &company4);
         assert_eq!(res, Err(Error::InsufficientPrivileges));
 
         let mut agreement2 = agreement.clone();
         agreement2.set_participants(vec![]);
-        let res = create(&user, &member, &company_to, &agreement2, id.clone(), costs.clone(), OrderAction::Transfer, None, Some(loc.clone()), Some(now.clone()), None, None, Some(false), None, None, None, vec![], None, Some("widgetzz".into()), Some("sending widgets to larry".into()), None, company_from.agent_id(), company_to.agent_id(), None, Some(resource.id().clone()), Some(Measure::new(dec!(10), Unit::One)), true, &now);
+        let res = testfn_inner(&state, &agreement2, &company_from, &company_to);
         assert_eq!(res, Err(Error::InsufficientPrivileges));
     }
 
@@ -272,28 +267,26 @@ mod tests {
     fn can_update() {
         let now = util::time::now();
         let id = CommitmentID::create();
+        let mut state = TestState::standard(vec![CompanyPermission::CommitmentCreate, CompanyPermission::CommitmentUpdate], &now);
         let company_from = make_company(&CompanyID::create(), "bridget's widgets", &now);
-        let company_to = make_company(&CompanyID::create(), "larry's chairs", &now);
+        let company_to = state.company().clone();
         let agreement = make_agreement(&AgreementID::create(), &vec![company_from.agent_id(), company_to.agent_id()], "order 111222", "UwU big order of widgetzzz", &now);
-        let user = make_user(&UserID::create(), None, &now);
-        let member = make_member_worker(&MemberID::create(), user.id(), company_to.id(), &OccupationID::create(), vec![CompanyPermission::CommitmentCreate, CompanyPermission::CommitmentUpdate], &now);
         let costs1 = Costs::new_with_labor("widgetmaker", 42);
         let costs2 = Costs::new_with_labor("widgetmaker", 31);
         let resource = make_resource(&ResourceID::new("widget1"), company_from.id(), &Measure::new(dec!(30), Unit::One), &Costs::new_with_labor("widgetmaker", dec!(50)), &now);
         let agreement_url: Url = "http://legalzoom.com/standard-widget-shopping-cart-agreement".parse().unwrap();
-        let loc = SpatialThing::builder()
-            .mappable_address(Some("444 Checkmate lane, LOGIC and FACTS, MN, 33133".into()))
-            .build().unwrap();
 
-        let mods = create(&user, &member, &company_to, &agreement, id.clone(), costs1.clone(), OrderAction::Transfer, None, Some(loc.clone()), Some(now.clone()), None, None, Some(false), None, None, None, vec![], None, Some("widgetzz".into()), Some("sending widgets to larry".into()), None, company_from.agent_id(), company_to.agent_id(), None, Some(resource.id().clone()), Some(Measure::new(dec!(10), Unit::One)), true, &now).unwrap().into_vec();
+        let mods = create(state.user(), state.member(), state.company(), &agreement, id.clone(), costs1.clone(), OrderAction::Transfer, None, Some(state.loc().clone()), Some(now.clone()), None, None, Some(false), None, None, None, vec![], None, Some("widgetzz".into()), Some("sending widgets to larry".into()), None, company_from.agent_id(), company_to.agent_id(), None, Some(resource.id().clone()), Some(Measure::new(dec!(10), Unit::One)), true, &now).unwrap().into_vec();
         let commitment1 = mods[0].clone().expect_op::<Commitment>(Op::Create).unwrap();
         let now2 = util::time::now();
+        state.model = Some(commitment1.clone());
 
-        let testfn = |user, member, company, _: Option<Commitment>| {
-            update(&user, &member, &company, commitment1.clone(), Some(costs2.clone()), None, Some(Some(agreement_url.clone())), None, Some(Some(now2.clone())), None, None, Some(Some(true)), Some(Some(now.clone())), None, None, Some(vec![company_from.agent_id()]), None, None, Some(Some("here, larry".into())), None, None, None, Some(Some(Measure::new(dec!(50), Unit::One))), None, &now2)
+        let testfn = |state: &TestState<Commitment, Commitment>| {
+            update(state.user(), state.member(), state.company(), state.model().clone(), Some(costs2.clone()), None, Some(Some(agreement_url.clone())), None, Some(Some(now2.clone())), None, None, Some(Some(true)), Some(Some(now.clone())), None, None, Some(vec![company_from.agent_id()]), None, None, Some(Some("here, larry".into())), None, None, None, Some(Some(Measure::new(dec!(50), Unit::One))), None, &now2)
         };
-        test::standard_transaction_tests(user.clone(), member.clone(), company_to.clone(), None, testfn.clone());
-        let mods = testfn(user.clone(), member.clone(), company_to.clone(), None).unwrap().into_vec();
+        test::standard_transaction_tests(&state, &testfn);
+
+        let mods = testfn(&state).unwrap().into_vec();
         let commitment2 = mods[0].clone().expect_op::<Commitment>(Op::Update).unwrap();
 
         assert_eq!(commitment2.id(), commitment1.id());
@@ -329,28 +322,25 @@ mod tests {
     fn can_delete() {
         let now = util::time::now();
         let id = CommitmentID::create();
+        let mut state = TestState::standard(vec![CompanyPermission::CommitmentCreate, CompanyPermission::CommitmentDelete], &now);
         let company_from = make_company(&CompanyID::create(), "bridget's widgets", &now);
-        let company_to = make_company(&CompanyID::create(), "larry's dairies (outdoor outdoor. shutup parker. thank you parker, shutup. thank you.)", &now);
+        let company_to = state.company().clone();
         let agreement = make_agreement(&AgreementID::create(), &vec![company_from.agent_id(), company_to.agent_id()], "order 111222", "UwU big order of widgetzzz", &now);
-        let user = make_user(&UserID::create(), None, &now);
-        let member = make_member_worker(&MemberID::create(), user.id(), company_to.id(), &OccupationID::create(), vec![CompanyPermission::CommitmentCreate, CompanyPermission::CommitmentDelete], &now);
         let resource = make_resource(&ResourceID::new("widget1"), company_from.id(), &Measure::new(dec!(30), Unit::One), &Costs::new_with_labor("widgetmaker", dec!(50)), &now);
         let costs1 = Costs::new_with_labor("widgetmaker", 42);
-        let loc = SpatialThing::builder()
-            .mappable_address(Some("444 Checkmate lane, LOGIC and FACTS, MN, 33133".into()))
-            .build().unwrap();
 
-        let mods = create(&user, &member, &company_to, &agreement, id.clone(), costs1.clone(), OrderAction::Transfer, None, Some(loc.clone()), Some(now.clone()), None, None, Some(false), None, None, None, vec![], None, Some("widgetzz".into()), Some("sending widgets to larry".into()), None, company_from.agent_id(), company_to.agent_id(), None, Some(resource.id().clone()), Some(Measure::new(dec!(10), Unit::One)), true, &now).unwrap().into_vec();
+        let mods = create(state.user(), state.member(), state.company(), &agreement, id.clone(), costs1.clone(), OrderAction::Transfer, None, Some(state.loc().clone()), Some(now.clone()), None, None, Some(false), None, None, None, vec![], None, Some("widgetzz".into()), Some("sending widgets to larry".into()), None, company_from.agent_id(), company_to.agent_id(), None, Some(resource.id().clone()), Some(Measure::new(dec!(10), Unit::One)), true, &now).unwrap().into_vec();
         let commitment1 = mods[0].clone().expect_op::<Commitment>(Op::Create).unwrap();
         let now2 = util::time::now();
+        state.model = Some(commitment1.clone());
 
-        let testfn = |user, member, company, subject: Option<Commitment>| {
-            delete(&user, &member, &company, subject.unwrap_or(commitment1.clone()), &now2)
+        let testfn = |state: &TestState<Commitment, Commitment>| {
+            delete(state.user(), state.member(), state.company(), state.model().clone(), &now2)
         };
-        test::standard_transaction_tests(user.clone(), member.clone(), company_to.clone(), None, testfn.clone());
-        test::double_deleted_tester(user.clone(), member.clone(), company_to.clone(), commitment1.clone(), "commitment", testfn.clone());
+        test::standard_transaction_tests(&state, &testfn);
+        test::double_deleted_tester(&state, "commitment", &testfn);
 
-        let mods = testfn(user.clone(), member.clone(), company_to.clone(), None).unwrap().into_vec();
+        let mods = testfn(&state).unwrap().into_vec();
         assert_eq!(mods.len(), 1);
 
         let commitment2 = mods[0].clone().expect_op::<Commitment>(Op::Delete).unwrap();

--- a/src/transactions/company.rs
+++ b/src/transactions/company.rs
@@ -199,10 +199,7 @@ mod tests {
         let res = delete(&user2, Some(&founder), company.clone(), &now3);
         assert_eq!(res, Err(Error::InsufficientPrivileges));
 
-        let mut company3 = company.clone();
-        company3.set_deleted(Some(now2.clone()));
-        let res = delete(&user, Some(&founder), company3.clone(), &now2);
-        assert_eq!(res, Err(Error::ObjectIsDeleted("company".into())));
+        double_deleted_tester!(company, "company", |subject| delete(&user, Some(&founder), subject, &now2));
     }
 }
 

--- a/src/transactions/company.rs
+++ b/src/transactions/company.rs
@@ -18,7 +18,7 @@ use crate::{
         Op,
         Modifications,
         company::{Company, CompanyID, Permission as CompanyPermission},
-        lib::basis_model::Deletable,
+        lib::basis_model::Model,
         member::{Member, MemberID, MemberClass, MemberWorker},
         occupation::OccupationID,
         user::User,

--- a/src/transactions/event/accounting.rs
+++ b/src/transactions/event/accounting.rs
@@ -15,7 +15,7 @@ use crate::{
         event::{Event, EventID, EventProcessState, MoveType},
         company::{Company, Permission as CompanyPermission},
         member::Member,
-        lib::basis_model::ActiveState,
+        lib::basis_model::Model,
         process::Process,
         resource::Resource,
         user::User,

--- a/src/transactions/event/accounting.rs
+++ b/src/transactions/event/accounting.rs
@@ -185,7 +185,7 @@ pub fn move_resource<T: Into<NumericUnion>>(caller: &User, member: &Member, comp
     Ok(mods)
 }
 
-/// Raise the quantity (both accounting and obhand) or a resource by a fixed
+/// Raise the quantity (both accounting and onhand) or a resource by a fixed
 /// amount.
 pub fn raise<T: Into<NumericUnion>>(caller: &User, member: &Member, company: &Company, id: EventID, resource: Resource, resource_measure: T, note: Option<String>, now: &DateTime<Utc>) -> Result<Modifications> {
     caller.access_check(Permission::EventCreate)?;
@@ -240,15 +240,12 @@ mod tests {
         models::{
             lib::agent::Agent,
             company::CompanyID,
-            member::MemberID,
             event::{EventID, EventError},
             occupation::OccupationID,
             process::{Process, ProcessID},
             resource::ResourceID,
-            testutils::{deleted_company_tester, make_user, make_company, make_member_worker, make_process, make_resource},
-            user::UserID,
         },
-        util::{self, test},
+        util::{self, test::{self, *}},
     };
     use om2::Unit;
     use rust_decimal_macros::*;
@@ -257,18 +254,16 @@ mod tests {
     fn can_lower() {
         let now = util::time::now();
         let id = EventID::create();
-        let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
-        let user = make_user(&UserID::create(), None, &now);
-        let occupation_id = OccupationID::new("machinist");
-        let member = make_member_worker(&MemberID::create(), user.id(), company.id(), &occupation_id, vec![CompanyPermission::Lower], &now);
-        let resource = make_resource(&ResourceID::new("widget"), company.id(), &Measure::new(dec!(15), Unit::One), &Costs::new_with_labor("homemaker", 157), &now);
+        let mut state = TestState::standard(vec![CompanyPermission::Lower], &now);
+        let resource = make_resource(&ResourceID::new("widget"), state.company().id(), &Measure::new(dec!(15), Unit::One), &Costs::new_with_labor("homemaker", 157), &now);
+        state.model = Some(resource);
 
-        let testfn = |user, member, company, _: Option<Event>| {
-            lower(&user, &member, &company, id.clone(), resource.clone(), 8, Some("a note".into()), &now)
+        let testfn = |state: &TestState<Resource, Resource>| {
+            lower(state.user(), state.member(), state.company(), id.clone(), state.model().clone(), 8, Some("a note".into()), &now)
         };
-        test::standard_transaction_tests(user.clone(), member.clone(), company.clone(), None, testfn.clone());
+        test::standard_transaction_tests(&state, &testfn);
 
-        let mods = testfn(user.clone(), member.clone(), company.clone(), None).unwrap().into_vec();
+        let mods = testfn(&state).unwrap().into_vec();
         assert_eq!(mods.len(), 2);
         let event = mods[0].clone().expect_op::<Event>(Op::Create).unwrap();
         let resource2 = mods[1].clone().expect_op::<Resource>(Op::Update).unwrap();
@@ -279,29 +274,29 @@ mod tests {
         assert_eq!(event.inner().input_of(), &None);
         assert_eq!(event.inner().note(), &Some("a note".into()));
         assert_eq!(event.inner().output_of(), &None);
-        assert_eq!(event.inner().provider().clone(), company.agent_id());
-        assert_eq!(event.inner().receiver().clone(), company.agent_id());
+        assert_eq!(event.inner().provider().clone(), state.company().agent_id());
+        assert_eq!(event.inner().receiver().clone(), state.company().agent_id());
         assert_eq!(event.inner().resource_quantity(), &Some(Measure::new(8, Unit::One)));
         assert_eq!(event.move_costs(), &None);
         assert_eq!(event.active(), &true);
         assert_eq!(event.created(), &now);
         assert_eq!(event.updated(), &now);
 
-        assert_eq!(resource2.id(), resource.id());
+        assert_eq!(resource2.id(), state.model().id());
         assert_eq!(resource2.inner().accounting_quantity(), &Some(Measure::new(dec!(7), Unit::One)));
         assert_eq!(resource2.inner().onhand_quantity(), &Some(Measure::new(dec!(7), Unit::One)));
-        assert_eq!(resource2.costs(), resource.costs());
+        assert_eq!(resource2.costs(), state.model().costs());
 
         // a company that doesn't own a resource can't lower it
-        let mut resource3 = resource.clone();
-        resource3.inner_mut().set_primary_accountable(Some(CompanyID::new("ziggy").into()));
-        let res = lower(&user, &member, &company, id.clone(), resource3.clone(), 8, Some("a note".into()), &now);
+        let mut state2 = state.clone();
+        state2.model_mut().inner_mut().set_primary_accountable(Some(CompanyID::new("ziggy").into()));
+        let res = testfn(&state2);
         assert_eq!(res, Err(Error::Event(EventError::ResourceOwnerMismatch)));
 
         // a company that doesn't have possession of a resource can't lower it
-        let mut resource4 = resource.clone();
-        resource4.set_in_custody_of(CompanyID::new("ziggy").into());
-        let res = lower(&user, &member, &company, id.clone(), resource4.clone(), 8, Some("a note".into()), &now);
+        let mut state3 = state.clone();
+        state3.model_mut().set_in_custody_of(CompanyID::new("ziggy").into());
+        let res = testfn(&state3);
         assert_eq!(res, Err(Error::Event(EventError::ResourceCustodyMismatch)));
     }
 
@@ -309,20 +304,19 @@ mod tests {
     fn can_move_costs() {
         let now = util::time::now();
         let id = EventID::create();
-        let company = make_company(&CompanyID::create(), "jerry's planks", &now);
-        let user = make_user(&UserID::create(), None, &now);
+        let mut state = TestState::standard(vec![CompanyPermission::MoveCosts], &now);
         let occupation_id = OccupationID::new("lawyer");
-        let member = make_member_worker(&MemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
-        let process_from = make_process(&ProcessID::create(), company.id(), "various lawyerings", &Costs::new_with_labor(occupation_id.clone(), dec!(177.25)), &now);
-        let process_to = make_process(&ProcessID::create(), company.id(), "overflow labor", &Costs::new_with_labor(occupation_id.clone(), dec!(804)), &now);
+        let process_from = make_process(&ProcessID::create(), state.company().id(), "various lawyerings", &Costs::new_with_labor(occupation_id.clone(), dec!(177.25)), &now);
+        let process_to = make_process(&ProcessID::create(), state.company().id(), "overflow labor", &Costs::new_with_labor(occupation_id.clone(), dec!(804)), &now);
+        state.model = Some(process_from);
+        state.model2 = Some(process_to);
 
-        let res = move_costs(&user, &member, &company, id.clone(), process_from.clone(), process_to.clone(), Costs::new_with_labor("lawyer", 100), Some("my note".into()), &now);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
+        let testfn = |state: &TestState<Process, Process>| {
+            move_costs(state.user(), state.member(), state.company(), id.clone(), state.model().clone(), state.model2().clone(), Costs::new_with_labor("lawyer", 100), Some("my note".into()), &now)
+        };
+        test::standard_transaction_tests(&state, &testfn);
 
-        let mut member = member.clone();
-        member.set_permissions(vec![CompanyPermission::MoveCosts]);
-        // test ResourceMover::Update()
-        let mods = move_costs(&user, &member, &company, id.clone(), process_from.clone(), process_to.clone(), Costs::new_with_labor("lawyer", 100), Some("my note".into()), &now).unwrap().into_vec();
+        let mods = testfn(&state).unwrap().into_vec();
         assert_eq!(mods.len(), 3);
         let event = mods[0].clone().expect_op::<Event>(Op::Create).unwrap();
         let process_from2 = mods[1].clone().expect_op::<Process>(Op::Update).unwrap();
@@ -331,11 +325,11 @@ mod tests {
         assert_eq!(event.id(), &id);
         assert_eq!(event.inner().agreed_in(), &None);
         assert_eq!(event.inner().has_point_in_time(), &Some(now.clone()));
-        assert_eq!(event.inner().input_of(), &Some(process_to.id().clone()));
+        assert_eq!(event.inner().input_of(), &Some(state.model2().id().clone()));
         assert_eq!(event.inner().note(), &Some("my note".into()));
-        assert_eq!(event.inner().output_of(), &Some(process_from.id().clone()));
-        assert_eq!(event.inner().provider().clone(), company.agent_id());
-        assert_eq!(event.inner().receiver().clone(), company.agent_id());
+        assert_eq!(event.inner().output_of(), &Some(state.model().id().clone()));
+        assert_eq!(event.inner().provider().clone(), state.company().agent_id());
+        assert_eq!(event.inner().receiver().clone(), state.company().agent_id());
         assert_eq!(event.inner().resource_quantity(), &None);
         assert_eq!(event.move_costs(), &Some(Costs::new_with_labor("lawyer", 100)));
         assert_eq!(event.active(), &true);
@@ -344,39 +338,26 @@ mod tests {
 
         let mut costs2 = Costs::new();
         costs2.track_labor("lawyer", dec!(177.25) - dec!(100));
-        assert_eq!(process_from2.id(), process_from.id());
-        assert_eq!(process_from2.company_id(), company.id());
+        assert_eq!(process_from2.id(), state.model().id());
+        assert_eq!(process_from2.company_id(), state.company().id());
         assert_eq!(process_from2.costs(), &costs2);
 
         let mut costs2 = Costs::new();
         costs2.track_labor("lawyer", dec!(804) + dec!(100));
-        assert_eq!(process_to2.id(), process_to.id());
-        assert_eq!(process_to2.company_id(), company.id());
+        assert_eq!(process_to2.id(), state.model2().id());
+        assert_eq!(process_to2.company_id(), state.company().id());
         assert_eq!(process_to2.costs(), &costs2);
 
-        let user2 = make_user(&UserID::create(), Some(vec![]), &now);
-        let res = move_costs(&user2, &member, &company, id.clone(), process_from.clone(), process_to.clone(), Costs::new_with_labor("lawyer", 100), Some("my note".into()), &now);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
-
-        let mut member2 = member.clone();
-        member2.set_permissions(vec![]);
-        let res = move_costs(&user, &member2, &company, id.clone(), process_from.clone(), process_to.clone(), Costs::new_with_labor("lawyer", 100), Some("my note".into()), &now);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
-
-        deleted_company_tester(company.clone(), &now, |company: Company| {
-            move_costs(&user, &member, &company, id.clone(), process_from.clone(), process_to.clone(), Costs::new_with_labor("lawyer", 100), Some("my note".into()), &now)
-        });
-
         // can't move costs from a process you don't own
-        let mut process_from3 = process_from.clone();
-        process_from3.set_company_id(CompanyID::new("zing").into());
-        let res = move_costs(&user, &member, &company, id.clone(), process_from3.clone(), process_to.clone(), Costs::new_with_labor("lawyer", 100), Some("my note".into()), &now);
+        let mut state2 = state.clone();
+        state2.model_mut().set_company_id(CompanyID::new("zing").into());
+        let res = testfn(&state2);
         assert_eq!(res, Err(Error::Event(EventError::ProcessOwnerMismatch)));
 
         // can't move costs into a process you don't own
-        let mut process_to3 = process_to.clone();
-        process_to3.set_company_id(CompanyID::new("zing").into());
-        let res = move_costs(&user, &member, &company, id.clone(), process_from.clone(), process_to3.clone(), Costs::new_with_labor("lawyer", 100), Some("my note".into()), &now);
+        let mut state3 = state.clone();
+        state3.model2_mut().set_company_id(CompanyID::new("zing").into());
+        let res = testfn(&state3);
         assert_eq!(res, Err(Error::Event(EventError::ProcessOwnerMismatch)));
     }
 
@@ -384,23 +365,26 @@ mod tests {
     fn can_move_resource() {
         let now = util::time::now();
         let id = EventID::create();
-        let company = make_company(&CompanyID::create(), "jerry's planks", &now);
-        let user = make_user(&UserID::create(), None, &now);
-        let occupation_id = OccupationID::new("machinist");
-        let member = make_member_worker(&MemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
-        let resource = make_resource(&ResourceID::new("plank"), company.id(), &Measure::new(dec!(15), Unit::One), &Costs::new_with_labor("homemaker", 157), &now);
-        let resource_to = make_resource(&ResourceID::new("plank"), company.id(), &Measure::new(dec!(3), Unit::One), &Costs::new_with_labor("homemaker", 2), &now);
-        let loc = SpatialThing::builder()
-            .mappable_address(Some("1212 Uranus lane, DERRSOYBOY, KY, 33133".into()))
-            .build().unwrap();
+        let mut state = TestState::standard(vec![CompanyPermission::MoveResource], &now);
+        let resource = make_resource(&ResourceID::new("plank"), state.company().id(), &Measure::new(dec!(15), Unit::One), &Costs::new_with_labor("homemaker", 157), &now);
+        let resource_to = make_resource(&ResourceID::new("plank"), state.company().id(), &Measure::new(dec!(3), Unit::One), &Costs::new_with_labor("homemaker", 2), &now);
+        state.model = Some(resource);
+        state.model2 = Some(resource_to);
 
-        let res = move_resource(&user, &member, &company, id.clone(), resource.clone(), ResourceMover::Update(resource_to.clone()), Costs::new_with_labor("homemaker", 23), 8, Some(loc.clone()), Some("lol".into()), &now);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
+        let testfn_inner = |state: &TestState<Resource, Resource>, mover: ResourceMover| {
+            move_resource(state.user(), state.member(), state.company(), id.clone(), state.model().clone(), mover, Costs::new_with_labor("homemaker", 23), 8, Some(state.loc().clone()), Some("lol".into()), &now)
+        };
+        let testfn_update = |state: &TestState<Resource, Resource>| {
+            testfn_inner(state, ResourceMover::Update(state.model2().clone()))
+        };
+        let testfn_create = |state: &TestState<Resource, Resource>| {
+            testfn_inner(state, ResourceMover::Create(state.model2().id().clone()))
+        };
+        test::standard_transaction_tests(&state, &testfn_update);
+        test::standard_transaction_tests(&state, &testfn_create);
 
-        let mut member = member.clone();
-        member.set_permissions(vec![CompanyPermission::MoveResource]);
         // test ResourceMover::Update()
-        let mods = move_resource(&user, &member, &company, id.clone(), resource.clone(), ResourceMover::Update(resource_to.clone()), Costs::new_with_labor("homemaker", 23), 8, Some(loc.clone()), Some("lol".into()), &now).unwrap().into_vec();
+        let mods = testfn_update(&state).unwrap().into_vec();
         assert_eq!(mods.len(), 3);
         let event = mods[0].clone().expect_op::<Event>(Op::Create).unwrap();
         let resource_from2 = mods[1].clone().expect_op::<Resource>(Op::Update).unwrap();
@@ -408,13 +392,13 @@ mod tests {
 
         assert_eq!(event.id(), &id);
         assert_eq!(event.inner().agreed_in(), &None);
-        assert_eq!(event.inner().at_location(), &Some(loc.clone()));
+        assert_eq!(event.inner().at_location(), &Some(state.loc().clone()));
         assert_eq!(event.inner().has_point_in_time(), &Some(now.clone()));
         assert_eq!(event.inner().input_of(), &None);
         assert_eq!(event.inner().note(), &Some("lol".into()));
         assert_eq!(event.inner().output_of(), &None);
-        assert_eq!(event.inner().provider().clone(), company.agent_id());
-        assert_eq!(event.inner().receiver().clone(), company.agent_id());
+        assert_eq!(event.inner().provider().clone(), state.company().agent_id());
+        assert_eq!(event.inner().receiver().clone(), state.company().agent_id());
         assert_eq!(event.inner().resource_quantity(), &Some(Measure::new(8, Unit::One)));
         assert_eq!(event.move_costs(), &Some(Costs::new_with_labor("homemaker", 23)));
         assert_eq!(event.active(), &true);
@@ -423,24 +407,24 @@ mod tests {
 
         let mut costs2 = Costs::new();
         costs2.track_labor("homemaker", dec!(157) - dec!(23));
-        assert_eq!(resource_from2.id(), resource.id());
-        assert_eq!(resource_from2.inner().primary_accountable(), &Some(company.agent_id()));
+        assert_eq!(resource_from2.id(), state.model().id());
+        assert_eq!(resource_from2.inner().primary_accountable(), &Some(state.company().agent_id()));
         assert_eq!(resource_from2.inner().accounting_quantity(), &Some(Measure::new(dec!(15) - dec!(8), Unit::One)));
         assert_eq!(resource_from2.inner().onhand_quantity(), &Some(Measure::new(dec!(15) - dec!(8), Unit::One)));
-        assert_eq!(resource_from2.in_custody_of(), &company.agent_id());
+        assert_eq!(resource_from2.in_custody_of(), &state.company().agent_id());
         assert_eq!(resource_from2.costs(), &costs2);
 
         let mut costs2 = Costs::new();
         costs2.track_labor("homemaker", dec!(23) + dec!(2));
-        assert_eq!(resource_to2.id(), resource_to.id());
-        assert_eq!(resource_to2.inner().primary_accountable(), &Some(company.agent_id()));
+        assert_eq!(resource_to2.id(), state.model2().id());
+        assert_eq!(resource_to2.inner().primary_accountable(), &Some(state.company().agent_id()));
         assert_eq!(resource_to2.inner().accounting_quantity(), &Some(Measure::new(dec!(8) + dec!(3), Unit::One)));
         assert_eq!(resource_to2.inner().onhand_quantity(), &Some(Measure::new(dec!(8) + dec!(3), Unit::One)));
-        assert_eq!(resource_to2.in_custody_of(), &company.agent_id());
+        assert_eq!(resource_to2.in_custody_of(), &state.company().agent_id());
         assert_eq!(resource_to2.costs(), &costs2);
 
         // test ResourceMover::Create()
-        let mods = move_resource(&user, &member, &company, id.clone(), resource.clone(), ResourceMover::Create(resource_to.id().clone()), Costs::new_with_labor("homemaker", 23), 8, Some(loc.clone()), None, &now).unwrap().into_vec();
+        let mods = testfn_create(&state).unwrap().into_vec();
         assert_eq!(mods.len(), 3);
         let event = mods[0].clone().expect_op::<Event>(Op::Create).unwrap();
         let resource_from3 = mods[1].clone().expect_op::<Resource>(Op::Update).unwrap();
@@ -450,10 +434,10 @@ mod tests {
         assert_eq!(event.inner().agreed_in(), &None);
         assert_eq!(event.inner().has_point_in_time(), &Some(now.clone()));
         assert_eq!(event.inner().input_of(), &None);
-        assert_eq!(event.inner().note(), &None);
+        assert_eq!(event.inner().note(), &Some("lol".into()));
         assert_eq!(event.inner().output_of(), &None);
-        assert_eq!(event.inner().provider().clone(), company.agent_id());
-        assert_eq!(event.inner().receiver().clone(), company.agent_id());
+        assert_eq!(event.inner().provider().clone(), state.company().agent_id());
+        assert_eq!(event.inner().receiver().clone(), state.company().agent_id());
         assert_eq!(event.inner().resource_quantity(), &Some(Measure::new(8, Unit::One)));
         assert_eq!(event.move_costs(), &Some(Costs::new_with_labor("homemaker", 23)));
         assert_eq!(event.active(), &true);
@@ -462,51 +446,42 @@ mod tests {
 
         let mut costs2 = Costs::new();
         costs2.track_labor("homemaker", dec!(157) - dec!(23));
-        assert_eq!(resource_from3.id(), resource.id());
-        assert_eq!(resource_from3.inner().primary_accountable(), &Some(company.agent_id()));
+        assert_eq!(resource_from3.id(), state.model().id());
+        assert_eq!(resource_from3.inner().primary_accountable(), &Some(state.company().agent_id()));
         assert_eq!(resource_from3.inner().accounting_quantity(), &Some(Measure::new(dec!(15) - dec!(8), Unit::One)));
         assert_eq!(resource_from3.inner().onhand_quantity(), &Some(Measure::new(dec!(15) - dec!(8), Unit::One)));
-        assert_eq!(resource_from3.in_custody_of(), &company.agent_id());
+        assert_eq!(resource_from3.in_custody_of(), &state.company().agent_id());
         assert_eq!(resource_from3.costs(), &costs2);
 
         let mut costs2 = Costs::new();
         costs2.track_labor("homemaker", dec!(23));
-        assert_eq!(resource_created.id(), resource_to.id());
-        assert_eq!(resource_created.inner().primary_accountable(), &Some(company.agent_id()));
+        assert_eq!(resource_created.id(), state.model2().id());
+        assert_eq!(resource_created.inner().primary_accountable(), &Some(state.company().agent_id()));
         assert_eq!(resource_created.inner().accounting_quantity(), &Some(Measure::new(dec!(8), Unit::One)));
         assert_eq!(resource_created.inner().onhand_quantity(), &Some(Measure::new(dec!(8), Unit::One)));
-        assert_eq!(resource_created.in_custody_of(), &company.agent_id());
+        assert_eq!(resource_created.in_custody_of(), &state.company().agent_id());
         assert_eq!(resource_created.costs(), &costs2);
 
-        let user2 = make_user(&UserID::create(), Some(vec![]), &now);
-        let res = move_resource(&user2, &member, &company, id.clone(), resource.clone(), ResourceMover::Update(resource_to.clone()), Costs::new_with_labor("homemaker", 23), 8, Some(loc.clone()), Some("lol".into()), &now);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
-
-        let mut member2 = member.clone();
-        member2.set_permissions(vec![]);
-        let res = move_resource(&user, &member2, &company, id.clone(), resource.clone(), ResourceMover::Update(resource_to.clone()), Costs::new_with_labor("homemaker", 23), 8, Some(loc.clone()), Some("lol".into()), &now);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
-
-        deleted_company_tester(company.clone(), &now, |company: Company| {
-            move_resource(&user, &member, &company, id.clone(), resource.clone(), ResourceMover::Update(resource_to.clone()), Costs::new_with_labor("homemaker", 23), 8, Some(loc.clone()), Some("lol".into()), &now)
-        });
-
         // can't move into a resource you don't own
-        let mut resource_to3 = resource_to.clone();
-        resource_to3.inner_mut().set_primary_accountable(Some(CompanyID::new("zing").into()));
-        let res = move_resource(&user, &member, &company, id.clone(), resource.clone(), ResourceMover::Update(resource_to3.clone()), Costs::new_with_labor("homemaker", 23), 8, Some(loc.clone()), Some("lol".into()), &now);
+        let mut state2 = state.clone();
+        state2.model2_mut().inner_mut().set_primary_accountable(Some(CompanyID::new("zing").into()));
+        let res = testfn_update(&state2);
         assert_eq!(res, Err(Error::Event(EventError::ResourceOwnerMismatch)));
 
         // a company that doesn't own a resource can't move it OBVIOUSLY
-        let mut resource3 = resource.clone();
-        resource3.inner_mut().set_primary_accountable(Some(CompanyID::new("ziggy").into()));
-        let res = move_resource(&user, &member, &company, id.clone(), resource3.clone(), ResourceMover::Update(resource_to.clone()), Costs::new_with_labor("homemaker", 23), 8, Some(loc.clone()), Some("lol".into()), &now);
+        let mut state3 = state.clone();
+        state3.model_mut().inner_mut().set_primary_accountable(Some(CompanyID::new("ziggy").into()));
+        let res = testfn_update(&state3);
+        assert_eq!(res, Err(Error::Event(EventError::ResourceOwnerMismatch)));
+        let res = testfn_create(&state3);
         assert_eq!(res, Err(Error::Event(EventError::ResourceOwnerMismatch)));
 
         // a company that doesn't have posession of a resource can't move it
-        let mut resource4 = resource.clone();
-        resource4.set_in_custody_of(CompanyID::new("ziggy").into());
-        let res = move_resource(&user, &member, &company, id.clone(), resource4.clone(), ResourceMover::Update(resource_to.clone()), Costs::new_with_labor("homemaker", 23), 8, Some(loc.clone()), Some("lol".into()), &now);
+        let mut state4 = state.clone();
+        state4.model_mut().set_in_custody_of(CompanyID::new("ziggy").into());
+        let res = testfn_update(&state4);
+        assert_eq!(res, Err(Error::Event(EventError::ResourceCustodyMismatch)));
+        let res = testfn_create(&state4);
         assert_eq!(res, Err(Error::Event(EventError::ResourceCustodyMismatch)));
     }
 
@@ -514,18 +489,16 @@ mod tests {
     fn can_raise() {
         let now = util::time::now();
         let id = EventID::create();
-        let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
-        let user = make_user(&UserID::create(), None, &now);
-        let occupation_id = OccupationID::new("machinist");
-        let member = make_member_worker(&MemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
-        let resource = make_resource(&ResourceID::new("widget"), company.id(), &Measure::new(dec!(15), Unit::One), &Costs::new_with_labor("homemaker", 157), &now);
+        let mut state = TestState::standard(vec![CompanyPermission::Raise], &now);
+        let resource = make_resource(&ResourceID::new("widget"), state.company().id(), &Measure::new(dec!(15), Unit::One), &Costs::new_with_labor("homemaker", 157), &now);
+        state.model = Some(resource);
 
-        let res = raise(&user, &member, &company, id.clone(), resource.clone(), 8, Some("toot".into()), &now);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
+        let testfn = |state: &TestState<Resource, Resource>| {
+            raise(state.user(), state.member(), state.company(), id.clone(), state.model().clone(), 8, Some("toot".into()), &now)
+        };
+        test::standard_transaction_tests(&state, &testfn);
 
-        let mut member = member.clone();
-        member.set_permissions(vec![CompanyPermission::Raise]);
-        let mods = raise(&user, &member, &company, id.clone(), resource.clone(), 8, Some("toot".into()), &now).unwrap().into_vec();
+        let mods = testfn(&state).unwrap().into_vec();
         assert_eq!(mods.len(), 2);
         let event = mods[0].clone().expect_op::<Event>(Op::Create).unwrap();
         let resource2 = mods[1].clone().expect_op::<Resource>(Op::Update).unwrap();
@@ -536,44 +509,30 @@ mod tests {
         assert_eq!(event.inner().input_of(), &None);
         assert_eq!(event.inner().note(), &Some("toot".into()));
         assert_eq!(event.inner().output_of(), &None);
-        assert_eq!(event.inner().provider().clone(), company.agent_id());
-        assert_eq!(event.inner().receiver().clone(), company.agent_id());
+        assert_eq!(event.inner().provider().clone(), state.company().agent_id());
+        assert_eq!(event.inner().receiver().clone(), state.company().agent_id());
         assert_eq!(event.inner().resource_quantity(), &Some(Measure::new(8, Unit::One)));
         assert_eq!(event.move_costs(), &None);
         assert_eq!(event.active(), &true);
         assert_eq!(event.created(), &now);
         assert_eq!(event.updated(), &now);
 
-        assert_eq!(resource2.id(), resource.id());
+        assert_eq!(resource2.id(), state.model().id());
         assert_eq!(resource2.inner().accounting_quantity(), &Some(Measure::new(dec!(23), Unit::One)));
         assert_eq!(resource2.inner().onhand_quantity(), &Some(Measure::new(dec!(23), Unit::One)));
-        assert_eq!(resource2.costs(), resource.costs());
-
-        let user2 = make_user(&UserID::create(), Some(vec![]), &now);
-        let res = raise(&user2, &member, &company, id.clone(), resource.clone(), 8, Some("toot".into()), &now);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
-
-        let mut member2 = member.clone();
-        member2.set_permissions(vec![]);
-        let res = raise(&user, &member2, &company, id.clone(), resource.clone(), 8, Some("toot".into()), &now);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
-
-        deleted_company_tester(company.clone(), &now, |company: Company| {
-            raise(&user, &member, &company, id.clone(), resource.clone(), 8, Some("toot".into()), &now)
-        });
+        assert_eq!(resource2.costs(), state.model().costs());
 
         // a company that doesn't own a resource can't raise it
-        let mut resource3 = resource.clone();
-        resource3.inner_mut().set_primary_accountable(Some(CompanyID::new("ziggy").into()));
-        let res = raise(&user, &member, &company, id.clone(), resource3.clone(), 8, Some("toot".into()), &now);
+        let mut state2 = state.clone();
+        state2.model_mut().inner_mut().set_primary_accountable(Some(CompanyID::new("ziggy").into()));
+        let res = testfn(&state2);
         assert_eq!(res, Err(Error::Event(EventError::ResourceOwnerMismatch)));
 
         // a company that doesn't have possession of a resource can't raise it
-        let mut resource4 = resource.clone();
-        resource4.set_in_custody_of(CompanyID::new("ziggy").into());
-        let res = raise(&user, &member, &company, id.clone(), resource4.clone(), 8, Some("toot".into()), &now);
+        let mut state3 = state.clone();
+        state3.model_mut().set_in_custody_of(CompanyID::new("ziggy").into());
+        let res = testfn(&state3);
         assert_eq!(res, Err(Error::Event(EventError::ResourceCustodyMismatch)));
-
     }
 }
 

--- a/src/transactions/event/delivery.rs
+++ b/src/transactions/event/delivery.rs
@@ -15,7 +15,7 @@ use crate::{
         event::{Event, EventID, EventProcessState},
         company::{Company, Permission as CompanyPermission},
         member::Member,
-        lib::basis_model::ActiveState,
+        lib::basis_model::Model,
         process::Process,
         resource::Resource,
         user::User,

--- a/src/transactions/event/delivery.rs
+++ b/src/transactions/event/delivery.rs
@@ -130,16 +130,13 @@ mod tests {
     use crate::{
         models::{
             company::CompanyID,
-            member::MemberID,
             event::{EventError, EventID},
             lib::agent::Agent,
             occupation::OccupationID,
             process::ProcessID,
             resource::ResourceID,
-            testutils::{deleted_company_tester, make_user, make_company, make_member_worker, make_process, make_resource},
-            user::UserID,
         },
-        util,
+        util::{self, test::{self, *}},
     };
     use om2::{Measure, Unit};
     use rust_decimal_macros::*;
@@ -148,23 +145,20 @@ mod tests {
     fn can_dropoff() {
         let now = util::time::now();
         let id = EventID::create();
-        let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
-        let user = make_user(&UserID::create(), None, &now);
+        let mut state = TestState::standard(vec![CompanyPermission::Dropoff], &now);
         let occupation_id = OccupationID::new("trucker");
-        let member = make_member_worker(&MemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
-        let resource = make_resource(&ResourceID::new("widget"), company.id(), &Measure::new(dec!(15), Unit::One), &Costs::new_with_labor("machinist", 157), &now);
         let costs = Costs::new_with_labor(occupation_id.clone(), dec!(42.2));
-        let process = make_process(&ProcessID::create(), company.id(), "deliver widgets", &costs, &now);
-        let loc = SpatialThing::builder()
-            .mappable_address(Some("1212 Uranus lane, DERRSOYBOY, KY, 33133".into()))
-            .build().unwrap();
+        let process = make_process(&ProcessID::create(), state.company().id(), "deliver widgets", &costs, &now);
+        let resource = make_resource(&ResourceID::new("widget"), state.company().id(), &Measure::new(dec!(15), Unit::One), &Costs::new_with_labor("machinist", 157), &now);
+        state.model = Some(process);
+        state.model2 = Some(resource);
 
-        let res = dropoff(&user, &member, &company, id.clone(), process.clone(), resource.clone(), process.costs().clone(), Some(loc.clone()), Some("memo".into()), &now);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
+        let testfn = |state: &TestState<Process, Resource>| {
+            dropoff(state.user(), state.member(), state.company(), id.clone(), state.model().clone(), state.model2().clone(), state.model().costs().clone(), Some(state.loc().clone()), Some("memo".into()), &now)
+        };
+        test::standard_transaction_tests(&state, &testfn);
 
-        let mut member = member.clone();
-        member.set_permissions(vec![CompanyPermission::Dropoff]);
-        let mods = dropoff(&user, &member, &company, id.clone(), process.clone(), resource.clone(), process.costs().clone(), Some(loc.clone()), Some("memo".into()), &now).unwrap().into_vec();
+        let mods = testfn(&state).unwrap().into_vec();
         assert_eq!(mods.len(), 3);
         let event = mods[0].clone().expect_op::<Event>(Op::Create).unwrap();
         let process2 = mods[1].clone().expect_op::<Process>(Op::Update).unwrap();
@@ -174,59 +168,46 @@ mod tests {
         assert_eq!(event.inner().agreed_in(), &None);
         assert_eq!(event.inner().has_point_in_time(), &Some(now.clone()));
         assert_eq!(event.inner().input_of(), &None);
-        assert_eq!(event.inner().output_of(), &Some(process.id().clone()));
-        assert_eq!(event.inner().provider().clone(), company.agent_id());
-        assert_eq!(event.inner().receiver().clone(), company.agent_id());
-        assert_eq!(event.move_costs(), &Some(process.costs().clone()));
+        assert_eq!(event.inner().output_of(), &Some(state.model().id().clone()));
+        assert_eq!(event.inner().provider().clone(), state.company().agent_id());
+        assert_eq!(event.inner().receiver().clone(), state.company().agent_id());
+        assert_eq!(event.move_costs(), &Some(state.model().costs().clone()));
         assert_eq!(event.active(), &true);
         assert_eq!(event.created(), &now);
         assert_eq!(event.updated(), &now);
 
-        assert_eq!(process2.id(), process.id());
-        assert_eq!(process2.company_id(), company.id());
+        assert_eq!(process2.id(), state.model().id());
+        assert_eq!(process2.company_id(), state.company().id());
         assert_eq!(process2.inner().name(), "deliver widgets");
         assert_eq!(process2.costs(), &Costs::new());
 
         let mut costs2 = Costs::new();
         costs2.track_labor(occupation_id.clone(), dec!(42.2));
         costs2.track_labor("machinist", 157);
-        assert_eq!(resource2.id(), resource.id());
-        assert_eq!(resource2.inner().primary_accountable(), &Some(company.agent_id()));
-        assert_eq!(resource2.in_custody_of(), &company.agent_id());
+        assert_eq!(resource2.id(), state.model2().id());
+        assert_eq!(resource2.inner().primary_accountable(), &Some(state.company().agent_id()));
+        assert_eq!(resource2.in_custody_of(), &state.company().agent_id());
         assert_eq!(resource2.inner().accounting_quantity(), &Some(Measure::new(dec!(15), Unit::One)));
         assert_eq!(event.inner().note(), &Some("memo".into()));
         assert_eq!(resource2.inner().onhand_quantity(), &Some(Measure::new(dec!(15), Unit::One)));
-        assert_eq!(resource2.inner().current_location(), &Some(loc.clone()));
+        assert_eq!(resource2.inner().current_location(), &Some(state.loc().clone()));
         assert_eq!(resource2.costs(), &costs2);
 
-        let user2 = make_user(&UserID::create(), Some(vec![]), &now);
-        let res = dropoff(&user2, &member, &company, id.clone(), process.clone(), resource.clone(), process.costs().clone(), Some(loc.clone()), Some("memo".into()), &now);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
-
-        let mut member2 = member.clone();
-        member2.set_permissions(vec![]);
-        let res = dropoff(&user, &member2, &company, id.clone(), process.clone(), resource.clone(), process.costs().clone(), Some(loc.clone()), Some("memo".into()), &now);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
-
-        deleted_company_tester(company.clone(), &now, |company: Company| {
-            dropoff(&user, &member, &company, id.clone(), process.clone(), resource.clone(), process.costs().clone(), Some(loc.clone()), Some("memo".into()), &now)
-        });
-
         // can't dropoff from a process you don't own
-        let mut process3 = process.clone();
-        process3.set_company_id(CompanyID::new("zing"));
-        let res = dropoff(&user, &member, &company, id.clone(), process3.clone(), resource.clone(), process.costs().clone(), Some(loc.clone()), Some("memo".into()), &now);
+        let mut state2 = state.clone();
+        state2.model_mut().set_company_id(CompanyID::new("zing"));
+        let res = testfn(&state2);
         assert_eq!(res, Err(Error::Event(EventError::ProcessOwnerMismatch)));
 
-        let mut resource3 = resource.clone();
-        resource3.inner_mut().set_primary_accountable(Some(CompanyID::new("ziggy").into()));
-        let res = dropoff(&user, &member, &company, id.clone(), process.clone(), resource3.clone(), process.costs().clone(), Some(loc.clone()), Some("memo".into()), &now);
+        let mut state3 = state.clone();
+        state3.model2_mut().inner_mut().set_primary_accountable(Some(CompanyID::new("ziggy").into()));
+        let res = testfn(&state3);
         assert!(res.is_ok());
 
         // a company that doesn't have posession of a resource can't drop it off
-        let mut resource4 = resource.clone();
-        resource4.set_in_custody_of(CompanyID::new("ziggy").into());
-        let res = dropoff(&user, &member, &company, id.clone(), process.clone(), resource4.clone(), process.costs().clone(), Some(loc.clone()), Some("memo".into()), &now);
+        let mut state4 = state.clone();
+        state4.model2_mut().set_in_custody_of(CompanyID::new("ziggy").into());
+        let res = testfn(&state4);
         assert_eq!(res, Err(Error::Event(EventError::ResourceCustodyMismatch)));
     }
 
@@ -234,62 +215,47 @@ mod tests {
     fn can_pickup() {
         let now = util::time::now();
         let id = EventID::create();
-        let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
-        let user = make_user(&UserID::create(), None, &now);
-        let occupation_id = OccupationID::new("machinist");
-        let member = make_member_worker(&MemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
-        let resource = make_resource(&ResourceID::new("widget"), company.id(), &Measure::new(dec!(15), Unit::One), &Costs::new_with_labor("homemaker", 157), &now);
-        let process = make_process(&ProcessID::create(), company.id(), "make widgets", &Costs::new(), &now);
+        let mut state = TestState::standard(vec![CompanyPermission::Pickup], &now);
+        let resource = make_resource(&ResourceID::new("widget"), state.company().id(), &Measure::new(dec!(15), Unit::One), &Costs::new_with_labor("homemaker", 157), &now);
+        let process = make_process(&ProcessID::create(), state.company().id(), "make widgets", &Costs::new(), &now);
+        state.model = Some(resource);
+        state.model2 = Some(process);
 
-        let res = pickup(&user, &member, &company, id.clone(), resource.clone(), process.clone(), Some("memo".into()), &now);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
+        let testfn = |state: &TestState<Resource, Process>| {
+            pickup(state.user(), state.member(), state.company(), id.clone(), state.model().clone(), state.model2().clone(), Some("memo".into()), &now)
+        };
+        test::standard_transaction_tests(&state, &testfn);
 
-        let mut member = member.clone();
-        member.set_permissions(vec![CompanyPermission::Pickup]);
-        let mods = pickup(&user, &member, &company, id.clone(), resource.clone(), process.clone(), Some("memo".into()), &now).unwrap().into_vec();
+        let mods = testfn(&state).unwrap().into_vec();
         assert_eq!(mods.len(), 1);
         let event = mods[0].clone().expect_op::<Event>(Op::Create).unwrap();
 
         assert_eq!(event.id(), &id);
         assert_eq!(event.inner().agreed_in(), &None);
         assert_eq!(event.inner().has_point_in_time(), &Some(now.clone()));
-        assert_eq!(event.inner().input_of(), &Some(process.id().clone()));
+        assert_eq!(event.inner().input_of(), &Some(state.model2().id().clone()));
         assert_eq!(event.inner().note(), &Some("memo".into()));
-        assert_eq!(event.inner().provider().clone(), company.agent_id());
-        assert_eq!(event.inner().receiver().clone(), company.agent_id());
+        assert_eq!(event.inner().provider().clone(), state.company().agent_id());
+        assert_eq!(event.inner().receiver().clone(), state.company().agent_id());
         assert_eq!(event.move_costs(), &Some(Costs::new()));
         assert_eq!(event.active(), &true);
         assert_eq!(event.created(), &now);
         assert_eq!(event.updated(), &now);
 
-        let user2 = make_user(&UserID::create(), Some(vec![]), &now);
-        let res = pickup(&user2, &member, &company, id.clone(), resource.clone(), process.clone(), Some("memo".into()), &now);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
-
-        let mut member2 = member.clone();
-        member2.set_permissions(vec![]);
-        let res = pickup(&user, &member2, &company, id.clone(), resource.clone(), process.clone(), Some("memo".into()), &now);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
-
-        deleted_company_tester(company.clone(), &now, |company: Company| {
-            pickup(&user, &member, &company, id.clone(), resource.clone(), process.clone(), Some("memo".into()), &now)
-        });
-
-        // can't consume into a process you don't own
-        let mut process3 = process.clone();
-        process3.set_company_id(CompanyID::new("zing"));
-        let res = pickup(&user, &member, &company, id.clone(), resource.clone(), process3.clone(), Some("memo".into()), &now);
+        let mut state2 = state.clone();
+        state2.model2_mut().set_company_id(CompanyID::new("zing"));
+        let res = testfn(&state2);
         assert_eq!(res, Err(Error::Event(EventError::ProcessOwnerMismatch)));
 
-        let mut resource3 = resource.clone();
-        resource3.inner_mut().set_primary_accountable(Some(CompanyID::new("ziggy").into()));
-        let res = pickup(&user, &member, &company, id.clone(), resource3.clone(), process.clone(), Some("memo".into()), &now);
+        let mut state3 = state.clone();
+        state3.model_mut().inner_mut().set_primary_accountable(Some(CompanyID::new("ziggy").into()));
+        let res = testfn(&state3);
         assert!(res.is_ok());
 
         // a company that doesn't have posession of a resource can't pick it up
-        let mut resource4 = resource.clone();
-        resource4.set_in_custody_of(CompanyID::new("ziggy").into());
-        let res = pickup(&user, &member, &company, id.clone(), resource4.clone(), process.clone(), Some("memo".into()), &now);
+        let mut state4 = state.clone();
+        state4.model_mut().set_in_custody_of(CompanyID::new("ziggy").into());
+        let res = testfn(&state4);
         assert_eq!(res, Err(Error::Event(EventError::ResourceCustodyMismatch)));
     }
 }

--- a/src/transactions/event/modification.rs
+++ b/src/transactions/event/modification.rs
@@ -138,16 +138,13 @@ mod tests {
     use crate::{
         models::{
             company::CompanyID,
-            member::MemberID,
             event::{EventError, EventID},
             lib::agent::Agent,
             occupation::OccupationID,
             process::ProcessID,
             resource::ResourceID,
-            testutils::{deleted_company_tester, make_user, make_company, make_member_worker, make_process, make_resource},
-            user::UserID,
         },
-        util,
+        util::{self, test::{self, *}},
     };
     use om2::{Measure, Unit};
     use rust_decimal_macros::*;
@@ -156,19 +153,18 @@ mod tests {
     fn can_accept() {
         let now = util::time::now();
         let id = EventID::create();
-        let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
-        let user = make_user(&UserID::create(), None, &now);
-        let occupation_id = OccupationID::new("mechanic");
-        let member = make_member_worker(&MemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
-        let resource = make_resource(&ResourceID::new("widget"), company.id(), &Measure::new(dec!(15), Unit::One), &Costs::new_with_resource("steel", 157), &now);
-        let process = make_process(&ProcessID::create(), company.id(), "make widgets", &Costs::new(), &now);
+        let mut state = TestState::standard(vec![CompanyPermission::Accept], &now);
+        let resource = make_resource(&ResourceID::new("widget"), state.company().id(), &Measure::new(dec!(15), Unit::One), &Costs::new_with_resource("steel", 157), &now);
+        let process = make_process(&ProcessID::create(), state.company().id(), "make widgets", &Costs::new(), &now);
+        state.model = Some(resource);
+        state.model2 = Some(process);
 
-        let res = accept(&user, &member, &company, id.clone(), resource.clone(), process.clone(), 3, Some("memo lol".into()), &now);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
+        let testfn = |state: &TestState<Resource, Process>| {
+            accept(state.user(), state.member(), state.company(), id.clone(), state.model().clone(), state.model2().clone(), 3, Some("memo lol".into()), &now)
+        };
+        test::standard_transaction_tests(&state, &testfn);
 
-        let mut member = member.clone();
-        member.set_permissions(vec![CompanyPermission::Accept]);
-        let mods = accept(&user, &member, &company, id.clone(), resource.clone(), process.clone(), 3, Some("memo lol".into()), &now).unwrap().into_vec();
+        let mods = testfn(&state).unwrap().into_vec();
         assert_eq!(mods.len(), 2);
         let event = mods[0].clone().expect_op::<Event>(Op::Create).unwrap();
         let resource2 = mods[1].clone().expect_op::<Resource>(Op::Update).unwrap();
@@ -176,52 +172,39 @@ mod tests {
         assert_eq!(event.id(), &id);
         assert_eq!(event.inner().agreed_in(), &None);
         assert_eq!(event.inner().has_point_in_time(), &Some(now.clone()));
-        assert_eq!(event.inner().input_of(), &Some(process.id().clone()));
+        assert_eq!(event.inner().input_of(), &Some(state.model2().id().clone()));
         assert_eq!(event.inner().note(), &Some("memo lol".into()));
-        assert_eq!(event.inner().provider().clone(), company.agent_id());
-        assert_eq!(event.inner().receiver().clone(), company.agent_id());
+        assert_eq!(event.inner().provider().clone(), state.company().agent_id());
+        assert_eq!(event.inner().receiver().clone(), state.company().agent_id());
         assert_eq!(event.inner().resource_quantity(), &Some(Measure::new(3, Unit::One)));
         assert_eq!(event.move_costs(), &Some(Costs::new()));
         assert_eq!(event.active(), &true);
         assert_eq!(event.created(), &now);
         assert_eq!(event.updated(), &now);
 
-        assert_eq!(resource2.id(), resource.id());
-        assert_eq!(resource2.inner().primary_accountable(), &Some(company.agent_id()));
-        assert_eq!(resource2.in_custody_of(), &company.agent_id());
+        assert_eq!(resource2.id(), state.model().id());
+        assert_eq!(resource2.inner().primary_accountable(), &Some(state.company().agent_id()));
+        assert_eq!(resource2.in_custody_of(), &state.company().agent_id());
         assert_eq!(resource2.inner().accounting_quantity(), &Some(Measure::new(dec!(15), Unit::One)));
         assert_eq!(resource2.inner().onhand_quantity(), &Some(Measure::new(dec!(12), Unit::One)));
         assert_eq!(resource2.costs(), &Costs::new_with_resource("steel", 157));
 
-        let user2 = make_user(&UserID::create(), Some(vec![]), &now);
-        let res = accept(&user2, &member, &company, id.clone(), resource.clone(), process.clone(), 3, Some("memo lol".into()), &now);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
-
-        let mut member2 = member.clone();
-        member2.set_permissions(vec![]);
-        let res = accept(&user, &member2, &company, id.clone(), resource.clone(), process.clone(), 3, Some("memo lol".into()), &now);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
-
-        deleted_company_tester(company.clone(), &now, |company: Company| {
-            accept(&user, &member, &company, id.clone(), resource.clone(), process.clone(), 3, Some("memo lol".into()), &now)
-        });
-
         // can't accept into a process you don't own
-        let mut process3 = process.clone();
-        process3.set_company_id(CompanyID::new("zing"));
-        let res = accept(&user, &member, &company, id.clone(), resource.clone(), process3.clone(), 3, Some("memo lol".into()), &now);
+        let mut state2 = state.clone();
+        state2.model2_mut().set_company_id(CompanyID::new("zing"));
+        let res = testfn(&state2);
         assert_eq!(res, Err(Error::Event(EventError::ProcessOwnerMismatch)));
 
         // a company that doesn't own a resource *can* accept it
-        let mut resource3 = resource.clone();
-        resource3.inner_mut().set_primary_accountable(Some(CompanyID::new("ziggy").into()));
-        let res = accept(&user, &member, &company, id.clone(), resource3.clone(), process.clone(), 3, Some("memo lol".into()), &now);
+        let mut state3 = state.clone();
+        state3.model_mut().inner_mut().set_primary_accountable(Some(CompanyID::new("ziggy").into()));
+        let res = testfn(&state3);
         assert!(res.is_ok());
 
         // a company that doesn't have possession of a resource can't accept it
-        let mut resource4 = resource.clone();
-        resource4.set_in_custody_of(CompanyID::new("ziggy").into());
-        let res = accept(&user, &member, &company, id.clone(), resource4.clone(), process.clone(), 3, Some("memo lol".into()), &now);
+        let mut state4 = state.clone();
+        state4.model_mut().set_in_custody_of(CompanyID::new("ziggy").into());
+        let res = testfn(&state4);
         assert_eq!(res, Err(Error::Event(EventError::ResourceCustodyMismatch)));
     }
 
@@ -229,20 +212,20 @@ mod tests {
     fn can_modify() {
         let now = util::time::now();
         let id = EventID::create();
-        let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
-        let user = make_user(&UserID::create(), None, &now);
+        let mut state = TestState::standard(vec![CompanyPermission::Modify], &now);
         let occupation_id = OccupationID::new("mechanic");
-        let member = make_member_worker(&MemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
-        let resource = make_resource(&ResourceID::new("car"), company.id(), &Measure::new(dec!(3), Unit::One), &Costs::new_with_resource("steel", 157), &now);
         let costs = Costs::new_with_labor(occupation_id.clone(), dec!(102.3));
-        let process = make_process(&ProcessID::create(), company.id(), "repair car", &costs, &now);
+        let process = make_process(&ProcessID::create(), state.company().id(), "repair car", &costs, &now);
+        let resource = make_resource(&ResourceID::new("car"), state.company().id(), &Measure::new(dec!(3), Unit::One), &Costs::new_with_resource("steel", 157), &now);
+        state.model = Some(process);
+        state.model2 = Some(resource);
 
-        let res = modify(&user, &member, &company, id.clone(), process.clone(), resource.clone(), process.costs().clone(), 12, Some("memo lol".into()), &now);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
+        let testfn = |state: &TestState<Process, Resource>| {
+            modify(state.user(), state.member(), state.company(), id.clone(), state.model().clone(), state.model2().clone(), state.model().costs().clone(), 12, Some("memo lol".into()), &now)
+        };
+        test::standard_transaction_tests(&state, &testfn);
 
-        let mut member = member.clone();
-        member.set_permissions(vec![CompanyPermission::Modify]);
-        let mods = modify(&user, &member, &company, id.clone(), process.clone(), resource.clone(), process.costs().clone(), 12, Some("memo lol".into()), &now).unwrap().into_vec();
+        let mods = testfn(&state).unwrap().into_vec();
         assert_eq!(mods.len(), 3);
         let event = mods[0].clone().expect_op::<Event>(Op::Create).unwrap();
         let process2 = mods[1].clone().expect_op::<Process>(Op::Update).unwrap();
@@ -253,58 +236,45 @@ mod tests {
         assert_eq!(event.inner().has_point_in_time(), &Some(now.clone()));
         assert_eq!(event.inner().input_of(), &None);
         assert_eq!(event.inner().note(), &Some("memo lol".into()));
-        assert_eq!(event.inner().output_of(), &Some(process.id().clone()));
-        assert_eq!(event.inner().provider().clone(), company.agent_id());
-        assert_eq!(event.inner().receiver().clone(), company.agent_id());
-        assert_eq!(event.move_costs(), &Some(process.costs().clone()));
+        assert_eq!(event.inner().output_of(), &Some(state.model().id().clone()));
+        assert_eq!(event.inner().provider().clone(), state.company().agent_id());
+        assert_eq!(event.inner().receiver().clone(), state.company().agent_id());
+        assert_eq!(event.move_costs(), &Some(state.model().costs().clone()));
         assert_eq!(event.active(), &true);
         assert_eq!(event.created(), &now);
         assert_eq!(event.updated(), &now);
 
-        assert_eq!(process2.id(), process.id());
-        assert_eq!(process2.company_id(), company.id());
+        assert_eq!(process2.id(), state.model().id());
+        assert_eq!(process2.company_id(), state.company().id());
         assert_eq!(process2.inner().name(), "repair car");
         assert_eq!(process2.costs(), &Costs::new());
 
         let mut costs2 = Costs::new();
         costs2.track_labor(occupation_id.clone(), dec!(102.3));
         costs2.track_resource("steel", 157);
-        assert_eq!(resource2.id(), resource.id());
-        assert_eq!(resource2.inner().primary_accountable(), &Some(company.agent_id()));
-        assert_eq!(resource2.in_custody_of(), &company.agent_id());
+        assert_eq!(resource2.id(), state.model2().id());
+        assert_eq!(resource2.inner().primary_accountable(), &Some(state.company().agent_id()));
+        assert_eq!(resource2.in_custody_of(), &state.company().agent_id());
         assert_eq!(resource2.inner().accounting_quantity(), &Some(Measure::new(dec!(3), Unit::One)));
         assert_eq!(resource2.inner().onhand_quantity(), &Some(Measure::new(dec!(15), Unit::One)));
         assert_eq!(resource2.costs(), &costs2);
 
-        let user2 = make_user(&UserID::create(), Some(vec![]), &now);
-        let res = modify(&user2, &member, &company, id.clone(), process.clone(), resource.clone(), process.costs().clone(), 12, Some("memo lol".into()), &now);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
-
-        let mut member2 = member.clone();
-        member2.set_permissions(vec![]);
-        let res = modify(&user, &member2, &company, id.clone(), process.clone(), resource.clone(), process.costs().clone(), 12, Some("memo lol".into()), &now);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
-
-        deleted_company_tester(company.clone(), &now, |company: Company| {
-            modify(&user, &member, &company, id.clone(), process.clone(), resource.clone(), process.costs().clone(), 12, Some("memo lol".into()), &now)
-        });
-
         // can't modify from a process you don't own
-        let mut process3 = process.clone();
-        process3.set_company_id(CompanyID::new("zing"));
-        let res = modify(&user, &member, &company, id.clone(), process3.clone(), resource.clone(), process.costs().clone(), 12, Some("memo lol".into()), &now);
+        let mut state2 = state.clone();
+        state2.model_mut().set_company_id(CompanyID::new("zing"));
+        let res = testfn(&state2);
         assert_eq!(res, Err(Error::Event(EventError::ProcessOwnerMismatch)));
 
         // a company that doesn't own a resource can't modify it
-        let mut resource3 = resource.clone();
-        resource3.inner_mut().set_primary_accountable(Some(CompanyID::new("ziggy").into()));
-        let res = modify(&user, &member, &company, id.clone(), process.clone(), resource3.clone(), process.costs().clone(), 12, Some("memo lol".into()), &now);
+        let mut state3 = state.clone();
+        state3.model2_mut().inner_mut().set_primary_accountable(Some(CompanyID::new("ziggy").into()));
+        let res = testfn(&state3);
         assert_eq!(res, Err(Error::Event(EventError::ResourceOwnerMismatch)));
 
         // a company that doesn't have posession of a resource can't modify it
-        let mut resource4 = resource.clone();
-        resource4.set_in_custody_of(CompanyID::new("ziggy").into());
-        let res = modify(&user, &member, &company, id.clone(), process.clone(), resource4.clone(), process.costs().clone(), 12, Some("memo lol".into()), &now);
+        let mut state4 = state.clone();
+        state4.model2_mut().set_in_custody_of(CompanyID::new("ziggy").into());
+        let res = testfn(&state4);
         assert_eq!(res, Err(Error::Event(EventError::ResourceCustodyMismatch)));
     }
 }

--- a/src/transactions/event/modification.rs
+++ b/src/transactions/event/modification.rs
@@ -15,7 +15,7 @@ use crate::{
         event::{Event, EventID, EventProcessState},
         company::{Company, Permission as CompanyPermission},
         member::Member,
-        lib::basis_model::ActiveState,
+        lib::basis_model::Model,
         process::Process,
         resource::Resource,
         user::User,

--- a/src/transactions/event/production.rs
+++ b/src/transactions/event/production.rs
@@ -13,7 +13,7 @@ use crate::{
         event::{Event, EventID, EventProcessState},
         company::{Company, Permission as CompanyPermission},
         member::Member,
-        lib::basis_model::ActiveState,
+        lib::basis_model::Model,
         process::Process,
         resource::Resource,
         user::User,

--- a/src/transactions/event/production.rs
+++ b/src/transactions/event/production.rs
@@ -261,16 +261,13 @@ mod tests {
     use crate::{
         models::{
             company::CompanyID,
-            member::MemberID,
             event::{EventError, EventID},
             lib::agent::Agent,
             occupation::OccupationID,
             process::ProcessID,
             resource::ResourceID,
-            testutils::{deleted_company_tester, make_user, make_company, make_member_worker, make_process, make_resource},
-            user::UserID,
         },
-        util,
+        util::{self, test::{self, *}},
     };
     use om2::Unit;
     use rust_decimal_macros::*;
@@ -279,22 +276,22 @@ mod tests {
     fn can_cite() {
         let now = util::time::now();
         let id = EventID::create();
-        let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
-        let user = make_user(&UserID::create(), None, &now);
+        let mut state = TestState::standard(vec![CompanyPermission::Cite], &now);
         let occupation_id = OccupationID::new("machinist");
-        let member = make_member_worker(&MemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
-        let resource = make_resource(&ResourceID::new("widget"), company.id(), &Measure::new(dec!(15), Unit::One), &Costs::new_with_labor("homemaker", 157), &now);
         let mut costs = Costs::new();
         costs.track_labor(occupation_id.clone(), dec!(42.2));
         costs.track_labor("homemaker", dec!(13.6));
-        let process = make_process(&ProcessID::create(), company.id(), "make widgets", &costs, &now);
+        let resource = make_resource(&ResourceID::new("widget"), state.company().id(), &Measure::new(dec!(15), Unit::One), &Costs::new_with_labor("homemaker", 157), &now);
+        let process = make_process(&ProcessID::create(), state.company().id(), "make widgets", &costs, &now);
+        state.model = Some(resource);
+        state.model2 = Some(process);
 
-        let res = cite(&user, &member, &company, id.clone(), resource.clone(), process.clone(), Costs::new_with_labor("homemaker", 23), Some("memo".into()), &now);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
+        let testfn = |state: &TestState<Resource, Process>| {
+            cite(state.user(), state.member(), state.company(), id.clone(), state.model().clone(), state.model2().clone(), Costs::new_with_labor("homemaker", 23), Some("memo".into()), &now)
+        };
+        test::standard_transaction_tests(&state, &testfn);
 
-        let mut member = member.clone();
-        member.set_permissions(vec![CompanyPermission::Cite]);
-        let mods = cite(&user, &member, &company, id.clone(), resource.clone(), process.clone(), Costs::new_with_labor("homemaker", 23), Some("memo".into()), &now).unwrap().into_vec();
+        let mods = testfn(&state).unwrap().into_vec();
         assert_eq!(mods.len(), 3);
         let event = mods[0].clone().expect_op::<Event>(Op::Create).unwrap();
         let process2 = mods[1].clone().expect_op::<Process>(Op::Update).unwrap();
@@ -303,59 +300,46 @@ mod tests {
         assert_eq!(event.id(), &id);
         assert_eq!(event.inner().agreed_in(), &None);
         assert_eq!(event.inner().has_point_in_time(), &Some(now.clone()));
-        assert_eq!(event.inner().input_of(), &Some(process.id().clone()));
+        assert_eq!(event.inner().input_of(), &Some(state.model2().id().clone()));
         assert_eq!(event.inner().note(), &Some("memo".into()));
-        assert_eq!(event.inner().provider().clone(), company.agent_id());
-        assert_eq!(event.inner().receiver().clone(), company.agent_id());
+        assert_eq!(event.inner().provider().clone(), state.company().agent_id());
+        assert_eq!(event.inner().receiver().clone(), state.company().agent_id());
         assert_eq!(event.move_costs(), &Some(Costs::new_with_labor("homemaker", 23)));
         assert_eq!(event.active(), &true);
         assert_eq!(event.created(), &now);
         assert_eq!(event.updated(), &now);
 
-        let mut costs2 = Costs::new();
-        costs2.track_labor(occupation_id.clone(), dec!(42.2));
-        costs2.track_labor("homemaker", dec!(23) + dec!(13.6));
-        assert_eq!(process2.id(), process.id());
-        assert_eq!(process2.company_id(), company.id());
-        assert_eq!(process2.inner().name(), "make widgets");
-        assert_eq!(process2.costs(), &costs2);
-
         let mut costs3 = Costs::new();
         costs3.track_labor("homemaker", dec!(157) - dec!(23));
-        assert_eq!(resource2.id(), resource.id());
+        assert_eq!(resource2.id(), state.model().id());
         assert_eq!(resource2.inner().accounting_quantity(), &Some(Measure::new(dec!(15), Unit::One)));
         assert_eq!(resource2.inner().onhand_quantity(), &Some(Measure::new(dec!(15), Unit::One)));
         assert_eq!(resource2.costs(), &costs3);
 
-        let user2 = make_user(&UserID::create(), Some(vec![]), &now);
-        let res = cite(&user2, &member, &company, id.clone(), resource.clone(), process.clone(), Costs::new_with_labor("homemaker", 23), Some("memo".into()), &now);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
-
-        let mut member2 = member.clone();
-        member2.set_permissions(vec![]);
-        let res = cite(&user, &member2, &company, id.clone(), resource.clone(), process.clone(), Costs::new_with_labor("homemaker", 23), Some("memo".into()), &now);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
-
-        deleted_company_tester(company.clone(), &now, |company: Company| {
-            cite(&user, &member, &company, id.clone(), resource.clone(), process.clone(), Costs::new_with_labor("homemaker", 23), Some("memo".into()), &now)
-        });
+        let mut costs2 = Costs::new();
+        costs2.track_labor(occupation_id.clone(), dec!(42.2));
+        costs2.track_labor("homemaker", dec!(23) + dec!(13.6));
+        assert_eq!(process2.id(), state.model2().id());
+        assert_eq!(process2.company_id(), state.company().id());
+        assert_eq!(process2.inner().name(), "make widgets");
+        assert_eq!(process2.costs(), &costs2);
 
         // can't consume into a process you don't own
-        let mut process3 = process.clone();
-        process3.set_company_id(CompanyID::new("zing"));
-        let res = cite(&user, &member, &company, id.clone(), resource.clone(), process3.clone(), Costs::new_with_labor("homemaker", 23), Some("memo".into()), &now);
+        let mut state2 = state.clone();
+        state2.model2_mut().set_company_id(CompanyID::new("zing"));
+        let res = testfn(&state2);
         assert_eq!(res, Err(Error::Event(EventError::ProcessOwnerMismatch)));
 
         // a company that doesn't own a resource can't consume it
-        let mut resource3 = resource.clone();
-        resource3.inner_mut().set_primary_accountable(Some(CompanyID::new("ziggy").into()));
-        let res = cite(&user, &member, &company, id.clone(), resource3.clone(), process.clone(), Costs::new_with_labor("homemaker", 23), Some("memo".into()), &now);
+        let mut state3 = state.clone();
+        state3.model_mut().inner_mut().set_primary_accountable(Some(CompanyID::new("ziggy").into()));
+        let res = testfn(&state3);
         assert_eq!(res, Err(Error::Event(EventError::ResourceOwnerMismatch)));
 
         // a company that doesn't have posession of a resource can't consume it
-        let mut resource4 = resource.clone();
-        resource4.set_in_custody_of(CompanyID::new("ziggy").into());
-        let res = cite(&user, &member, &company, id.clone(), resource4.clone(), process.clone(), Costs::new_with_labor("homemaker", 23), Some("memo".into()), &now);
+        let mut state4 = state.clone();
+        state4.model_mut().set_in_custody_of(CompanyID::new("ziggy").into());
+        let res = testfn(&state4);
         assert_eq!(res, Err(Error::Event(EventError::ResourceCustodyMismatch)));
     }
 
@@ -363,22 +347,22 @@ mod tests {
     fn can_consume() {
         let now = util::time::now();
         let id = EventID::create();
-        let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
-        let user = make_user(&UserID::create(), None, &now);
+        let mut state = TestState::standard(vec![CompanyPermission::Consume], &now);
         let occupation_id = OccupationID::new("machinist");
-        let member = make_member_worker(&MemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
-        let resource = make_resource(&ResourceID::new("widget"), company.id(), &Measure::new(dec!(15), Unit::One), &Costs::new_with_labor("homemaker", 157), &now);
         let mut costs = Costs::new();
         costs.track_labor(occupation_id.clone(), dec!(42.2));
         costs.track_labor("homemaker", dec!(13.6));
-        let process = make_process(&ProcessID::create(), company.id(), "make widgets", &costs, &now);
+        let resource = make_resource(&ResourceID::new("widget"), state.company().id(), &Measure::new(dec!(15), Unit::One), &Costs::new_with_labor("homemaker", 157), &now);
+        let process = make_process(&ProcessID::create(), state.company().id(), "make widgets", &costs, &now);
+        state.model = Some(resource);
+        state.model2 = Some(process);
 
-        let res = consume(&user, &member, &company, id.clone(), resource.clone(), process.clone(), Costs::new_with_labor("homemaker", 23), 8, Some("memo".into()), &now);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
+        let testfn = |state: &TestState<Resource, Process>| {
+            consume(state.user(), state.member(), state.company(), id.clone(), state.model().clone(), state.model2().clone(), Costs::new_with_labor("homemaker", 23), 8, Some("memo".into()), &now)
+        };
+        test::standard_transaction_tests(&state, &testfn);
 
-        let mut member = member.clone();
-        member.set_permissions(vec![CompanyPermission::Consume]);
-        let mods = consume(&user, &member, &company, id.clone(), resource.clone(), process.clone(), Costs::new_with_labor("homemaker", 23), 8, Some("memo".into()), &now).unwrap().into_vec();
+        let mods = testfn(&state).unwrap().into_vec();
         assert_eq!(mods.len(), 3);
         let event = mods[0].clone().expect_op::<Event>(Op::Create).unwrap();
         let process2 = mods[1].clone().expect_op::<Process>(Op::Update).unwrap();
@@ -387,10 +371,10 @@ mod tests {
         assert_eq!(event.id(), &id);
         assert_eq!(event.inner().agreed_in(), &None);
         assert_eq!(event.inner().has_point_in_time(), &Some(now.clone()));
-        assert_eq!(event.inner().input_of(), &Some(process.id().clone()));
+        assert_eq!(event.inner().input_of(), &Some(state.model2().id().clone()));
         assert_eq!(event.inner().note(), &Some("memo".into()));
-        assert_eq!(event.inner().provider().clone(), company.agent_id());
-        assert_eq!(event.inner().receiver().clone(), company.agent_id());
+        assert_eq!(event.inner().provider().clone(), state.company().agent_id());
+        assert_eq!(event.inner().receiver().clone(), state.company().agent_id());
         assert_eq!(event.move_costs(), &Some(Costs::new_with_labor("homemaker", 23)));
         assert_eq!(event.active(), &true);
         assert_eq!(event.created(), &now);
@@ -399,47 +383,34 @@ mod tests {
         let mut costs2 = Costs::new();
         costs2.track_labor(occupation_id.clone(), dec!(42.2));
         costs2.track_labor("homemaker", dec!(23) + dec!(13.6));
-        assert_eq!(process2.id(), process.id());
-        assert_eq!(process2.company_id(), company.id());
+        assert_eq!(process2.id(), state.model2().id());
+        assert_eq!(process2.company_id(), state.company().id());
         assert_eq!(process2.inner().name(), "make widgets");
         assert_eq!(process2.costs(), &costs2);
 
         let mut costs3 = Costs::new();
         costs3.track_labor("homemaker", dec!(157) - dec!(23));
-        assert_eq!(resource2.id(), resource.id());
+        assert_eq!(resource2.id(), state.model().id());
         assert_eq!(resource2.inner().accounting_quantity(), &Some(Measure::new(dec!(7), Unit::One)));
         assert_eq!(resource2.inner().onhand_quantity(), &Some(Measure::new(dec!(7), Unit::One)));
         assert_eq!(resource2.costs(), &costs3);
 
-        let user2 = make_user(&UserID::create(), Some(vec![]), &now);
-        let res = consume(&user2, &member, &company, id.clone(), resource.clone(), process.clone(), Costs::new_with_labor("homemaker", 23), 8, Some("memo".into()), &now);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
-
-        let mut member2 = member.clone();
-        member2.set_permissions(vec![]);
-        let res = consume(&user, &member2, &company, id.clone(), resource.clone(), process.clone(), Costs::new_with_labor("homemaker", 23), 8, Some("memo".into()), &now);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
-
-        deleted_company_tester(company.clone(), &now, |company: Company| {
-            consume(&user, &member, &company, id.clone(), resource.clone(), process.clone(), Costs::new_with_labor("homemaker", 23), 8, Some("memo".into()), &now)
-        });
-
         // can't consume into a process you don't own
-        let mut process3 = process.clone();
-        process3.set_company_id(CompanyID::new("zing"));
-        let res = consume(&user, &member, &company, id.clone(), resource.clone(), process3.clone(), Costs::new_with_labor("homemaker", 23), 8, Some("memo".into()), &now);
+        let mut state2 = state.clone();
+        state2.model2_mut().set_company_id(CompanyID::new("zing"));
+        let res = testfn(&state2);
         assert_eq!(res, Err(Error::Event(EventError::ProcessOwnerMismatch)));
 
         // a company that doesn't own a resource can't consume it
-        let mut resource3 = resource.clone();
-        resource3.inner_mut().set_primary_accountable(Some(CompanyID::new("ziggy").into()));
-        let res = consume(&user, &member, &company, id.clone(), resource3.clone(), process.clone(), Costs::new_with_labor("homemaker", 23), 8, Some("memo".into()), &now);
+        let mut state3 = state.clone();
+        state3.model_mut().inner_mut().set_primary_accountable(Some(CompanyID::new("ziggy").into()));
+        let res = testfn(&state3);
         assert_eq!(res, Err(Error::Event(EventError::ResourceOwnerMismatch)));
 
         // a company that doesn't have posession of a resource can't consume it
-        let mut resource4 = resource.clone();
-        resource4.set_in_custody_of(CompanyID::new("ziggy").into());
-        let res = consume(&user, &member, &company, id.clone(), resource4.clone(), process.clone(), Costs::new_with_labor("homemaker", 23), 8, Some("memo".into()), &now);
+        let mut state4 = state.clone();
+        state4.model_mut().set_in_custody_of(CompanyID::new("ziggy").into());
+        let res = testfn(&state4);
         assert_eq!(res, Err(Error::Event(EventError::ResourceCustodyMismatch)));
     }
 
@@ -447,22 +418,22 @@ mod tests {
     fn can_produce() {
         let now = util::time::now();
         let id = EventID::create();
-        let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
-        let user = make_user(&UserID::create(), None, &now);
+        let mut state = TestState::standard(vec![CompanyPermission::Produce], &now);
         let occupation_id = OccupationID::new("machinist");
-        let member = make_member_worker(&MemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
-        let resource = make_resource(&ResourceID::new("widget"), company.id(), &Measure::new(dec!(15), Unit::One), &Costs::new_with_labor("homemaker", 157), &now);
         let mut costs = Costs::new();
         costs.track_labor(occupation_id.clone(), dec!(42.2));
         costs.track_labor("homemaker", dec!(89.3));
-        let process = make_process(&ProcessID::create(), company.id(), "make widgets", &costs, &now);
+        let process = make_process(&ProcessID::create(), state.company().id(), "make widgets", &costs, &now);
+        let resource = make_resource(&ResourceID::new("widget"), state.company().id(), &Measure::new(dec!(15), Unit::One), &Costs::new_with_labor("homemaker", 157), &now);
+        state.model = Some(process);
+        state.model2 = Some(resource);
 
-        let res = produce(&user, &member, &company, id.clone(), process.clone(), resource.clone(), Costs::new_with_labor("homemaker", 23), 8, Some("memo".into()), &now);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
+        let testfn = |state: &TestState<Process, Resource>| {
+            produce(state.user(), state.member(), state.company(), id.clone(), state.model().clone(), state.model2().clone(), Costs::new_with_labor("homemaker", 23), 8, Some("memo".into()), &now)
+        };
+        test::standard_transaction_tests(&state, &testfn);
 
-        let mut member = member.clone();
-        member.set_permissions(vec![CompanyPermission::Produce]);
-        let mods = produce(&user, &member, &company, id.clone(), process.clone(), resource.clone(), Costs::new_with_labor("homemaker", 23), 8, Some("memo".into()), &now).unwrap().into_vec();
+        let mods = testfn(&state).unwrap().into_vec();
         assert_eq!(mods.len(), 3);
         let event = mods[0].clone().expect_op::<Event>(Op::Create).unwrap();
         let process2 = mods[1].clone().expect_op::<Process>(Op::Update).unwrap();
@@ -473,9 +444,9 @@ mod tests {
         assert_eq!(event.inner().has_point_in_time(), &Some(now.clone()));
         assert_eq!(event.inner().input_of(), &None);
         assert_eq!(event.inner().note(), &Some("memo".into()));
-        assert_eq!(event.inner().output_of(), &Some(process.id().clone()));
-        assert_eq!(event.inner().provider().clone(), company.agent_id());
-        assert_eq!(event.inner().receiver().clone(), company.agent_id());
+        assert_eq!(event.inner().output_of(), &Some(state.model().id().clone()));
+        assert_eq!(event.inner().provider().clone(), state.company().agent_id());
+        assert_eq!(event.inner().receiver().clone(), state.company().agent_id());
         assert_eq!(event.move_costs(), &Some(Costs::new_with_labor("homemaker", 23)));
         assert_eq!(event.active(), &true);
         assert_eq!(event.created(), &now);
@@ -484,47 +455,34 @@ mod tests {
         let mut costs2 = Costs::new();
         costs2.track_labor(occupation_id.clone(), dec!(42.2));
         costs2.track_labor("homemaker", dec!(89.3) - dec!(23));
-        assert_eq!(process2.id(), process.id());
-        assert_eq!(process2.company_id(), company.id());
+        assert_eq!(process2.id(), state.model().id());
+        assert_eq!(process2.company_id(), state.company().id());
         assert_eq!(process2.inner().name(), "make widgets");
         assert_eq!(process2.costs(), &costs2);
 
         let mut costs3 = Costs::new();
         costs3.track_labor("homemaker", dec!(157) + dec!(23));
-        assert_eq!(resource2.id(), resource.id());
+        assert_eq!(resource2.id(), state.model2().id());
         assert_eq!(resource2.inner().accounting_quantity(), &Some(Measure::new(dec!(23), Unit::One)));
         assert_eq!(resource2.inner().onhand_quantity(), &Some(Measure::new(dec!(23), Unit::One)));
         assert_eq!(resource2.costs(), &costs3);
 
-        let user2 = make_user(&UserID::create(), Some(vec![]), &now);
-        let res = produce(&user2, &member, &company, id.clone(), process.clone(), resource.clone(), Costs::new_with_labor("homemaker", 23), 8, Some("memo".into()), &now);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
-
-        let mut member2 = member.clone();
-        member2.set_permissions(vec![]);
-        let res = produce(&user, &member2, &company, id.clone(), process.clone(), resource.clone(), Costs::new_with_labor("homemaker", 23), 8, Some("memo".into()), &now);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
-
-        deleted_company_tester(company.clone(), &now, |company: Company| {
-            produce(&user, &member, &company, id.clone(), process.clone(), resource.clone(), Costs::new_with_labor("homemaker", 23), 8, Some("memo".into()), &now)
-        });
-
         // can't produce from a process you don't own
-        let mut process3 = process.clone();
-        process3.set_company_id(CompanyID::new("zing"));
-        let res = produce(&user, &member, &company, id.clone(), process3.clone(), resource.clone(), Costs::new_with_labor("homemaker", 23), 8, Some("memo".into()), &now);
+        let mut state2 = state.clone();
+        state2.model_mut().set_company_id(CompanyID::new("zing"));
+        let res = testfn(&state2);
         assert_eq!(res, Err(Error::Event(EventError::ProcessOwnerMismatch)));
 
         // a company that doesn't own a resource can't consume it
-        let mut resource3 = resource.clone();
-        resource3.inner_mut().set_primary_accountable(Some(CompanyID::new("ziggy").into()));
-        let res = produce(&user, &member, &company, id.clone(), process.clone(), resource3.clone(), Costs::new_with_labor("homemaker", 23), 8, Some("memo".into()), &now);
+        let mut state3 = state.clone();
+        state3.model2_mut().inner_mut().set_primary_accountable(Some(CompanyID::new("ziggy").into()));
+        let res = testfn(&state3);
         assert_eq!(res, Err(Error::Event(EventError::ResourceOwnerMismatch)));
 
         // a company that doesn't have posession of a resource can't consume it
-        let mut resource4 = resource.clone();
-        resource4.set_in_custody_of(CompanyID::new("ziggy").into());
-        let res = produce(&user, &member, &company, id.clone(), process.clone(), resource4.clone(), Costs::new_with_labor("homemaker", 23), 8, Some("memo".into()), &now);
+        let mut state4 = state.clone();
+        state4.model2_mut().set_in_custody_of(CompanyID::new("ziggy").into());
+        let res = testfn(&state4);
         assert_eq!(res, Err(Error::Event(EventError::ResourceCustodyMismatch)));
     }
 
@@ -532,22 +490,22 @@ mod tests {
     fn can_use() {
         let now = util::time::now();
         let id = EventID::create();
-        let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
-        let user = make_user(&UserID::create(), None, &now);
+        let mut state = TestState::standard(vec![CompanyPermission::Use], &now);
         let occupation_id = OccupationID::new("machinist");
-        let member = make_member_worker(&MemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
-        let resource = make_resource(&ResourceID::new("widget"), company.id(), &Measure::new(dec!(15), Unit::One), &Costs::new_with_labor("homemaker", 157), &now);
         let mut costs = Costs::new();
         costs.track_labor(occupation_id.clone(), dec!(42.2));
         costs.track_labor("homemaker", dec!(13.6));
-        let process = make_process(&ProcessID::create(), company.id(), "make widgets", &costs, &now);
+        let resource = make_resource(&ResourceID::new("widget"), state.company().id(), &Measure::new(dec!(15), Unit::One), &Costs::new_with_labor("homemaker", 157), &now);
+        let process = make_process(&ProcessID::create(), state.company().id(), "make widgets", &costs, &now);
+        state.model = Some(resource);
+        state.model2 = Some(process);
 
-        let res = useeee(&user, &member, &company, id.clone(), resource.clone(), process.clone(), Costs::new_with_labor("homemaker", dec!(0.3)), Some(Measure::new(8, Unit::Hour)), Some("memo".into()), &now);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
+        let testfn = |state: &TestState<Resource, Process>| {
+            useeee(state.user(), state.member(), state.company(), id.clone(), state.model().clone(), state.model2().clone(), Costs::new_with_labor("homemaker", dec!(0.3)), Some(Measure::new(8, Unit::Hour)), Some("memo".into()), &now)
+        };
+        test::standard_transaction_tests(&state, &testfn);
 
-        let mut member = member.clone();
-        member.set_permissions(vec![CompanyPermission::Use]);
-        let mods = useeee(&user, &member, &company, id.clone(), resource.clone(), process.clone(), Costs::new_with_labor("homemaker", dec!(0.3)), Some(Measure::new(8, Unit::Hour)), Some("memo".into()), &now).unwrap().into_vec();
+        let mods = testfn(&state).unwrap().into_vec();
         assert_eq!(mods.len(), 3);
         let event = mods[0].clone().expect_op::<Event>(Op::Create).unwrap();
         let process2 = mods[1].clone().expect_op::<Process>(Op::Update).unwrap();
@@ -556,10 +514,10 @@ mod tests {
         assert_eq!(event.id(), &id);
         assert_eq!(event.inner().agreed_in(), &None);
         assert_eq!(event.inner().has_point_in_time(), &Some(now.clone()));
-        assert_eq!(event.inner().input_of(), &Some(process.id().clone()));
+        assert_eq!(event.inner().input_of(), &Some(state.model2().id().clone()));
         assert_eq!(event.inner().note(), &Some("memo".into()));
-        assert_eq!(event.inner().provider().clone(), company.agent_id());
-        assert_eq!(event.inner().receiver().clone(), company.agent_id());
+        assert_eq!(event.inner().provider().clone(), state.company().agent_id());
+        assert_eq!(event.inner().receiver().clone(), state.company().agent_id());
         assert_eq!(event.move_costs(), &Some(Costs::new_with_labor("homemaker", dec!(0.3))));
         assert_eq!(event.active(), &true);
         assert_eq!(event.created(), &now);
@@ -568,47 +526,34 @@ mod tests {
         let mut costs2 = Costs::new();
         costs2.track_labor(occupation_id.clone(), dec!(42.2));
         costs2.track_labor("homemaker", dec!(0.3) + dec!(13.6));
-        assert_eq!(process2.id(), process.id());
-        assert_eq!(process2.company_id(), company.id());
+        assert_eq!(process2.id(), state.model2().id());
+        assert_eq!(process2.company_id(), state.company().id());
         assert_eq!(process2.inner().name(), "make widgets");
         assert_eq!(process2.costs(), &costs2);
 
         let mut costs3 = Costs::new();
         costs3.track_labor("homemaker", dec!(157) - dec!(0.3));
-        assert_eq!(resource2.id(), resource.id());
+        assert_eq!(resource2.id(), state.model().id());
         assert_eq!(resource2.inner().accounting_quantity(), &Some(Measure::new(dec!(15), Unit::One)));
         assert_eq!(resource2.inner().onhand_quantity(), &Some(Measure::new(dec!(15), Unit::One)));
         assert_eq!(resource2.costs(), &costs3);
 
-        let user2 = make_user(&UserID::create(), Some(vec![]), &now);
-        let res = useeee(&user2, &member, &company, id.clone(), resource.clone(), process.clone(), Costs::new_with_labor("homemaker", dec!(0.3)), Some(Measure::new(8, Unit::Hour)), Some("memo".into()), &now);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
-
-        let mut member2 = member.clone();
-        member2.set_permissions(vec![]);
-        let res = useeee(&user, &member2, &company, id.clone(), resource.clone(), process.clone(), Costs::new_with_labor("homemaker", dec!(0.3)), Some(Measure::new(8, Unit::Hour)), Some("memo".into()), &now);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
-
-        deleted_company_tester(company.clone(), &now, |company: Company| {
-            useeee(&user, &member, &company, id.clone(), resource.clone(), process.clone(), Costs::new_with_labor("homemaker", dec!(0.3)), Some(Measure::new(8, Unit::Hour)), Some("memo".into()), &now)
-        });
-
         // can't useeee into a process you don't own
-        let mut process3 = process.clone();
-        process3.set_company_id(CompanyID::new("zing"));
-        let res = useeee(&user, &member, &company, id.clone(), resource.clone(), process3.clone(), Costs::new_with_labor("homemaker", dec!(0.3)), Some(Measure::new(8, Unit::Hour)), Some("memo".into()), &now);
+        let mut state2 = state.clone();
+        state2.model2_mut().set_company_id(CompanyID::new("zing"));
+        let res = testfn(&state2);
         assert_eq!(res, Err(Error::Event(EventError::ProcessOwnerMismatch)));
 
         // a company that doesn't own a resource can't use it
-        let mut resource3 = resource.clone();
-        resource3.inner_mut().set_primary_accountable(Some(CompanyID::new("ziggy").into()));
-        let res = useeee(&user, &member, &company, id.clone(), resource3.clone(), process.clone(), Costs::new_with_labor("homemaker", dec!(0.3)), Some(Measure::new(8, Unit::Hour)), Some("memo".into()), &now);
+        let mut state3 = state.clone();
+        state3.model_mut().inner_mut().set_primary_accountable(Some(CompanyID::new("ziggy").into()));
+        let res = testfn(&state3);
         assert_eq!(res, Err(Error::Event(EventError::ResourceOwnerMismatch)));
 
         // a company that doesn't have posession of a resource can't use it
-        let mut resource4 = resource.clone();
-        resource4.set_in_custody_of(CompanyID::new("ziggy").into());
-        let res = useeee(&user, &member, &company, id.clone(), resource4.clone(), process.clone(), Costs::new_with_labor("homemaker", dec!(0.3)), Some(Measure::new(8, Unit::Hour)), Some("memo".into()), &now);
+        let mut state4 = state.clone();
+        state4.model_mut().set_in_custody_of(CompanyID::new("ziggy").into());
+        let res = testfn(&state4);
         assert_eq!(res, Err(Error::Event(EventError::ResourceCustodyMismatch)));
     }
 }

--- a/src/transactions/event/service.rs
+++ b/src/transactions/event/service.rs
@@ -17,7 +17,7 @@ use crate::{
         member::Member,
         lib::{
             agent::Agent,
-            basis_model::ActiveState,
+            basis_model::Model,
         },
         process::Process,
         user::User,

--- a/src/transactions/event/service.rs
+++ b/src/transactions/event/service.rs
@@ -89,15 +89,12 @@ mod tests {
         models::{
             agreement::AgreementID,
             company::CompanyID,
-            member::MemberID,
             event::{EventID, EventError},
             lib::agent::Agent,
             occupation::OccupationID,
             process::{Process, ProcessID},
-            testutils::{deleted_company_tester, make_agreement, make_user, make_company, make_member_worker, make_process},
-            user::UserID,
         },
-        util,
+        util::{self, test::{self, *}},
     };
     use rust_decimal_macros::*;
 
@@ -105,22 +102,29 @@ mod tests {
     fn can_deliver_service() {
         let now = util::time::now();
         let id = EventID::create();
-        let company_from = make_company(&CompanyID::create(), "jerry's planks", &now);
+        let mut state = TestState::standard(vec![CompanyPermission::DeliverService], &now);
+        let company_from = state.company().clone();
         let company_to = make_company(&CompanyID::create(), "jinkey's skateboards", &now);
         let agreement = make_agreement(&AgreementID::create(), &vec![company_from.agent_id(), company_to.agent_id()], "order 1234", "gotta make some planks", &now);
         let agreed_in: Url = "https://legalzoom.com/my-dad-is-suing-your-dad-the-agreement".parse().unwrap();
-        let user = make_user(&UserID::create(), None, &now);
         let occupation_id = OccupationID::new("lawyer");
-        let member = make_member_worker(&MemberID::create(), user.id(), company_from.id(), &occupation_id, vec![], &now);
         let process_from = make_process(&ProcessID::create(), company_from.id(), "various lawyerings", &Costs::new_with_labor(occupation_id.clone(), dec!(177.25)), &now);
         let process_to = make_process(&ProcessID::create(), company_to.id(), "employee legal agreement drafting", &Costs::new_with_labor(occupation_id.clone(), dec!(804)), &now);
+        state.model = Some(process_from);
+        state.model2 = Some(process_to);
 
-        let res = deliver_service(&user, &member, &company_from, &company_to, &agreement, id.clone(), process_from.clone(), process_to.clone(), Costs::new_with_labor("lawyer", 100), None, None, &now);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
+        let testfn_inner = |state: &TestState<Process, Process>, company_from: &Company, company_to: &Company, agreement: &Agreement| {
+            deliver_service(state.user(), state.member(), company_from, company_to, agreement, id.clone(), state.model().clone(), state.model2().clone(), Costs::new_with_labor("lawyer", 100), Some(agreed_in.clone()), Some("making planks lol".into()), &now)
+        };
+        let testfn_from = |state: &TestState<Process, Process>| {
+            testfn_inner(state, state.company(), &company_to, &agreement)
+        };
+        let testfn_to = |state: &TestState<Process, Process>| {
+            testfn_inner(state, &company_from, state.company(), &agreement)
+        };
+        test::standard_transaction_tests(&state, &testfn_from);
 
-        let mut member = member.clone();
-        member.set_permissions(vec![CompanyPermission::DeliverService]);
-        let mods = deliver_service(&user, &member, &company_from, &company_to, &agreement, id.clone(), process_from.clone(), process_to.clone(), Costs::new_with_labor("lawyer", 100), Some(agreed_in.clone()), Some("making planks lol".into()), &now).unwrap().into_vec();
+        let mods = testfn_from(&state).unwrap().into_vec();
         assert_eq!(mods.len(), 3);
         let event = mods[0].clone().expect_op::<Event>(Op::Create).unwrap();
         let process_from2 = mods[1].clone().expect_op::<Process>(Op::Update).unwrap();
@@ -129,9 +133,9 @@ mod tests {
         assert_eq!(event.id(), &id);
         assert_eq!(event.inner().agreed_in(), &Some(agreed_in.clone()));
         assert_eq!(event.inner().has_point_in_time(), &Some(now.clone()));
-        assert_eq!(event.inner().input_of(), &Some(process_to.id().clone()));
+        assert_eq!(event.inner().input_of(), &Some(state.model2().id().clone()));
         assert_eq!(event.inner().note(), &Some("making planks lol".into()));
-        assert_eq!(event.inner().output_of(), &Some(process_from.id().clone()));
+        assert_eq!(event.inner().output_of(), &Some(state.model().id().clone()));
         assert_eq!(event.inner().provider().clone(), company_from.agent_id());
         assert_eq!(event.inner().realization_of(), &Some(agreement.id().clone()));
         assert_eq!(event.inner().receiver().clone(), company_to.agent_id());
@@ -143,49 +147,37 @@ mod tests {
 
         let mut costs2 = Costs::new();
         costs2.track_labor("lawyer", dec!(177.25) - dec!(100));
-        assert_eq!(process_from2.id(), process_from.id());
+        assert_eq!(process_from2.id(), state.model().id());
         assert_eq!(process_from2.company_id(), company_from.id());
         assert_eq!(process_from2.costs(), &costs2);
 
         let mut costs2 = Costs::new();
         costs2.track_labor("lawyer", dec!(804) + dec!(100));
-        assert_eq!(process_to2.id(), process_to.id());
+        assert_eq!(process_to2.id(), state.model2().id());
         assert_eq!(process_to2.company_id(), company_to.id());
         assert_eq!(process_to2.costs(), &costs2);
 
-        let user2 = make_user(&UserID::create(), Some(vec![]), &now);
-        let res = deliver_service(&user2, &member, &company_from, &company_to, &agreement, id.clone(), process_from.clone(), process_to.clone(), Costs::new_with_labor("lawyer", 100), None, None, &now);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
-
-        let mut member2 = member.clone();
-        member2.set_permissions(vec![]);
-        let res = deliver_service(&user, &member2, &company_from, &company_to, &agreement, id.clone(), process_from.clone(), process_to.clone(), Costs::new_with_labor("lawyer", 100), None, None, &now);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
-
-        deleted_company_tester(company_from.clone(), &now, |company_from: Company| {
-            deliver_service(&user, &member, &company_from, &company_to, &agreement, id.clone(), process_from.clone(), process_to.clone(), Costs::new_with_labor("lawyer", 100), None, None, &now)
-        });
-        deleted_company_tester(company_to.clone(), &now, |company_to: Company| {
-            deliver_service(&user, &member, &company_from, &company_to, &agreement, id.clone(), process_from.clone(), process_to.clone(), Costs::new_with_labor("lawyer", 100), None, None, &now)
-        });
-
         // can't move costs from a process you don't own
-        let mut process_from3 = process_from.clone();
-        process_from3.set_company_id(CompanyID::new("zing").into());
-        let res = deliver_service(&user, &member, &company_from, &company_to, &agreement, id.clone(), process_from3.clone(), process_to.clone(), Costs::new_with_labor("lawyer", 100), None, None, &now);
+        let mut state2 = state.clone();
+        state2.model_mut().set_company_id(CompanyID::new("zing").into());
+        let res = testfn_from(&state2);
         assert_eq!(res, Err(Error::Event(EventError::ProcessOwnerMismatch)));
 
         // can't move costs into a process company_to doesnt own
-        let mut process_to3 = process_to.clone();
-        process_to3.set_company_id(CompanyID::new("zing").into());
-        let res = deliver_service(&user, &member, &company_from, &company_to, &agreement, id.clone(), process_from.clone(), process_to3.clone(), Costs::new_with_labor("lawyer", 100), None, None, &now);
+        let mut state3 = state.clone();
+        state3.model2_mut().set_company_id(CompanyID::new("zing").into());
+        let res = testfn_from(&state3);
         assert_eq!(res, Err(Error::Event(EventError::ProcessOwnerMismatch)));
 
         // can't add an event unless both parties are participants in the agreement
         let mut agreement2 = agreement.clone();
         agreement2.set_participants(vec![company_to.agent_id()]);
-        let res = deliver_service(&user, &member, &company_from, &company_to, &agreement2, id.clone(), process_from.clone(), process_to.clone(), Costs::new_with_labor("lawyer", 100), None, None, &now);
+        let res = testfn_inner(&state, &company_from, &company_to, &agreement2);
         assert_eq!(res, Err(Error::InsufficientPrivileges));
+
+        let mut state5 = state.clone();
+        state5.company = Some(company_to.clone());
+        test::deleted_company_tester(&state5, &testfn_to);
     }
 }
 

--- a/src/transactions/event/transfer.rs
+++ b/src/transactions/event/transfer.rs
@@ -17,7 +17,7 @@ use crate::{
         event::{Event, EventID, EventProcessState},
         lib::{
             agent::Agent,
-            basis_model::ActiveState,
+            basis_model::Model,
         },
         company::{Company, Permission as CompanyPermission},
         member::Member,

--- a/src/transactions/event/transfer.rs
+++ b/src/transactions/event/transfer.rs
@@ -103,7 +103,7 @@ pub fn transfer<T: Into<NumericUnion>>(caller: &User, member: &Member, company_f
 /// another, moving a set of costs with it.
 pub fn transfer_all_rights<T: Into<NumericUnion>>(caller: &User, member: &Member, company_from: &Company, company_to: &Company, agreement: &Agreement, id: EventID, resource_from: Resource, resource_to: ResourceMover, move_costs: Costs, move_measure: T, agreed_in: Option<Url>, note: Option<String>, now: &DateTime<Utc>) -> Result<Modifications> {
     caller.access_check(Permission::EventCreate)?;
-    member.access_check(caller.id(), company_from.id(), CompanyPermission::Transfer)?;
+    member.access_check(caller.id(), company_from.id(), CompanyPermission::TransferAllRights)?;
     if !company_from.is_active() {
         Err(Error::ObjectIsInactive("company".into()))?;
     }
@@ -172,7 +172,7 @@ pub fn transfer_all_rights<T: Into<NumericUnion>>(caller: &User, member: &Member
 /// another, moving a set of costs with it.
 pub fn transfer_custody<T: Into<NumericUnion>>(caller: &User, member: &Member, company_from: &Company, company_to: &Company, agreement: &Agreement, id: EventID, resource_from: Resource, resource_to: ResourceMover, move_costs: Costs, move_measure: T, agreed_in: Option<Url>, note: Option<String>, now: &DateTime<Utc>) -> Result<Modifications> {
     caller.access_check(Permission::EventCreate)?;
-    member.access_check(caller.id(), company_from.id(), CompanyPermission::Transfer)?;
+    member.access_check(caller.id(), company_from.id(), CompanyPermission::TransferCustody)?;
     if !company_from.is_active() {
         Err(Error::ObjectIsInactive("company".into()))?;
     }
@@ -244,15 +244,11 @@ mod tests {
         models::{
             agreement::AgreementID,
             company::CompanyID,
-            member::MemberID,
             event::{EventID, EventError},
             lib::agent::Agent,
-            occupation::OccupationID,
             resource::ResourceID,
-            testutils::{deleted_company_tester, make_agreement, make_user, make_company, make_member_worker, make_resource},
-            user::UserID,
         },
-        util,
+        util::{self, test::{self, *}},
     };
     use om2::Unit;
     use rust_decimal_macros::*;
@@ -261,23 +257,33 @@ mod tests {
     fn can_transfer() {
         let now = util::time::now();
         let id = EventID::create();
-        let company = make_company(&CompanyID::create(), "jerry's planks", &now);
-        let company2 = make_company(&CompanyID::create(), "jinkey's skateboards", &now);
-        let agreement = make_agreement(&AgreementID::create(), &vec![company.agent_id(), company2.agent_id()], "order 1234", "gotta get some planks", &now);
+        let mut state = TestState::standard(vec![CompanyPermission::Transfer], &now);
+        let company_from = state.company().clone();
+        let company_to = make_company(&CompanyID::create(), "jinkey's skateboards", &now);
+        let agreement = make_agreement(&AgreementID::create(), &vec![company_from.agent_id(), company_to.agent_id()], "order 1234", "gotta get some planks", &now);
         let agreed_in: Url = "https://legalzoom.com/standard-boilerplate-hereto-notwithstanding-each-of-them-damage-to-the-hood-ornament-alone".parse().unwrap();
-        let user = make_user(&UserID::create(), None, &now);
-        let occupation_id = OccupationID::new("machinist");
-        let member = make_member_worker(&MemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
-        let resource = make_resource(&ResourceID::new("plank"), company.id(), &Measure::new(dec!(15), Unit::One), &Costs::new_with_labor("homemaker", 157), &now);
-        let resource_to = make_resource(&ResourceID::new("plank"), company2.id(), &Measure::new(dec!(3), Unit::One), &Costs::new_with_labor("homemaker", 2), &now);
+        let resource_from = make_resource(&ResourceID::new("plank"), company_from.id(), &Measure::new(dec!(15), Unit::One), &Costs::new_with_labor("homemaker", 157), &now);
+        let resource_to = make_resource(&ResourceID::new("plank"), company_to.id(), &Measure::new(dec!(3), Unit::One), &Costs::new_with_labor("homemaker", 2), &now);
+        state.model = Some(resource_from);
+        state.model2 = Some(resource_to);
 
-        let res = transfer(&user, &member, &company, &company2, &agreement, id.clone(), resource.clone(), ResourceMover::Update(resource_to.clone()), Costs::new_with_labor("homemaker", 23), 8, Some(agreed_in.clone()), Some("giving jinkey some post-capitalist planks".into()), &now);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
+        let testfn_inner = |state: &TestState<Resource, Resource>, company_from: &Company, company_to: &Company, agreement: &Agreement, resource_to: ResourceMover| {
+            transfer(state.user(), state.member(), &company_from, &company_to, &agreement, id.clone(), state.model().clone(), resource_to, Costs::new_with_labor("homemaker", 23), 8, Some(agreed_in.clone()), Some("giving jinkey some post-capitalist planks".into()), &now)
+        };
+        let testfn_update = |state: &TestState<Resource, Resource>| {
+            testfn_inner(state, state.company(), &company_to, &agreement, ResourceMover::Update(state.model2().clone()))
+        };
+        let testfn_create = |state: &TestState<Resource, Resource>| {
+            testfn_inner(state, state.company(), &company_to, &agreement, ResourceMover::Create(state.model2().id().clone()))
+        };
+        let testfn_update_to = |state: &TestState<Resource, Resource>| {
+            testfn_inner(state, &company_from, state.company(), &agreement, ResourceMover::Update(state.model2().clone()))
+        };
+        test::standard_transaction_tests(&state, &testfn_update);
+        test::standard_transaction_tests(&state, &testfn_create);
 
-        let mut member = member.clone();
-        member.set_permissions(vec![CompanyPermission::Transfer]);
         // test ResourceMover::Update()
-        let mods = transfer(&user, &member, &company, &company2, &agreement, id.clone(), resource.clone(), ResourceMover::Update(resource_to.clone()), Costs::new_with_labor("homemaker", 23), 8, Some(agreed_in.clone()), Some("giving jinkey some post-capitalist planks".into()), &now).unwrap().into_vec();
+        let mods = testfn_update(&state).unwrap().into_vec();
         assert_eq!(mods.len(), 3);
         let event = mods[0].clone().expect_op::<Event>(Op::Create).unwrap();
         let resource2 = mods[1].clone().expect_op::<Resource>(Op::Update).unwrap();
@@ -288,9 +294,9 @@ mod tests {
         assert_eq!(event.inner().has_point_in_time(), &Some(now.clone()));
         assert_eq!(event.inner().input_of(), &None);
         assert_eq!(event.inner().note(), &Some("giving jinkey some post-capitalist planks".into()));
-        assert_eq!(event.inner().provider().clone(), company.agent_id());
+        assert_eq!(event.inner().provider().clone(), company_from.agent_id());
         assert_eq!(event.inner().realization_of(), &Some(agreement.id().clone()));
-        assert_eq!(event.inner().receiver().clone(), company2.agent_id());
+        assert_eq!(event.inner().receiver().clone(), company_to.agent_id());
         assert_eq!(event.inner().resource_quantity(), &Some(Measure::new(8, Unit::One)));
         assert_eq!(event.move_costs(), &Some(Costs::new_with_labor("homemaker", 23)));
         assert_eq!(event.active(), &true);
@@ -299,36 +305,36 @@ mod tests {
 
         let mut costs2 = Costs::new();
         costs2.track_labor("homemaker", dec!(157) - dec!(23));
-        assert_eq!(resource2.id(), resource.id());
-        assert_eq!(resource2.inner().primary_accountable(), &Some(company.agent_id()));
+        assert_eq!(resource2.id(), state.model().id());
+        assert_eq!(resource2.inner().primary_accountable(), &Some(company_from.agent_id()));
         assert_eq!(resource2.inner().accounting_quantity(), &Some(Measure::new(dec!(15) - dec!(8), Unit::One)));
         assert_eq!(resource2.inner().onhand_quantity(), &Some(Measure::new(dec!(15) - dec!(8), Unit::One)));
-        assert_eq!(resource2.in_custody_of(), &company.agent_id());
+        assert_eq!(resource2.in_custody_of(), &company_from.agent_id());
         assert_eq!(resource2.costs(), &costs2);
 
         let mut costs2 = Costs::new();
         costs2.track_labor("homemaker", dec!(23) + dec!(2));
-        assert_eq!(resource_to2.id(), resource_to.id());
-        assert_eq!(resource_to2.inner().primary_accountable(), &Some(company2.agent_id()));
+        assert_eq!(resource_to2.id(), state.model2().id());
+        assert_eq!(resource_to2.inner().primary_accountable(), &Some(company_to.agent_id()));
         assert_eq!(resource_to2.inner().accounting_quantity(), &Some(Measure::new(dec!(8) + dec!(3), Unit::One)));
         assert_eq!(resource_to2.inner().onhand_quantity(), &Some(Measure::new(dec!(8) + dec!(3), Unit::One)));
-        assert_eq!(resource_to2.in_custody_of(), &company2.agent_id());
+        assert_eq!(resource_to2.in_custody_of(), &company_to.agent_id());
         assert_eq!(resource_to2.costs(), &costs2);
 
         // test ResourceMover::Create()
-        let mods = transfer(&user, &member, &company, &company2, &agreement, id.clone(), resource.clone(), ResourceMover::Create(resource_to.id().clone()), Costs::new_with_labor("homemaker", 23), 8, None, None, &now).unwrap().into_vec();
+        let mods = testfn_create(&state).unwrap().into_vec();
         assert_eq!(mods.len(), 3);
         let event = mods[0].clone().expect_op::<Event>(Op::Create).unwrap();
         let resource3 = mods[1].clone().expect_op::<Resource>(Op::Update).unwrap();
         let resource_created = mods[2].clone().expect_op::<Resource>(Op::Create).unwrap();
 
         assert_eq!(event.id(), &id);
-        assert_eq!(event.inner().agreed_in(), &None);
+        assert_eq!(event.inner().agreed_in(), &Some(agreed_in.clone()));
         assert_eq!(event.inner().has_point_in_time(), &Some(now.clone()));
         assert_eq!(event.inner().input_of(), &None);
-        assert_eq!(event.inner().note(), &None);
-        assert_eq!(event.inner().provider().clone(), company.agent_id());
-        assert_eq!(event.inner().receiver().clone(), company2.agent_id());
+        assert_eq!(event.inner().note(), &Some("giving jinkey some post-capitalist planks".into()));
+        assert_eq!(event.inner().provider().clone(), company_from.agent_id());
+        assert_eq!(event.inner().receiver().clone(), company_to.agent_id());
         assert_eq!(event.inner().resource_quantity(), &Some(Measure::new(8, Unit::One)));
         assert_eq!(event.move_costs(), &Some(Costs::new_with_labor("homemaker", 23)));
         assert_eq!(event.active(), &true);
@@ -337,84 +343,88 @@ mod tests {
 
         let mut costs2 = Costs::new();
         costs2.track_labor("homemaker", dec!(157) - dec!(23));
-        assert_eq!(resource3.id(), resource.id());
-        assert_eq!(resource3.inner().primary_accountable(), &Some(company.agent_id()));
+        assert_eq!(resource3.id(), state.model().id());
+        assert_eq!(resource3.inner().primary_accountable(), &Some(company_from.agent_id()));
         assert_eq!(resource3.inner().accounting_quantity(), &Some(Measure::new(dec!(15) - dec!(8), Unit::One)));
         assert_eq!(resource3.inner().onhand_quantity(), &Some(Measure::new(dec!(15) - dec!(8), Unit::One)));
-        assert_eq!(resource3.in_custody_of(), &company.agent_id());
+        assert_eq!(resource3.in_custody_of(), &company_from.agent_id());
         assert_eq!(resource3.costs(), &costs2);
 
         let mut costs2 = Costs::new();
         costs2.track_labor("homemaker", dec!(23));
-        assert_eq!(resource_created.id(), resource_to.id());
-        assert_eq!(resource_created.inner().primary_accountable(), &Some(company2.agent_id()));
+        assert_eq!(resource_created.id(), state.model2().id());
+        assert_eq!(resource_created.inner().primary_accountable(), &Some(company_to.agent_id()));
         assert_eq!(resource_created.inner().accounting_quantity(), &Some(Measure::new(dec!(8), Unit::One)));
         assert_eq!(resource_created.inner().onhand_quantity(), &Some(Measure::new(dec!(8), Unit::One)));
-        assert_eq!(resource_created.in_custody_of(), &company2.agent_id());
+        assert_eq!(resource_created.in_custody_of(), &company_to.agent_id());
         assert_eq!(resource_created.costs(), &costs2);
 
-        let user2 = make_user(&UserID::create(), Some(vec![]), &now);
-        let res = transfer(&user2, &member, &company, &company2, &agreement, id.clone(), resource.clone(), ResourceMover::Update(resource_to.clone()), Costs::new_with_labor("homemaker", 23), 8, None, None, &now);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
-
-        let mut member2 = member.clone();
-        member2.set_permissions(vec![]);
-        let res = transfer(&user, &member2, &company, &company2, &agreement, id.clone(), resource.clone(), ResourceMover::Update(resource_to.clone()), Costs::new_with_labor("homemaker", 23), 8, None, None, &now);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
-
-        deleted_company_tester(company.clone(), &now, |company: Company| {
-            transfer(&user, &member, &company, &company2, &agreement, id.clone(), resource.clone(), ResourceMover::Update(resource_to.clone()), Costs::new_with_labor("homemaker", 23), 8, None, None, &now)
-        });
-        deleted_company_tester(company2.clone(), &now, |company_to: Company| {
-            transfer(&user, &member, &company, &company_to, &agreement, id.clone(), resource.clone(), ResourceMover::Update(resource_to.clone()), Costs::new_with_labor("homemaker", 23), 8, None, None, &now)
-        });
-
         // can't transfer into a resource you don't own
-        let mut resource_to3 = resource_to.clone();
-        resource_to3.inner_mut().set_primary_accountable(Some(CompanyID::new("zing").into()));
-        let res = transfer(&user, &member, &company, &company2, &agreement, id.clone(), resource.clone(), ResourceMover::Update(resource_to3.clone()), Costs::new_with_labor("homemaker", 23), 8, None, None, &now);
+        let mut state2 = state.clone();
+        state2.model2_mut().inner_mut().set_primary_accountable(Some(CompanyID::new("zing").into()));
+        let res = testfn_update(&state2);
         assert_eq!(res, Err(Error::Event(EventError::ResourceOwnerMismatch)));
 
         // a company that doesn't own a resource can't transfer it OBVIOUSLY
-        let mut resource3 = resource.clone();
-        resource3.inner_mut().set_primary_accountable(Some(CompanyID::new("ziggy").into()));
-        let res = transfer(&user, &member, &company, &company2, &agreement, id.clone(), resource3.clone(), ResourceMover::Update(resource_to.clone()), Costs::new_with_labor("homemaker", 23), 8, None, None, &now);
+        let mut state3 = state.clone();
+        state3.model_mut().inner_mut().set_primary_accountable(Some(CompanyID::new("ziggy").into()));
+        let res = testfn_update(&state3);
+        assert_eq!(res, Err(Error::Event(EventError::ResourceOwnerMismatch)));
+        let res = testfn_create(&state3);
         assert_eq!(res, Err(Error::Event(EventError::ResourceOwnerMismatch)));
 
         // a company that doesn't have posession of a resource can't transfer it
-        let mut resource4 = resource.clone();
-        resource4.set_in_custody_of(CompanyID::new("ziggy").into());
-        let res = transfer(&user, &member, &company, &company2, &agreement, id.clone(), resource4.clone(), ResourceMover::Update(resource_to.clone()), Costs::new_with_labor("homemaker", 23), 8, None, None, &now);
+        let mut state4 = state.clone();
+        state4.model_mut().set_in_custody_of(CompanyID::new("ziggy").into());
+        let res = testfn_update(&state4);
+        assert_eq!(res, Err(Error::Event(EventError::ResourceCustodyMismatch)));
+        let res = testfn_create(&state4);
         assert_eq!(res, Err(Error::Event(EventError::ResourceCustodyMismatch)));
 
         // can't add an event unless both parties are participants in the agreement
         let mut agreement2 = agreement.clone();
-        agreement2.set_participants(vec![company2.agent_id()]);
-        let res = transfer(&user, &member, &company, &company2, &agreement2, id.clone(), resource.clone(), ResourceMover::Update(resource_to.clone()), Costs::new_with_labor("homemaker", 23), 8, None, None, &now);
+        agreement2.set_participants(vec![company_to.agent_id()]);
+        let res = testfn_inner(&state, &company_from, &company_to, &agreement2, ResourceMover::Update(state.model2().clone()));
         assert_eq!(res, Err(Error::InsufficientPrivileges));
+        let res = testfn_inner(&state, &company_from, &company_to, &agreement2, ResourceMover::Create(state.model2().id().clone()));
+        assert_eq!(res, Err(Error::InsufficientPrivileges));
+
+        let mut state5 = state.clone();
+        state5.company = Some(company_to.clone());
+        test::deleted_company_tester(&state5, &testfn_update_to);
     }
 
     #[test]
     fn can_transfer_all_rights() {
         let now = util::time::now();
         let id = EventID::create();
-        let company = make_company(&CompanyID::create(), "jerry's planks", &now);
-        let company2 = make_company(&CompanyID::create(), "jinkey's skateboards", &now);
-        let agreement = make_agreement(&AgreementID::create(), &vec![company.agent_id(), company2.agent_id()], "order 1234", "gotta get some planks", &now);
+        let mut state = TestState::standard(vec![CompanyPermission::TransferAllRights], &now);
+        let company_from = state.company().clone();
+        let company_to = make_company(&CompanyID::create(), "jinkey's skateboards", &now);
+        let agreement = make_agreement(&AgreementID::create(), &vec![company_from.agent_id(), company_to.agent_id()], "order 1234", "gotta get some planks", &now);
         let agreed_in: Url = "https://legalzoom.com/is-it-too-much-to-ask-for-todays-pedestrian-to-wear-at-least-one-piece-of-reflective-clothing".parse().unwrap();
-        let user = make_user(&UserID::create(), None, &now);
-        let occupation_id = OccupationID::new("machinist");
-        let member = make_member_worker(&MemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
-        let resource = make_resource(&ResourceID::new("plank"), company.id(), &Measure::new(dec!(15), Unit::One), &Costs::new_with_labor("homemaker", 157), &now);
-        let resource_to = make_resource(&ResourceID::new("plank"), company2.id(), &Measure::new(dec!(3), Unit::One), &Costs::new_with_labor("homemaker", 2), &now);
+        let resource_from = make_resource(&ResourceID::new("plank"), company_from.id(), &Measure::new(dec!(15), Unit::One), &Costs::new_with_labor("homemaker", 157), &now);
+        let resource_to = make_resource(&ResourceID::new("plank"), company_to.id(), &Measure::new(dec!(3), Unit::One), &Costs::new_with_labor("homemaker", 2), &now);
+        state.model = Some(resource_from);
+        state.model2 = Some(resource_to);
 
-        let res = transfer_all_rights(&user, &member, &company, &company2, &agreement, id.clone(), resource.clone(), ResourceMover::Update(resource_to.clone()), Costs::new_with_labor("homemaker", 23), 8, None, None, &now);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
+        let testfn_inner = |state: &TestState<Resource, Resource>, company_from: &Company, company_to: &Company, agreement: &Agreement, resource_to: ResourceMover| {
+            transfer_all_rights(state.user(), state.member(), &company_from, &company_to, &agreement, id.clone(), state.model().clone(), resource_to, Costs::new_with_labor("homemaker", 23), 8, Some(agreed_in.clone()), Some("note blah blah".into()), &now)
+        };
+        let testfn_update = |state: &TestState<Resource, Resource>| {
+            testfn_inner(state, state.company(), &company_to, &agreement, ResourceMover::Update(state.model2().clone()))
+        };
+        let testfn_create = |state: &TestState<Resource, Resource>| {
+            testfn_inner(state, state.company(), &company_to, &agreement, ResourceMover::Create(state.model2().id().clone()))
+        };
+        let testfn_update_to = |state: &TestState<Resource, Resource>| {
+            testfn_inner(state, &company_from, state.company(), &agreement, ResourceMover::Update(state.model2().clone()))
+        };
+        test::standard_transaction_tests(&state, &testfn_update);
+        test::standard_transaction_tests(&state, &testfn_create);
 
-        let mut member = member.clone();
-        member.set_permissions(vec![CompanyPermission::Transfer]);
         // test ResourceMover::Update()
-        let mods = transfer_all_rights(&user, &member, &company, &company2, &agreement, id.clone(), resource.clone(), ResourceMover::Update(resource_to.clone()), Costs::new_with_labor("homemaker", 23), 8, Some(agreed_in.clone()), Some("note blah blah".into()), &now).unwrap().into_vec();
+        let mods = testfn_update(&state).unwrap().into_vec();
         assert_eq!(mods.len(), 3);
         let event = mods[0].clone().expect_op::<Event>(Op::Create).unwrap();
         let resource2 = mods[1].clone().expect_op::<Resource>(Op::Update).unwrap();
@@ -425,9 +435,9 @@ mod tests {
         assert_eq!(event.inner().has_point_in_time(), &Some(now.clone()));
         assert_eq!(event.inner().input_of(), &None);
         assert_eq!(event.inner().note(), &Some("note blah blah".into()));
-        assert_eq!(event.inner().provider().clone(), company.agent_id());
+        assert_eq!(event.inner().provider().clone(), company_from.agent_id());
         assert_eq!(event.inner().realization_of(), &Some(agreement.id().clone()));
-        assert_eq!(event.inner().receiver().clone(), company2.agent_id());
+        assert_eq!(event.inner().receiver().clone(), company_to.agent_id());
         assert_eq!(event.inner().resource_quantity(), &Some(Measure::new(8, Unit::One)));
         assert_eq!(event.move_costs(), &Some(Costs::new_with_labor("homemaker", 23)));
         assert_eq!(event.active(), &true);
@@ -436,35 +446,36 @@ mod tests {
 
         let mut costs2 = Costs::new();
         costs2.track_labor("homemaker", dec!(157) - dec!(23));
-        assert_eq!(resource2.id(), resource.id());
-        assert_eq!(resource2.inner().primary_accountable(), &Some(company.agent_id()));
+        assert_eq!(resource2.id(), state.model().id());
+        assert_eq!(resource2.inner().primary_accountable(), &Some(company_from.agent_id()));
         assert_eq!(resource2.inner().accounting_quantity(), &Some(Measure::new(dec!(15) - dec!(8), Unit::One)));
         assert_eq!(resource2.inner().onhand_quantity(), &Some(Measure::new(dec!(15), Unit::One)));
-        assert_eq!(resource2.in_custody_of(), &company.agent_id());
+        assert_eq!(resource2.in_custody_of(), &company_from.agent_id());
         assert_eq!(resource2.costs(), &costs2);
 
         let mut costs2 = Costs::new();
         costs2.track_labor("homemaker", dec!(23) + dec!(2));
-        assert_eq!(resource_to2.id(), resource_to.id());
-        assert_eq!(resource_to2.inner().primary_accountable(), &Some(company2.agent_id()));
+        assert_eq!(resource_to2.id(), state.model2().id());
+        assert_eq!(resource_to2.inner().primary_accountable(), &Some(company_to.agent_id()));
         assert_eq!(resource_to2.inner().accounting_quantity(), &Some(Measure::new(dec!(8) + dec!(3), Unit::One)));
         assert_eq!(resource_to2.inner().onhand_quantity(), &Some(Measure::new(dec!(3), Unit::One)));
-        assert_eq!(resource_to2.in_custody_of(), &company2.agent_id());
+        assert_eq!(resource_to2.in_custody_of(), &company_to.agent_id());
         assert_eq!(resource_to2.costs(), &costs2);
 
         // test ResourceMover::Create()
-        let mods = transfer_all_rights(&user, &member, &company, &company2, &agreement, id.clone(), resource.clone(), ResourceMover::Create(resource_to.id().clone()), Costs::new_with_labor("homemaker", 23), 8, None, None, &now).unwrap().into_vec();
+        let mods = testfn_create(&state).unwrap().into_vec();
         assert_eq!(mods.len(), 3);
         let event = mods[0].clone().expect_op::<Event>(Op::Create).unwrap();
         let resource3 = mods[1].clone().expect_op::<Resource>(Op::Update).unwrap();
         let resource_created = mods[2].clone().expect_op::<Resource>(Op::Create).unwrap();
 
         assert_eq!(event.id(), &id);
-        assert_eq!(event.inner().agreed_in(), &None);
+        assert_eq!(event.inner().agreed_in(), &Some(agreed_in.clone()));
         assert_eq!(event.inner().has_point_in_time(), &Some(now.clone()));
         assert_eq!(event.inner().input_of(), &None);
-        assert_eq!(event.inner().provider().clone(), company.agent_id());
-        assert_eq!(event.inner().receiver().clone(), company2.agent_id());
+        assert_eq!(event.inner().note(), &Some("note blah blah".into()));
+        assert_eq!(event.inner().provider().clone(), company_from.agent_id());
+        assert_eq!(event.inner().receiver().clone(), company_to.agent_id());
         assert_eq!(event.inner().resource_quantity(), &Some(Measure::new(8, Unit::One)));
         assert_eq!(event.move_costs(), &Some(Costs::new_with_labor("homemaker", 23)));
         assert_eq!(event.active(), &true);
@@ -473,78 +484,80 @@ mod tests {
 
         let mut costs2 = Costs::new();
         costs2.track_labor("homemaker", dec!(157) - dec!(23));
-        assert_eq!(resource3.id(), resource.id());
-        assert_eq!(resource3.inner().primary_accountable(), &Some(company.agent_id()));
+        assert_eq!(resource3.id(), state.model().id());
+        assert_eq!(resource3.inner().primary_accountable(), &Some(company_from.agent_id()));
         assert_eq!(resource3.inner().accounting_quantity(), &Some(Measure::new(dec!(15) - dec!(8), Unit::One)));
         assert_eq!(resource3.inner().onhand_quantity(), &Some(Measure::new(dec!(15), Unit::One)));
-        assert_eq!(resource3.in_custody_of(), &company.agent_id());
+        assert_eq!(resource3.in_custody_of(), &company_from.agent_id());
         assert_eq!(resource3.costs(), &costs2);
 
         let mut costs2 = Costs::new();
         costs2.track_labor("homemaker", dec!(23));
-        assert_eq!(resource_created.id(), resource_to.id());
-        assert_eq!(resource_created.inner().primary_accountable(), &Some(company2.agent_id()));
+        assert_eq!(resource_created.id(), state.model2().id());
+        assert_eq!(resource_created.inner().primary_accountable(), &Some(company_to.agent_id()));
         assert_eq!(resource_created.inner().accounting_quantity(), &Some(Measure::new(dec!(8), Unit::One)));
         assert_eq!(resource_created.inner().onhand_quantity(), &Some(Measure::new(dec!(0), Unit::One)));
-        assert_eq!(resource_created.in_custody_of(), &company.agent_id());
+        assert_eq!(resource_created.in_custody_of(), &company_from.agent_id());
         assert_eq!(resource_created.costs(), &costs2);
 
-        let user2 = make_user(&UserID::create(), Some(vec![]), &now);
-        let res = transfer_all_rights(&user2, &member, &company, &company2, &agreement, id.clone(), resource.clone(), ResourceMover::Update(resource_to.clone()), Costs::new_with_labor("homemaker", 23), 8, None, None, &now);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
-
-        let mut member2 = member.clone();
-        member2.set_permissions(vec![]);
-        let res = transfer_all_rights(&user, &member2, &company, &company2, &agreement, id.clone(), resource.clone(), ResourceMover::Update(resource_to.clone()), Costs::new_with_labor("homemaker", 23), 8, None, None, &now);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
-
-        deleted_company_tester(company.clone(), &now, |company_from: Company| {
-            transfer_all_rights(&user, &member, &company_from, &company2, &agreement, id.clone(), resource.clone(), ResourceMover::Update(resource_to.clone()), Costs::new_with_labor("homemaker", 23), 8, None, None, &now)
-        });
-        deleted_company_tester(company2.clone(), &now, |company_to: Company| {
-            transfer_all_rights(&user, &member, &company, &company_to, &agreement, id.clone(), resource.clone(), ResourceMover::Update(resource_to.clone()), Costs::new_with_labor("homemaker", 23), 8, None, None, &now)
-        });
-
         // can't transfer into a resource you don't own
-        let mut resource_to3 = resource_to.clone();
-        resource_to3.inner_mut().set_primary_accountable(Some(CompanyID::new("zing").into()));
-        let res = transfer_all_rights(&user, &member, &company, &company2, &agreement, id.clone(), resource.clone(), ResourceMover::Update(resource_to3.clone()), Costs::new_with_labor("homemaker", 23), 8, None, None, &now);
+        let mut state2 = state.clone();
+        state2.model2_mut().inner_mut().set_primary_accountable(Some(CompanyID::new("zing").into()));
+        let res = testfn_update(&state2);
         assert_eq!(res, Err(Error::Event(EventError::ResourceOwnerMismatch)));
 
         // a company that doesn't own a resource can't transfer it OBVIOUSLY
-        let mut resource3 = resource.clone();
-        resource3.inner_mut().set_primary_accountable(Some(CompanyID::new("ziggy").into()));
-        let res = transfer_all_rights(&user, &member, &company, &company2, &agreement, id.clone(), resource3.clone(), ResourceMover::Update(resource_to.clone()), Costs::new_with_labor("homemaker", 23), 8, None, None, &now);
+        let mut state3 = state.clone();
+        state3.model_mut().inner_mut().set_primary_accountable(Some(CompanyID::new("ziggy").into()));
+        let res = testfn_update(&state3);
+        assert_eq!(res, Err(Error::Event(EventError::ResourceOwnerMismatch)));
+        let res = testfn_create(&state3);
         assert_eq!(res, Err(Error::Event(EventError::ResourceOwnerMismatch)));
 
         // can't add an event unless both parties are participants in the agreement
         let mut agreement2 = agreement.clone();
-        agreement2.set_participants(vec![company2.agent_id()]);
-        let res = transfer_all_rights(&user, &member, &company, &company2, &agreement2, id.clone(), resource.clone(), ResourceMover::Update(resource_to.clone()), Costs::new_with_labor("homemaker", 23), 8, None, None, &now);
+        agreement2.set_participants(vec![company_to.agent_id()]);
+        let res = testfn_inner(&state, &company_from, &company_to, &agreement2, ResourceMover::Update(state.model2().clone()));
         assert_eq!(res, Err(Error::InsufficientPrivileges));
+        let res = testfn_inner(&state, &company_from, &company_to, &agreement2, ResourceMover::Create(state.model2().id().clone()));
+        assert_eq!(res, Err(Error::InsufficientPrivileges));
+
+        let mut state5 = state.clone();
+        state5.company = Some(company_to.clone());
+        test::deleted_company_tester(&state5, &testfn_update_to);
     }
 
     #[test]
     fn can_transfer_custody() {
         let now = util::time::now();
         let id = EventID::create();
-        let company = make_company(&CompanyID::create(), "jerry's planks", &now);
-        let company2 = make_company(&CompanyID::create(), "jinkey's skateboards", &now);
-        let agreement = make_agreement(&AgreementID::create(), &vec![company.agent_id(), company2.agent_id()], "order 1234", "gotta get some planks", &now);
+        let mut state = TestState::standard(vec![CompanyPermission::TransferCustody], &now);
+        let company_from = state.company().clone();
+        let company_to = make_company(&CompanyID::create(), "jinkey's skateboards", &now);
+        let agreement = make_agreement(&AgreementID::create(), &vec![company_from.agent_id(), company_to.agent_id()], "order 1234", "gotta get some planks", &now);
         let agreed_in: Url = "https://legaldoom.com/trade-secrets-trade-secrets".parse().unwrap();
-        let user = make_user(&UserID::create(), None, &now);
-        let occupation_id = OccupationID::new("machinist");
-        let member = make_member_worker(&MemberID::create(), user.id(), company.id(), &occupation_id, vec![], &now);
-        let resource = make_resource(&ResourceID::new("plank"), company.id(), &Measure::new(dec!(15), Unit::One), &Costs::new_with_labor("homemaker", 157), &now);
-        let resource_to = make_resource(&ResourceID::new("plank"), company2.id(), &Measure::new(dec!(3), Unit::One), &Costs::new_with_labor("homemaker", 2), &now);
+        let resource_from = make_resource(&ResourceID::new("plank"), company_from.id(), &Measure::new(dec!(15), Unit::One), &Costs::new_with_labor("homemaker", 157), &now);
+        let resource_to = make_resource(&ResourceID::new("plank"), company_to.id(), &Measure::new(dec!(3), Unit::One), &Costs::new_with_labor("homemaker", 2), &now);
+        state.model = Some(resource_from);
+        state.model2 = Some(resource_to);
 
-        let res = transfer_custody(&user, &member, &company, &company2, &agreement, id.clone(), resource.clone(), ResourceMover::Update(resource_to.clone()), Costs::new_with_labor("homemaker", 23), 8, None, None, &now);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
+        let testfn_inner = |state: &TestState<Resource, Resource>, company_from: &Company, company_to: &Company, agreement: &Agreement, resource_to: ResourceMover| {
+            transfer_custody(state.user(), state.member(), &company_from, &company_to, &agreement, id.clone(), state.model().clone(), resource_to, Costs::new_with_labor("homemaker", 23), 8, Some(agreed_in.clone()), Some("nomnomnom".into()), &now)
+        };
+        let testfn_update = |state: &TestState<Resource, Resource>| {
+            testfn_inner(state, state.company(), &company_to, &agreement, ResourceMover::Update(state.model2().clone()))
+        };
+        let testfn_create = |state: &TestState<Resource, Resource>| {
+            testfn_inner(state, state.company(), &company_to, &agreement, ResourceMover::Create(state.model2().id().clone()))
+        };
+        let testfn_update_to = |state: &TestState<Resource, Resource>| {
+            testfn_inner(state, &company_from, state.company(), &agreement, ResourceMover::Update(state.model2().clone()))
+        };
+        test::standard_transaction_tests(&state, &testfn_update);
+        test::standard_transaction_tests(&state, &testfn_create);
 
-        let mut member = member.clone();
-        member.set_permissions(vec![CompanyPermission::Transfer]);
         // test ResourceMover::Update()
-        let mods = transfer_custody(&user, &member, &company, &company2, &agreement, id.clone(), resource.clone(), ResourceMover::Update(resource_to.clone()), Costs::new_with_labor("homemaker", 23), 8, Some(agreed_in.clone()), Some("nomnomnom".into()), &now).unwrap().into_vec();
+        let mods = testfn_update(&state).unwrap().into_vec();
         assert_eq!(mods.len(), 3);
         let event = mods[0].clone().expect_op::<Event>(Op::Create).unwrap();
         let resource2 = mods[1].clone().expect_op::<Resource>(Op::Update).unwrap();
@@ -555,9 +568,9 @@ mod tests {
         assert_eq!(event.inner().has_point_in_time(), &Some(now.clone()));
         assert_eq!(event.inner().input_of(), &None);
         assert_eq!(event.inner().note(), &Some("nomnomnom".into()));
-        assert_eq!(event.inner().provider().clone(), company.agent_id());
+        assert_eq!(event.inner().provider().clone(), company_from.agent_id());
         assert_eq!(event.inner().realization_of(), &Some(agreement.id().clone()));
-        assert_eq!(event.inner().receiver().clone(), company2.agent_id());
+        assert_eq!(event.inner().receiver().clone(), company_to.agent_id());
         assert_eq!(event.inner().resource_quantity(), &Some(Measure::new(8, Unit::One)));
         assert_eq!(event.move_costs(), &Some(Costs::new_with_labor("homemaker", 23)));
         assert_eq!(event.active(), &true);
@@ -566,35 +579,35 @@ mod tests {
 
         let mut costs2 = Costs::new();
         costs2.track_labor("homemaker", dec!(157) - dec!(23));
-        assert_eq!(resource2.id(), resource.id());
-        assert_eq!(resource2.inner().primary_accountable(), &Some(company.agent_id()));
+        assert_eq!(resource2.id(), state.model().id());
+        assert_eq!(resource2.inner().primary_accountable(), &Some(company_from.agent_id()));
         assert_eq!(resource2.inner().accounting_quantity(), &Some(Measure::new(dec!(15), Unit::One)));
         assert_eq!(resource2.inner().onhand_quantity(), &Some(Measure::new(dec!(15) - dec!(8), Unit::One)));
-        assert_eq!(resource2.in_custody_of(), &company.agent_id());
+        assert_eq!(resource2.in_custody_of(), &company_from.agent_id());
         assert_eq!(resource2.costs(), &costs2);
 
         let mut costs2 = Costs::new();
         costs2.track_labor("homemaker", dec!(23) + dec!(2));
-        assert_eq!(resource_to2.id(), resource_to.id());
-        assert_eq!(resource_to2.inner().primary_accountable(), &Some(company2.agent_id()));
+        assert_eq!(resource_to2.id(), state.model2().id());
+        assert_eq!(resource_to2.inner().primary_accountable(), &Some(company_to.agent_id()));
         assert_eq!(resource_to2.inner().accounting_quantity(), &Some(Measure::new(dec!(3), Unit::One)));
         assert_eq!(resource_to2.inner().onhand_quantity(), &Some(Measure::new(dec!(8) + dec!(3), Unit::One)));
-        assert_eq!(resource_to2.in_custody_of(), &company2.agent_id());
+        assert_eq!(resource_to2.in_custody_of(), &company_to.agent_id());
         assert_eq!(resource_to2.costs(), &costs2);
 
         // test ResourceMover::Create()
-        let mods = transfer_custody(&user, &member, &company, &company2, &agreement, id.clone(), resource.clone(), ResourceMover::Create(resource_to.id().clone()), Costs::new_with_labor("homemaker", 23), 8, None, None, &now).unwrap().into_vec();
+        let mods = testfn_create(&state).unwrap().into_vec();
         assert_eq!(mods.len(), 3);
         let event = mods[0].clone().expect_op::<Event>(Op::Create).unwrap();
         let resource3 = mods[1].clone().expect_op::<Resource>(Op::Update).unwrap();
         let resource_created = mods[2].clone().expect_op::<Resource>(Op::Create).unwrap();
 
         assert_eq!(event.id(), &id);
-        assert_eq!(event.inner().agreed_in(), &None);
+        assert_eq!(event.inner().agreed_in(), &Some(agreed_in.clone()));
         assert_eq!(event.inner().has_point_in_time(), &Some(now.clone()));
         assert_eq!(event.inner().input_of(), &None);
-        assert_eq!(event.inner().provider().clone(), company.agent_id());
-        assert_eq!(event.inner().receiver().clone(), company2.agent_id());
+        assert_eq!(event.inner().provider().clone(), company_from.agent_id());
+        assert_eq!(event.inner().receiver().clone(), company_to.agent_id());
         assert_eq!(event.inner().resource_quantity(), &Some(Measure::new(8, Unit::One)));
         assert_eq!(event.move_costs(), &Some(Costs::new_with_labor("homemaker", 23)));
         assert_eq!(event.active(), &true);
@@ -603,55 +616,47 @@ mod tests {
 
         let mut costs2 = Costs::new();
         costs2.track_labor("homemaker", dec!(157) - dec!(23));
-        assert_eq!(resource3.id(), resource.id());
-        assert_eq!(resource3.inner().primary_accountable(), &Some(company.agent_id()));
+        assert_eq!(resource3.id(), state.model().id());
+        assert_eq!(resource3.inner().primary_accountable(), &Some(company_from.agent_id()));
         assert_eq!(resource3.inner().accounting_quantity(), &Some(Measure::new(dec!(15), Unit::One)));
         assert_eq!(resource3.inner().onhand_quantity(), &Some(Measure::new(dec!(15) - dec!(8), Unit::One)));
-        assert_eq!(resource3.in_custody_of(), &company.agent_id());
+        assert_eq!(resource3.in_custody_of(), &company_from.agent_id());
         assert_eq!(resource3.costs(), &costs2);
 
         let mut costs2 = Costs::new();
         costs2.track_labor("homemaker", dec!(23));
-        assert_eq!(resource_created.id(), resource_to.id());
-        assert_eq!(resource_created.inner().primary_accountable(), &Some(company.agent_id()));
+        assert_eq!(resource_created.id(), state.model2().id());
+        assert_eq!(resource_created.inner().primary_accountable(), &Some(company_from.agent_id()));
         assert_eq!(resource_created.inner().accounting_quantity(), &Some(Measure::new(dec!(0), Unit::One)));
         assert_eq!(resource_created.inner().onhand_quantity(), &Some(Measure::new(dec!(8), Unit::One)));
-        assert_eq!(resource_created.in_custody_of(), &company2.agent_id());
+        assert_eq!(resource_created.in_custody_of(), &company_to.agent_id());
         assert_eq!(resource_created.costs(), &costs2);
 
-        let user2 = make_user(&UserID::create(), Some(vec![]), &now);
-        let res = transfer_custody(&user2, &member, &company, &company2, &agreement, id.clone(), resource.clone(), ResourceMover::Update(resource_to.clone()), Costs::new_with_labor("homemaker", 23), 8, None, None, &now);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
-
-        let mut member2 = member.clone();
-        member2.set_permissions(vec![]);
-        let res = transfer_custody(&user, &member2, &company, &company2, &agreement, id.clone(), resource.clone(), ResourceMover::Update(resource_to.clone()), Costs::new_with_labor("homemaker", 23), 8, None, None, &now);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
-
-        deleted_company_tester(company.clone(), &now, |company_from: Company| {
-            transfer_custody(&user, &member, &company_from, &company2, &agreement, id.clone(), resource.clone(), ResourceMover::Update(resource_to.clone()), Costs::new_with_labor("homemaker", 23), 8, None, None, &now)
-        });
-        deleted_company_tester(company2.clone(), &now, |company_to: Company| {
-            transfer_custody(&user, &member, &company, &company_to, &agreement, id.clone(), resource.clone(), ResourceMover::Update(resource_to.clone()), Costs::new_with_labor("homemaker", 23), 8, None, None, &now)
-        });
-
         // can't override a resource you don't own
-        let mut resource_to3 = resource_to.clone();
-        resource_to3.inner_mut().set_primary_accountable(Some(CompanyID::new("zing").into()));
-        let res = transfer_custody(&user, &member, &company, &company2, &agreement, id.clone(), resource.clone(), ResourceMover::Update(resource_to3.clone()), Costs::new_with_labor("homemaker", 23), 8, None, None, &now);
+        let mut state2 = state.clone();
+        state2.model2_mut().inner_mut().set_primary_accountable(Some(CompanyID::new("zing").into()));
+        let res = testfn_update(&state2);
         assert_eq!(res, Err(Error::Event(EventError::ResourceOwnerMismatch)));
 
         // can't transfer custody of a resource you don't have custody of
-        let mut resource4 = resource.clone();
-        resource4.set_in_custody_of(CompanyID::new("ziggy").into());
-        let res = transfer_custody(&user, &member, &company, &company2, &agreement, id.clone(), resource4.clone(), ResourceMover::Update(resource_to.clone()), Costs::new_with_labor("homemaker", 23), 8, None, None, &now);
+        let mut state3 = state.clone();
+        state3.model_mut().set_in_custody_of(CompanyID::new("ziggy").into());
+        let res = testfn_update(&state3);
+        assert_eq!(res, Err(Error::Event(EventError::ResourceCustodyMismatch)));
+        let res = testfn_create(&state3);
         assert_eq!(res, Err(Error::Event(EventError::ResourceCustodyMismatch)));
 
         // can't add an event unless both parties are participants in the agreement
         let mut agreement2 = agreement.clone();
-        agreement2.set_participants(vec![company2.agent_id()]);
-        let res = transfer_custody(&user, &member, &company, &company2, &agreement2, id.clone(), resource.clone(), ResourceMover::Update(resource_to.clone()), Costs::new_with_labor("homemaker", 23), 8, None, None, &now);
+        agreement2.set_participants(vec![company_to.agent_id()]);
+        let res = testfn_inner(&state, &company_from, &company_to, &agreement2, ResourceMover::Update(state.model2().clone()));
         assert_eq!(res, Err(Error::InsufficientPrivileges));
+        let res = testfn_inner(&state, &company_from, &company_to, &agreement2, ResourceMover::Create(state.model2().id().clone()));
+        assert_eq!(res, Err(Error::InsufficientPrivileges));
+
+        let mut state5 = state.clone();
+        state5.company = Some(company_to.clone());
+        test::deleted_company_tester(&state5, &testfn_update_to);
     }
 }
 

--- a/src/transactions/event/work.rs
+++ b/src/transactions/event/work.rs
@@ -106,11 +106,9 @@ mod tests {
             member::*,
             event::{Event, EventID, EventError},
             lib::agent::Agent,
-            occupation::OccupationID,
             process::ProcessID,
-            testutils::{deleted_company_tester, make_user, make_company, make_member_worker, make_process},
-            user::UserID,
         },
+        util::test::{self, *},
     };
     use rust_decimal_macros::*;
 
@@ -119,107 +117,89 @@ mod tests {
         let now: DateTime<Utc> = "2018-06-06T00:00:00Z".parse().unwrap();
         let now2: DateTime<Utc> = "2018-06-06T06:52:00Z".parse().unwrap();
         let id = EventID::create();
-        let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
-        let user = make_user(&UserID::create(), None, &now);
-        let occupation_id = OccupationID::new("machinist");
-        let member = make_member_worker(&MemberID::create(), user.id(), company.id(), &occupation_id, vec![CompanyPermission::Work], &now);
-        let worker = member.clone();
-        let process = make_process(&ProcessID::create(), company.id(), "make widgets", &Costs::new_with_labor(occupation_id.clone(), dec!(177.5)), &now);
+        let mut state = TestState::standard(vec![CompanyPermission::Work], &now);
+        let occupation_id = state.member().occupation_id().unwrap().clone();
+        let worker = state.member().clone();
+        let process = make_process(&ProcessID::create(), state.company().id(), "make widgets", &Costs::new_with_labor(occupation_id.clone(), dec!(177.5)), &now);
+        state.model = Some(worker);
+        state.model2 = Some(process);
 
-        let mods = work(&user, &member, &company, id.clone(), worker.clone(), process.clone(), Some(dec!(78.4)), now.clone(), now2.clone(), Some("just doing some work".into()), &now2).unwrap().into_vec();
+        let testfn = |state: &TestState<Member, Process>| {
+            work(state.user(), state.member(), state.company(), id.clone(), state.model().clone(), state.model2().clone(), Some(dec!(78.4)), now.clone(), now2.clone(), Some("just doing some work".into()), &now2)
+        };
+        test::standard_transaction_tests(&state, &testfn);
+
+        let mods = testfn(&state).unwrap().into_vec();
         assert_eq!(mods.len(), 2);
         let event = mods[0].clone().expect_op::<Event>(Op::Create).unwrap();
+
         assert_eq!(event.id(), &id);
-        assert_eq!(event.inner().agreed_in(), member.agreement());
+        assert_eq!(event.inner().agreed_in(), state.member().agreement());
         assert_eq!(event.inner().has_beginning(), &Some(now.clone()));
         assert_eq!(event.inner().has_end(), &Some(now2.clone()));
-        assert_eq!(event.inner().input_of(), &Some(process.id().clone()));
+        assert_eq!(event.inner().input_of(), &Some(state.model2().id().clone()));
         assert_eq!(event.inner().note(), &Some("just doing some work".into()));
-        assert_eq!(event.inner().provider().clone(), worker.agent_id());
-        assert_eq!(event.inner().receiver().clone(), company.agent_id());
+        assert_eq!(event.inner().provider().clone(), state.model().agent_id());
+        assert_eq!(event.inner().receiver().clone(), state.company().agent_id());
         assert_eq!(event.move_costs(), &Some(Costs::new_with_labor(occupation_id.clone(), dec!(78.4))));
         assert_eq!(event.active(), &true);
         assert_eq!(event.created(), &now2);
         assert_eq!(event.updated(), &now2);
+
         let mut costs2 = Costs::new();
         costs2.track_labor(occupation_id.clone(), dec!(177.5) + dec!(78.4));
         costs2.track_labor_hours(occupation_id.clone(), dec!(6.8666666666666666666666666666));
         let process2 = mods[1].clone().expect_op::<Process>(Op::Update).unwrap();
-        assert_eq!(process2.id(), process.id());
-        assert_eq!(process2.company_id(), company.id());
+        assert_eq!(process2.id(), state.model2().id());
+        assert_eq!(process2.company_id(), state.company().id());
         assert_eq!(process2.inner().name(), "make widgets");
         assert_eq!(process2.costs(), &costs2);
-
-        let user2 = make_user(&UserID::create(), Some(vec![]), &now);
-        let res = work(&user2, &member, &company, id.clone(), worker.clone(), process.clone(), Some(dec!(78.4)), now.clone(), now2.clone(), Some("just doing some work".into()), &now2);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
-
-        let mut member2 = member.clone();
-        member2.set_permissions(vec![]);
-        let res = work(&user, &member2, &company, id.clone(), worker.clone(), process.clone(), Some(dec!(78.4)), now.clone(), now2.clone(), Some("just doing some work".into()), &now2);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
-
-        deleted_company_tester(company.clone(), &now, |company: Company| {
-            work(&user, &member, &company, id.clone(), worker.clone(), process.clone(), Some(dec!(78.4)), now.clone(), now2.clone(), Some("just doing some work".into()), &now2)
-        });
 
         // test worker != member
-        let mut worker2 = worker.clone();
-        worker2.set_id(MemberID::create());
-        let res = work(&user, &member, &company, id.clone(), worker2.clone(), process.clone(), Some(dec!(78.4)), now.clone(), now2.clone(), Some("just doing some work".into()), &now2);
+        let mut state2 = state.clone();
+        state2.model_mut().set_id(MemberID::create());
+        let res = testfn(&state2);
         assert_eq!(res, Err(Error::InsufficientPrivileges));
-
-        let mut member2 = member.clone();
-        member2.set_permissions(vec![CompanyPermission::WorkAdmin]);
-        let mods = work(&user, &member2, &company, id.clone(), worker2.clone(), process.clone(), Some(dec!(78.4)), now.clone(), now2.clone(), None, &now2).unwrap().into_vec();
+        state2.member_mut().set_permissions(vec![CompanyPermission::WorkAdmin]);
+        let mods = testfn(&state2).unwrap().into_vec();
         assert_eq!(mods.len(), 2);
         let event = mods[0].clone().expect_op::<Event>(Op::Create).unwrap();
+
         assert_eq!(event.id(), &id);
-        assert_eq!(event.inner().agreed_in(), member2.agreement());
+        assert_eq!(event.inner().agreed_in(), state2.member().agreement());
         assert_eq!(event.inner().has_beginning(), &Some(now.clone()));
         assert_eq!(event.inner().has_end(), &Some(now2.clone()));
-        assert_eq!(event.inner().input_of(), &Some(process.id().clone()));
-        assert_eq!(event.inner().note(), &None);
-        assert_eq!(event.inner().provider().clone(), worker2.agent_id());
-        assert_eq!(event.inner().receiver().clone(), company.agent_id());
+        assert_eq!(event.inner().input_of(), &Some(state.model2().id().clone()));
+        assert_eq!(event.inner().note(), &Some("just doing some work".into()));
+        assert_eq!(event.inner().provider().clone(), state2.model().agent_id());
+        assert_eq!(event.inner().receiver().clone(), state.company().agent_id());
         assert_eq!(event.move_costs(), &Some(Costs::new_with_labor(occupation_id.clone(), dec!(78.4))));
         assert_eq!(event.active(), &true);
         assert_eq!(event.created(), &now2);
         assert_eq!(event.updated(), &now2);
+
         let mut costs2 = Costs::new();
         costs2.track_labor(occupation_id.clone(), dec!(177.5) + dec!(78.4));
         costs2.track_labor_hours(occupation_id.clone(), dec!(6.8666666666666666666666666666));
         let process2 = mods[1].clone().expect_op::<Process>(Op::Update).unwrap();
-        assert_eq!(process2.id(), process.id());
-        assert_eq!(process2.company_id(), company.id());
+
+        assert_eq!(process2.id(), state.model2().id());
+        assert_eq!(process2.company_id(), state.company().id());
         assert_eq!(process2.inner().name(), "make widgets");
         assert_eq!(process2.costs(), &costs2);
 
-        let user2 = make_user(&UserID::create(), Some(vec![]), &now);
-        let res = work(&user2, &member2, &company, id.clone(), worker2.clone(), process.clone(), Some(dec!(78.4)), now.clone(), now2.clone(), Some("just doing some work".into()), &now2);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
-
-        let mut member3 = member2.clone();
-        member3.set_permissions(vec![]);
-        let res = work(&user, &member3, &company, id.clone(), worker2.clone(), process.clone(), Some(dec!(78.4)), now.clone(), now2.clone(), Some("just doing some work".into()), &now2);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
-
-        deleted_company_tester(company.clone(), &now2, |company: Company| {
-            work(&user, &member2, &company, id.clone(), worker2.clone(), process.clone(), Some(dec!(78.4)), now.clone(), now2.clone(), Some("just doing some work".into()), &now2)
-        });
-
         // can't work into a process you don't own
-        let mut process3 = process.clone();
-        process3.set_company_id(CompanyID::new("zing"));
-        let res = work(&user, &member2, &company, id.clone(), worker2.clone(), process3.clone(), Some(dec!(78.4)), now.clone(), now2.clone(), Some("just doing some work".into()), &now2);
+        let mut state3 = state.clone();
+        state3.model2_mut().set_company_id(CompanyID::new("zing"));
+        let res = testfn(&state3);
         assert_eq!(res, Err(Error::Event(EventError::ProcessOwnerMismatch)));
 
-        let mut worker3 = worker2.clone();
-        worker3.set_class(MemberClass::User(MemberUser::new()));
-        let res = work(&user, &member2, &company, id.clone(), worker3.clone(), process.clone(), Some(dec!(78.4)), now.clone(), now2.clone(), Some("just doing some work".into()), &now2);
+        let mut state4 = state.clone();
+        state4.model_mut().set_class(MemberClass::User(MemberUser::new()));
+        let res = testfn(&state4);
         assert_eq!(res, Err(Error::MemberMustBeWorker));
-        worker3.set_class(MemberClass::Company(MemberCompany::new()));
-        let res = work(&user, &member2, &company, id.clone(), worker3.clone(), process.clone(), Some(dec!(78.4)), now.clone(), now2.clone(), Some("just doing some work".into()), &now2);
+        state4.model_mut().set_class(MemberClass::Company(MemberCompany::new()));
+        let res = testfn(&state4);
         assert_eq!(res, Err(Error::MemberMustBeWorker));
     }
 }

--- a/src/transactions/event/work.rs
+++ b/src/transactions/event/work.rs
@@ -14,7 +14,7 @@ use crate::{
         event::{Event, EventID, EventProcessState},
         company::{Company, Permission as CompanyPermission},
         member::Member,
-        lib::basis_model::ActiveState,
+        lib::basis_model::Model,
         process::Process,
         user::User,
     },

--- a/src/transactions/intent.rs
+++ b/src/transactions/intent.rs
@@ -404,10 +404,7 @@ mod tests {
             delete(&user, &member, &company, intent1.clone(), &now2)
         });
 
-        let mut intent3 = intent1.clone();
-        intent3.set_deleted(Some(now2.clone()));
-        let res = delete(&user, &member, &company, intent3.clone(), &now2);
-        assert_eq!(res, Err(Error::ObjectIsDeleted("intent".into())));
+        double_deleted_tester!(intent1, "intent", |subject| delete(&user, &member, &company, subject, &now2));
     }
 }
 

--- a/src/transactions/intent.rs
+++ b/src/transactions/intent.rs
@@ -20,7 +20,7 @@ use crate::{
         member::Member,
         lib::{
             agent::{Agent, AgentID},
-            basis_model::{ActiveState, Deletable},
+            basis_model::Model,
         },
         intent::{Intent, IntentID},
         resource::ResourceID,

--- a/src/transactions/intent.rs
+++ b/src/transactions/intent.rs
@@ -201,12 +201,8 @@ mod tests {
     use crate::{
         models::{
             company::CompanyID,
-            member::MemberID,
-            occupation::OccupationID,
-            testutils::{deleted_company_tester, make_user, make_company, make_member_worker},
-            user::UserID,
         },
-        util,
+        util::{self, test::{self, *}},
     };
     use om2::Unit;
 
@@ -214,15 +210,18 @@ mod tests {
     fn can_create() {
         let now = util::time::now();
         let id = IntentID::create();
-        let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
-        let user = make_user(&UserID::create(), None, &now);
-        let member = make_member_worker(&MemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::IntentCreate], &now);
+        let state = TestState::standard(vec![CompanyPermission::IntentCreate], &now);
         let costs = Costs::new_with_labor("widgetmaker", 42);
-        let loc = SpatialThing::builder()
-            .mappable_address(Some("444 Checkmate lane, LOGIC and FACTS, MN, 33133".into()))
-            .build().unwrap();
 
-        let mods = create(&user, &member, &company, id.clone(), Some(costs.clone()), OrderAction::Transfer, None, Some(loc.clone()), Some(Measure::new(10, Unit::One)), None, None, Some(false), Some(now.clone()), None, None, vec![company.agent_id()], Some("buy my widget".into()), Some("gee willickers i hope someone buys my widget".into()), Some(company.agent_id()), None, None, Some(ResourceID::new("widget1")), None, true, &now).unwrap().into_vec();
+        let testfn_inner = |state: &TestState<Intent, Intent>, provider: Option<AgentID>, receiver: Option<AgentID>| {
+            create(state.user(), state.member(), state.company(), id.clone(), Some(costs.clone()), OrderAction::Transfer, None, Some(state.loc().clone()), Some(Measure::new(10, Unit::One)), None, None, Some(false), Some(now.clone()), None, None, vec![state.company().agent_id()], Some("buy my widget".into()), Some("gee willickers i hope someone buys my widget".into()), provider, receiver, None, Some(ResourceID::new("widget1")), None, true, &now)
+        };
+        let testfn = |state: &TestState<Intent, Intent>| {
+            testfn_inner(state, Some(state.company().agent_id()), None)
+        };
+        test::standard_transaction_tests(&state, &testfn);
+
+        let mods = testfn(&state).unwrap().into_vec();
         assert_eq!(mods.len(), 1);
 
         let intent = mods[0].clone().expect_op::<Intent>(Op::Create).unwrap();
@@ -230,7 +229,7 @@ mod tests {
         assert_eq!(intent.move_costs(), &Some(costs.clone()));
         assert_eq!(intent.inner().action(), &vf::Action::Transfer);
         assert_eq!(intent.inner().agreed_in(), &None);
-        assert_eq!(intent.inner().at_location(), &Some(loc.clone()));
+        assert_eq!(intent.inner().at_location(), &Some(state.loc().clone()));
         assert_eq!(intent.inner().available_quantity(), &Some(Measure::new(10, Unit::One)));
         assert_eq!(intent.inner().due(), &None);
         assert_eq!(intent.inner().effort_quantity(), &None);
@@ -238,10 +237,10 @@ mod tests {
         assert_eq!(intent.inner().has_beginning(), &Some(now.clone()));
         assert_eq!(intent.inner().has_end(), &None);
         assert_eq!(intent.inner().has_point_in_time(), &None);
-        assert_eq!(intent.inner().in_scope_of(), &vec![company.agent_id()]);
+        assert_eq!(intent.inner().in_scope_of(), &vec![state.company().agent_id()]);
         assert_eq!(intent.inner().name(), &Some("buy my widget".into()));
         assert_eq!(intent.inner().note(), &Some("gee willickers i hope someone buys my widget".into()));
-        assert_eq!(intent.inner().provider(), &Some(company.agent_id()));
+        assert_eq!(intent.inner().provider(), &Some(state.company().agent_id()));
         assert_eq!(intent.inner().receiver(), &None);
         assert_eq!(intent.inner().resource_conforms_to(), &None);
         assert_eq!(intent.inner().resource_inventoried_as(), &Some(ResourceID::new("widget1")));
@@ -251,28 +250,14 @@ mod tests {
         assert_eq!(intent.updated(), &now);
         assert_eq!(intent.deleted(), &None);
 
-        let mut member2 = member.clone();
-        member2.set_permissions(vec![CompanyPermission::ProcessDelete]);
-        let res = create(&user, &member2, &company, id.clone(), Some(costs.clone()), OrderAction::Transfer, None, Some(loc.clone()), Some(Measure::new(10, Unit::One)), None, None, Some(false), Some(now.clone()), None, None, vec![company.agent_id()], Some("buy my widget".into()), Some("gee willickers i hope someone buys my widget".into()), Some(company.agent_id()), None, None, Some(ResourceID::new("widget1")), None, true, &now);
+        let mut state2 = state.clone();
+        state2.company_mut().set_id(CompanyID::new("bill's company"));
+        let res = testfn_inner(&state2, Some(state.company().agent_id()), None);
+        assert_eq!(res, Err(Error::InsufficientPrivileges));
+        let res = testfn_inner(&state2, None, Some(state.company().agent_id()));
         assert_eq!(res, Err(Error::InsufficientPrivileges));
 
-        let mut user2 = user.clone();
-        user2.set_roles(vec![]);
-        let res = create(&user2, &member, &company, id.clone(), Some(costs.clone()), OrderAction::Transfer, None, Some(loc.clone()), Some(Measure::new(10, Unit::One)), None, None, Some(false), Some(now.clone()), None, None, vec![company.agent_id()], Some("buy my widget".into()), Some("gee willickers i hope someone buys my widget".into()), Some(company.agent_id()), None, None, Some(ResourceID::new("widget1")), None, true, &now);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
-
-        deleted_company_tester(company.clone(), &now, |company: Company| {
-            create(&user, &member, &company, id.clone(), Some(costs.clone()), OrderAction::Transfer, None, Some(loc.clone()), Some(Measure::new(10, Unit::One)), None, None, Some(false), Some(now.clone()), None, None, vec![company.agent_id()], Some("buy my widget".into()), Some("gee willickers i hope someone buys my widget".into()), Some(company.agent_id()), None, None, Some(ResourceID::new("widget1")), None, true, &now)
-        });
-
-        let mut company3 = company.clone();
-        company3.set_id(CompanyID::new("bill's company"));
-        let res = create(&user, &member, &company3, id.clone(), Some(costs.clone()), OrderAction::Transfer, None, Some(loc.clone()), Some(Measure::new(10, Unit::One)), None, None, Some(false), Some(now.clone()), None, None, vec![company.agent_id()], Some("buy my widget".into()), Some("gee willickers i hope someone buys my widget".into()), Some(company.agent_id()), None, None, Some(ResourceID::new("widget1")), None, true, &now);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
-        let res = create(&user, &member, &company3, id.clone(), Some(costs.clone()), OrderAction::Transfer, None, Some(loc.clone()), Some(Measure::new(10, Unit::One)), None, None, Some(false), Some(now.clone()), None, None, vec![company.agent_id()], Some("buy my widget".into()), Some("gee willickers i hope someone buys my widget".into()), None, Some(company.agent_id()), None, Some(ResourceID::new("widget1")), None, true, &now);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
-
-        let res = create(&user, &member, &company, id.clone(), Some(costs.clone()), OrderAction::Transfer, None, Some(loc.clone()), Some(Measure::new(10, Unit::One)), None, None, Some(false), Some(now.clone()), None, None, vec![company.agent_id()], Some("buy my widget".into()), Some("gee willickers i hope someone buys my widget".into()), None, None, None, Some(ResourceID::new("widget1")), None, true, &now);
+        let res = testfn_inner(&state, None, None);
         assert_eq!(res, Err(Error::MissingFields(vec!["provider".into(), "receiver".into()])));
     }
 
@@ -280,68 +265,59 @@ mod tests {
     fn can_update() {
         let now = util::time::now();
         let id = IntentID::create();
-        let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
-        let user = make_user(&UserID::create(), None, &now);
-        let member = make_member_worker(&MemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::IntentCreate, CompanyPermission::IntentUpdate], &now);
+        let mut state = TestState::standard(vec![CompanyPermission::IntentCreate, CompanyPermission::IntentUpdate], &now);
         let costs1 = Costs::new_with_labor("widgetmaker", 42);
         let costs2 = Costs::new_with_labor("widgetmaker", 41);
-        let loc = SpatialThing::builder()
-            .mappable_address(Some("444 Checkmate lane, LOGIC and FACTS, MN, 33133".into()))
-            .build().unwrap();
 
-        let mods = create(&user, &member, &company, id.clone(), Some(costs1.clone()), OrderAction::Transfer, None, Some(loc.clone()), Some(Measure::new(10, Unit::One)), None, None, Some(false), Some(now.clone()), None, None, vec![company.agent_id()], Some("buy my widget".into()), Some("gee willickers i hope someone buys my widget".into()), Some(company.agent_id()), None, None, Some(ResourceID::new("widget1")), None, true, &now).unwrap().into_vec();
-        let intent1 = mods[0].clone().expect_op::<Intent>(Op::Create).unwrap();
+        let mods = create(state.user(), state.member(), state.company(), id.clone(), Some(costs1.clone()), OrderAction::Transfer, None, Some(state.loc().clone()), Some(Measure::new(10, Unit::One)), None, None, Some(false), Some(now.clone()), None, None, vec![state.company().agent_id()], Some("buy my widget".into()), Some("gee willickers i hope someone buys my widget".into()), Some(state.company().agent_id()), None, None, Some(ResourceID::new("widget1")), None, true, &now).unwrap().into_vec();
+        let intent = mods[0].clone().expect_op::<Intent>(Op::Create).unwrap();
+        state.model = Some(intent);
+
         let now2 = util::time::now();
-        let mods = update(&user, &member, &company, intent1.clone(), Some(Some(costs2.clone())), None, None, Some(None), None, None, None, None, None, None, None, Some(vec![]), Some(Some("buy widget".into())), None, None, None, None, None, None, Some(false), &now2).unwrap().into_vec();
+        let testfn_inner = |state: &TestState<Intent, Intent>, provider: Option<Option<AgentID>>, receiver: Option<Option<AgentID>>| {
+            update(state.user(), state.member(), state.company(), state.model().clone(), Some(Some(costs2.clone())), None, None, Some(None), None, None, None, None, None, None, None, Some(vec![]), Some(Some("buy widget".into())), None, provider, receiver, None, None, None, Some(false), &now2)
+        };
+        let testfn = |state: &TestState<Intent, Intent>| {
+            testfn_inner(state, None, None)
+        };
+        test::standard_transaction_tests(&state, &testfn);
+
+        let mods = testfn(&state).unwrap().into_vec();
         let intent2 = mods[0].clone().expect_op::<Intent>(Op::Update).unwrap();
 
-        assert_eq!(intent2.id(), intent1.id());
+        assert_eq!(intent2.id(), state.model().id());
         assert_eq!(intent2.move_costs(), &Some(costs2.clone()));
-        assert_eq!(intent2.inner().action(), intent1.inner().action());
+        assert_eq!(intent2.inner().action(), state.model().inner().action());
         assert_eq!(intent2.inner().agreed_in(), intent2.inner().agreed_in());
         assert_eq!(intent2.inner().at_location(), &None);
-        assert_eq!(intent2.inner().available_quantity(), intent1.inner().available_quantity());
-        assert_eq!(intent2.inner().due(), intent1.inner().due());
-        assert_eq!(intent2.inner().effort_quantity(), intent1.inner().effort_quantity());
-        assert_eq!(intent2.inner().finished(), intent1.inner().finished());
-        assert_eq!(intent2.inner().has_beginning(), intent1.inner().has_beginning());
-        assert_eq!(intent2.inner().has_end(), intent1.inner().has_end());
-        assert_eq!(intent2.inner().has_point_in_time(), intent1.inner().has_point_in_time());
+        assert_eq!(intent2.inner().available_quantity(), state.model().inner().available_quantity());
+        assert_eq!(intent2.inner().due(), state.model().inner().due());
+        assert_eq!(intent2.inner().effort_quantity(), state.model().inner().effort_quantity());
+        assert_eq!(intent2.inner().finished(), state.model().inner().finished());
+        assert_eq!(intent2.inner().has_beginning(), state.model().inner().has_beginning());
+        assert_eq!(intent2.inner().has_end(), state.model().inner().has_end());
+        assert_eq!(intent2.inner().has_point_in_time(), state.model().inner().has_point_in_time());
         assert_eq!(intent2.inner().in_scope_of(), &vec![]);
         assert_eq!(intent2.inner().name(), &Some("buy widget".into()));
-        assert_eq!(intent2.inner().note(), intent1.inner().note());
-        assert_eq!(intent2.inner().provider(), intent1.inner().provider());
-        assert_eq!(intent2.inner().receiver(), intent1.inner().receiver());
-        assert_eq!(intent2.inner().resource_conforms_to(), intent1.inner().resource_conforms_to());
-        assert_eq!(intent2.inner().resource_inventoried_as(), intent1.inner().resource_inventoried_as());
-        assert_eq!(intent2.inner().resource_quantity(), intent1.inner().resource_quantity());
+        assert_eq!(intent2.inner().note(), state.model().inner().note());
+        assert_eq!(intent2.inner().provider(), state.model().inner().provider());
+        assert_eq!(intent2.inner().receiver(), state.model().inner().receiver());
+        assert_eq!(intent2.inner().resource_conforms_to(), state.model().inner().resource_conforms_to());
+        assert_eq!(intent2.inner().resource_inventoried_as(), state.model().inner().resource_inventoried_as());
+        assert_eq!(intent2.inner().resource_quantity(), state.model().inner().resource_quantity());
         assert_eq!(intent2.active(), &false);
         assert_eq!(intent2.created(), &now);
         assert_eq!(intent2.updated(), &now2);
         assert_eq!(intent2.deleted(), &None);
 
-        let mut member2 = member.clone();
-        member2.set_permissions(vec![CompanyPermission::ProcessDelete]);
-        let res = update(&user, &member2, &company, intent1.clone(), Some(Some(costs2.clone())), None, None, Some(None), None, None, None, None, None, None, None, Some(vec![]), Some(Some("buy widget".into())), None, None, None, None, None, None, Some(false), &now2);
+        let mut state2 = state.clone();
+        state2.company_mut().set_id(CompanyID::new("bill's company"));
+        let res = testfn_inner(&state2, Some(Some(CompanyID::new("widgetzzz plus").into())), None);
+        assert_eq!(res, Err(Error::InsufficientPrivileges));
+        let res = testfn_inner(&state2, None, Some(Some(CompanyID::new("widgetzzz plus").into())));
         assert_eq!(res, Err(Error::InsufficientPrivileges));
 
-        let mut user2 = user.clone();
-        user2.set_roles(vec![]);
-        let res = update(&user2, &member, &company, intent1.clone(), Some(Some(costs2.clone())), None, None, Some(None), None, None, None, None, None, None, None, Some(vec![]), Some(Some("buy widget".into())), None, None, None, None, None, None, Some(false), &now2);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
-
-        deleted_company_tester(company.clone(), &now2, |company: Company| {
-            update(&user, &member, &company, intent1.clone(), Some(Some(costs2.clone())), None, None, Some(None), None, None, None, None, None, None, None, Some(vec![]), Some(Some("buy widget".into())), None, None, None, None, None, None, Some(false), &now2)
-        });
-
-        let mut company3 = company.clone();
-        company3.set_id(CompanyID::new("bill's company"));
-        let res = update(&user, &member, &company3, intent1.clone(), Some(Some(costs2.clone())), None, None, Some(None), None, None, None, None, None, None, None, Some(vec![]), Some(Some("buy widget".into())), None, Some(Some(CompanyID::new("widgetzzz plus").into())), None, None, None, None, Some(false), &now2);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
-        let res = update(&user, &member, &company3, intent1.clone(), Some(Some(costs2.clone())), None, None, Some(None), None, None, None, None, None, None, None, Some(vec![]), Some(Some("buy widget".into())), None, None, Some(Some(CompanyID::new("widgetzzz plus").into())), None, None, None, Some(false), &now2);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
-
-        let res = update(&user, &member, &company, intent1.clone(), Some(Some(costs2.clone())), None, None, Some(None), None, None, None, None, None, None, None, Some(vec![]), Some(Some("buy widget".into())), None, Some(None), Some(None), None, None, None, Some(false), &now2);
+        let res = testfn_inner(&state, Some(None), Some(None));
         assert_eq!(res, Err(Error::MissingFields(vec!["provider".into(), "receiver".into()])));
     }
 
@@ -349,62 +325,31 @@ mod tests {
     fn can_delete() {
         let now = util::time::now();
         let id = IntentID::create();
-        let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
-        let user = make_user(&UserID::create(), None, &now);
-        let member = make_member_worker(&MemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::IntentCreate, CompanyPermission::IntentDelete], &now);
+        let mut state = TestState::standard(vec![CompanyPermission::IntentCreate, CompanyPermission::IntentDelete], &now);
         let costs = Costs::new_with_labor("widgetmaker", 42);
-        let loc = SpatialThing::builder()
-            .mappable_address(Some("444 Checkmate lane, LOGIC and FACTS, MN, 33133".into()))
-            .build().unwrap();
 
-        let mods = create(&user, &member, &company, id.clone(), Some(costs.clone()), OrderAction::Transfer, None, Some(loc.clone()), Some(Measure::new(10, Unit::One)), None, None, Some(false), Some(now.clone()), None, None, vec![company.agent_id()], Some("buy my widget".into()), Some("gee willickers i hope someone buys my widget".into()), Some(company.agent_id()), None, None, Some(ResourceID::new("widget1")), None, true, &now).unwrap().into_vec();
-        let intent1 = mods[0].clone().expect_op::<Intent>(Op::Create).unwrap();
+        let mods = create(state.user(), state.member(), state.company(), id.clone(), Some(costs.clone()), OrderAction::Transfer, None, Some(state.loc().clone()), Some(Measure::new(10, Unit::One)), None, None, Some(false), Some(now.clone()), None, None, vec![state.company().agent_id()], Some("buy my widget".into()), Some("gee willickers i hope someone buys my widget".into()), Some(state.company().agent_id()), None, None, Some(ResourceID::new("widget1")), None, true, &now).unwrap().into_vec();
+        let intent = mods[0].clone().expect_op::<Intent>(Op::Create).unwrap();
+        state.model = Some(intent);
 
         let now2 = util::time::now();
-        let mods = delete(&user, &member, &company, intent1.clone(), &now2).unwrap().into_vec();
+        let testfn = |state: &TestState<Intent, Intent>| {
+            delete(state.user(), state.member(), state.company(), state.model().clone(), &now2)
+        };
+        test::standard_transaction_tests(&state, &testfn);
+        test::double_deleted_tester(&state, "intent", &testfn);
+
+        let mods = testfn(&state).unwrap().into_vec();
         assert_eq!(mods.len(), 1);
 
         let intent2 = mods[0].clone().expect_op::<Intent>(Op::Delete).unwrap();
-        assert_eq!(intent2.id(), intent1.id());
-        assert_eq!(intent2.move_costs(), intent1.move_costs());
-        assert_eq!(intent2.inner().action(), intent1.inner().action());
-        assert_eq!(intent2.inner().agreed_in(), intent2.inner().agreed_in());
-        assert_eq!(intent2.inner().at_location(), intent1.inner().at_location());
-        assert_eq!(intent2.inner().available_quantity(), intent1.inner().available_quantity());
-        assert_eq!(intent2.inner().due(), intent1.inner().due());
-        assert_eq!(intent2.inner().effort_quantity(), intent1.inner().effort_quantity());
-        assert_eq!(intent2.inner().finished(), intent1.inner().finished());
-        assert_eq!(intent2.inner().has_beginning(), intent1.inner().has_beginning());
-        assert_eq!(intent2.inner().has_end(), intent1.inner().has_end());
-        assert_eq!(intent2.inner().has_point_in_time(), intent1.inner().has_point_in_time());
-        assert_eq!(intent2.inner().in_scope_of(), intent1.inner().in_scope_of());
-        assert_eq!(intent2.inner().name(), intent1.inner().name());
-        assert_eq!(intent2.inner().note(), intent1.inner().note());
-        assert_eq!(intent2.inner().provider(), intent1.inner().provider());
-        assert_eq!(intent2.inner().receiver(), intent1.inner().receiver());
-        assert_eq!(intent2.inner().resource_conforms_to(), intent1.inner().resource_conforms_to());
-        assert_eq!(intent2.inner().resource_inventoried_as(), intent1.inner().resource_inventoried_as());
-        assert_eq!(intent2.inner().resource_quantity(), intent1.inner().resource_quantity());
-        assert_eq!(intent2.active(), intent1.active());
-        assert_eq!(intent2.created(), intent1.created());
-        assert_eq!(intent2.updated(), intent1.updated());
+        assert_eq!(intent2.id(), state.model().id());
+        assert_eq!(intent2.move_costs(), state.model().move_costs());
+        assert_eq!(intent2.inner(), state.model().inner());
+        assert_eq!(intent2.active(), state.model().active());
+        assert_eq!(intent2.created(), state.model().created());
+        assert_eq!(intent2.updated(), state.model().updated());
         assert_eq!(intent2.deleted(), &Some(now2));
-
-        let mut member2 = member.clone();
-        member2.set_permissions(vec![CompanyPermission::ProcessDelete]);
-        let res = delete(&user, &member2, &company, intent1.clone(), &now2);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
-
-        let mut user2 = user.clone();
-        user2.set_roles(vec![]);
-        let res = delete(&user2, &member, &company, intent1.clone(), &now2);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
-
-        deleted_company_tester(company.clone(), &now2, |company: Company| {
-            delete(&user, &member, &company, intent1.clone(), &now2)
-        });
-
-        double_deleted_tester!(intent1, "intent", |subject| delete(&user, &member, &company, subject, &now2));
     }
 }
 

--- a/src/transactions/member.rs
+++ b/src/transactions/member.rs
@@ -57,9 +57,15 @@ pub fn create<T: Agent>(caller: &User, member: &Member, id: MemberID, agent_from
 }
 
 /// Update a member.
-pub fn update(caller: &User, member: &Member, mut subject: Member, occupation_id: Option<OccupationID>, agreement: Option<Url>, active: Option<bool>, now: &DateTime<Utc>) -> Result<Modifications> {
+pub fn update(caller: &User, member: &Member, company: &Company, mut subject: Member, occupation_id: Option<OccupationID>, agreement: Option<Url>, active: Option<bool>, now: &DateTime<Utc>) -> Result<Modifications> {
     caller.access_check(Permission::CompanyUpdateMembers)?;
-    member.access_check(caller.id(), &subject.company_id()?, CompanyPermission::MemberUpdate)?;
+    member.access_check(caller.id(), company.id(), CompanyPermission::MemberUpdate)?;
+    if company.id() != &subject.company_id()? {
+        Err(Error::InsufficientPrivileges)?;
+    }
+    if !company.is_active() {
+        Err(Error::ObjectIsInactive("company".into()))?;
+    }
 
     if let Some(occupation_id) = occupation_id {
         match subject.class_mut() {
@@ -80,9 +86,15 @@ pub fn update(caller: &User, member: &Member, mut subject: Member, occupation_id
 }
 
 /// Set a member's company permissions.
-pub fn set_permissions(caller: &User, member: &Member, mut subject: Member, permissions: Vec<CompanyPermission>, now: &DateTime<Utc>) -> Result<Modifications> {
+pub fn set_permissions(caller: &User, member: &Member, company: &Company, mut subject: Member, permissions: Vec<CompanyPermission>, now: &DateTime<Utc>) -> Result<Modifications> {
     caller.access_check(Permission::CompanyUpdateMembers)?;
-    member.access_check(caller.id(), &subject.company_id()?, CompanyPermission::MemberSetPermissions)?;
+    member.access_check(caller.id(), company.id(), CompanyPermission::MemberSetPermissions)?;
+    if company.id() != &subject.company_id()? {
+        Err(Error::InsufficientPrivileges)?;
+    }
+    if !company.is_active() {
+        Err(Error::ObjectIsInactive("company".into()))?;
+    }
 
     subject.set_permissions(permissions);
     subject.set_updated(now.clone());
@@ -90,9 +102,15 @@ pub fn set_permissions(caller: &User, member: &Member, mut subject: Member, perm
 }
 
 /// Set a member's compensation.
-pub fn set_compensation(caller: &User, member: &Member, mut subject: Member, compensation: Compensation, now: &DateTime<Utc>) -> Result<Modifications> {
+pub fn set_compensation(caller: &User, member: &Member, company: &Company, mut subject: Member, compensation: Compensation, now: &DateTime<Utc>) -> Result<Modifications> {
     caller.access_check(Permission::CompanyUpdateMembers)?;
-    member.access_check(caller.id(), &subject.company_id()?, CompanyPermission::MemberSetCompensation)?;
+    member.access_check(caller.id(), company.id(), CompanyPermission::MemberSetCompensation)?;
+    if company.id() != &subject.company_id()? {
+        Err(Error::InsufficientPrivileges)?;
+    }
+    if !company.is_active() {
+        Err(Error::ObjectIsInactive("company".into()))?;
+    }
 
     match subject.class_mut() {
         MemberClass::Worker(worker) => {
@@ -105,12 +123,19 @@ pub fn set_compensation(caller: &User, member: &Member, mut subject: Member, com
 }
 
 /// Delete a member.
-pub fn delete(caller: &User, member: &Member, mut subject: Member, now: &DateTime<Utc>) -> Result<Modifications> {
+pub fn delete(caller: &User, member: &Member, company: &Company, mut subject: Member, now: &DateTime<Utc>) -> Result<Modifications> {
     caller.access_check(Permission::CompanyUpdateMembers)?;
-    member.access_check(caller.id(), &subject.company_id()?, CompanyPermission::MemberDelete)?;
+    member.access_check(caller.id(), company.id(), CompanyPermission::MemberDelete)?;
+    if company.id() != &subject.company_id()? {
+        Err(Error::InsufficientPrivileges)?;
+    }
+    if !company.is_active() {
+        Err(Error::ObjectIsInactive("company".into()))?;
+    }
     if subject.is_deleted() {
         Err(Error::ObjectIsDeleted("member".into()))?;
     }
+
     subject.set_deleted(Some(now.clone()));
     Ok(Modifications::new_single(Op::Delete, subject))
 }
@@ -120,17 +145,15 @@ mod tests {
     use super::*;
     use crate::{
         models::{
-            account::AccountID,
-            company::CompanyID,
             member::*,
+            account::AccountID,
             lib::{
                 agent::Agent,
                 basis_model::Model,
             },
             user::UserID,
-            testutils::{deleted_company_tester, make_user, make_company, make_member_worker},
         },
-        util,
+        util::{self, test::{self, *}},
     };
     use rust_decimal_macros::*;
     use om2::{Measure, Unit};
@@ -139,20 +162,24 @@ mod tests {
     fn can_create() {
         let now = util::time::now();
         let id = MemberID::create();
-        let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
+        let mut state = TestState::standard(vec![CompanyPermission::MemberCreate], &now);
         let occupation_id = OccupationID::create();
         let agreement: Url = "https://mydoc.com/work_agreement_1".parse().unwrap();
-        let user = make_user(&UserID::create(), None, &now);
         let new_user = make_user(&UserID::create(), None, &now);
-        let existing_member = make_member_worker(&MemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::MemberCreate], &now);
         let new_class = MemberClass::Worker(MemberWorker::new(occupation_id.clone(), None));
+        state.model = Some(new_user);
 
-        let mods = create(&user, &existing_member, id.clone(), new_user.clone(), company.clone(), new_class.clone(), vec![], Some(agreement.clone()), true, &now).unwrap().into_vec();
+        let testfn = |state: &TestState<User, Member>| {
+            create(state.user(), state.member(), id.clone(), state.model().clone(), state.company().clone(), new_class.clone(), vec![], Some(agreement.clone()), true, &now)
+        };
+        test::standard_transaction_tests(&state, &testfn);
+
+        let mods = testfn(&state).unwrap().into_vec();
         assert_eq!(mods.len(), 1);
         let member = mods[0].clone().expect_op::<Member>(Op::Create).unwrap();
         assert_eq!(member.id(), &id);
-        assert_eq!(member.inner().subject(), &new_user.agent_id());
-        assert_eq!(member.inner().object(), &company.agent_id());
+        assert_eq!(member.inner().subject(), &state.model().agent_id());
+        assert_eq!(member.inner().object(), &state.company().agent_id());
         assert_eq!(member.occupation_id().unwrap(), &occupation_id);
         assert_eq!(member.permissions().len(), 0);
         assert_eq!(member.agreement(), &Some(agreement.clone()));
@@ -163,21 +190,9 @@ mod tests {
         assert_eq!(member.is_active(), true);
         assert_eq!(member.is_deleted(), false);
 
-        let user2 = make_user(user.id(), Some(vec![]), &now);
-        let res = create(&user2, &existing_member, id.clone(), new_user.clone(), company.clone(), new_class.clone(), vec![], Some(agreement.clone()), true, &now);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
-
-        let user3 = make_user(&UserID::create(), None, &now);
-        let res = create(&user3, &existing_member, id.clone(), new_user.clone(), company.clone(), new_class.clone(), vec![], Some(agreement.clone()), true, &now);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
-
-        deleted_company_tester(company.clone(), &now, |company: Company| {
-            create(&user, &existing_member, id.clone(), new_user.clone(), company.clone(), new_class.clone(), vec![], Some(agreement.clone()), true, &now)
-        });
-
-        let mut new_user2 = new_user.clone();
-        new_user2.set_deleted(Some(now.clone()));
-        let res = create(&user, &existing_member, id.clone(), new_user2.clone(), company.clone(), new_class.clone(), vec![], Some(agreement.clone()), true, &now);
+        let mut state2 = state.clone();
+        state2.model_mut().set_deleted(Some(now.clone()));
+        let res = testfn(&state2);
         assert_eq!(res, Err(Error::ObjectIsInactive("agent".into())));
     }
 
@@ -185,49 +200,49 @@ mod tests {
     fn can_update() {
         let now = util::time::now();
         let id = MemberID::create();
-        let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
+        let mut state = TestState::standard(vec![CompanyPermission::MemberCreate, CompanyPermission::MemberUpdate], &now);
         let occupation_id = OccupationID::create();
         let agreement: Url = "https://mydoc.com/work_agreement_1".parse().unwrap();
-        let user = make_user(&UserID::create(), None, &now);
         let new_user = make_user(&UserID::create(), None, &now);
-        let mut existing_member = make_member_worker(&MemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::MemberCreate], &now);
         let new_class = MemberClass::Worker(MemberWorker::new(occupation_id.clone(), None));
-
-        let mods = create(&user, &existing_member, id.clone(), new_user.clone(), company.clone(), new_class.clone(), vec![], None, true, &now).unwrap().into_vec();
+        let mods = create(state.user(), state.member(), id.clone(), new_user.clone(), state.company().clone(), new_class.clone(), vec![], None, true, &now).unwrap().into_vec();
         let member = mods[0].clone().expect_op::<Member>(Op::Create).unwrap();
+        state.model = Some(member);
 
-        // fails because existing_member doesn't have update perm
         let now2 = util::time::now();
         let new_occupation = OccupationID::create();
-        let res = update(&user, &existing_member, member.clone(), Some(new_occupation.clone()), None, None, &now2);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
+        let testfn = |state: &TestState<Member, Member>| {
+            update(state.user(), state.member(), state.company(), state.model().clone(), Some(new_occupation.clone()), Some(agreement.clone()), None, &now2)
+        };
 
-        existing_member.set_permissions(vec![CompanyPermission::MemberUpdate]);
-        let mods = update(&user, &existing_member, member.clone(), Some(new_occupation.clone()), Some(agreement.clone()), None, &now2).unwrap().into_vec();
+        let mods = testfn(&state).unwrap().into_vec();
         assert_eq!(mods.len(), 1);
-
         let member2 = mods[0].clone().expect_op::<Member>(Op::Update).unwrap();
-        assert_eq!(member.id(), member2.id());
-        assert_eq!(member.created(), member2.created());
-        assert!(member.updated() != member2.updated());
+        assert_eq!(state.model().id(), member2.id());
+        assert_eq!(state.model().created(), member2.created());
+        assert!(state.model().updated() != member2.updated());
         assert_eq!(member2.updated(), &now2);
-        assert!(member.agreement() != member2.agreement());
+        assert!(state.model().agreement() != member2.agreement());
         assert_eq!(member2.agreement(), &Some(agreement.clone()));
         assert_eq!(member2.active(), &true);
         assert_eq!(member2.occupation_id().unwrap(), &new_occupation);
 
-        let res = update(&user, &member, member.clone(), Some(new_occupation.clone()), Some(agreement.clone()), None, &now2);
+        let mut state2 = state.clone();
+        state2.member = state.model.clone();
+        let res = testfn(&state2);
         assert_eq!(res, Err(Error::InsufficientPrivileges));
 
-        let res = update(&new_user, &existing_member, member.clone(), Some(new_occupation.clone()), Some(agreement.clone()), None, &now2);
+        let mut state3 = state.clone();
+        state3.user = Some(new_user.clone());
+        let res = testfn(&state3);
         assert_eq!(res, Err(Error::InsufficientPrivileges));
 
-        let mut member3 = member2.clone();
-        member3.set_class(MemberClass::User(MemberUser::new()));
-        let res = update(&user, &existing_member, member3.clone(), Some(new_occupation.clone()), Some(agreement.clone()), None, &now2);
+        let mut state4 = state.clone();
+        state4.model_mut().set_class(MemberClass::User(MemberUser::new()));
+        let res = testfn(&state4);
         assert_eq!(res, Err(Error::MemberMustBeWorker));
-        member3.set_class(MemberClass::Company(MemberCompany::new()));
-        let res = update(&user, &existing_member, member3.clone(), Some(new_occupation.clone()), Some(agreement.clone()), None, &now2);
+        state4.model_mut().set_class(MemberClass::Company(MemberCompany::new()));
+        let res = testfn(&state4);
         assert_eq!(res, Err(Error::MemberMustBeWorker));
     }
 
@@ -235,41 +250,34 @@ mod tests {
     fn can_set_permissions() {
         let now = util::time::now();
         let id = MemberID::create();
-        let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
+        let mut state = TestState::standard(vec![CompanyPermission::MemberCreate, CompanyPermission::MemberSetPermissions], &now);
         let occupation_id = OccupationID::create();
-        let user = make_user(&UserID::create(), None, &now);
         let new_user = make_user(&UserID::create(), None, &now);
-        let mut existing_member = make_member_worker(&MemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::MemberCreate], &now);
         let new_class = MemberClass::Worker(MemberWorker::new(occupation_id.clone(), None));
-
-        let mods = create(&user, &existing_member, id.clone(), new_user.clone(), company.clone(), new_class.clone(), vec![], None, true, &now).unwrap().into_vec();
+        let mods = create(state.user(), state.member(), id.clone(), new_user.clone(), state.company().clone(), new_class.clone(), vec![], None, true, &now).unwrap().into_vec();
         let member = mods[0].clone().expect_op::<Member>(Op::Create).unwrap();
+        state.model = Some(member);
 
-        // fails because existing_member doesn't have set_perms perm
         let now2 = util::time::now();
-        let res = set_permissions(&user, &existing_member, member.clone(), vec![CompanyPermission::ResourceSpecCreate], &now2);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
+        let testfn = |state: &TestState<Member, Member>| {
+            set_permissions(state.user(), state.member(), state.company(), state.model().clone(), vec![CompanyPermission::ResourceSpecCreate], &now2)
+        };
+        test::standard_transaction_tests(&state, &testfn);
 
-        existing_member.set_permissions(vec![CompanyPermission::MemberSetPermissions]);
-        let mods = set_permissions(&user, &existing_member, member.clone(), vec![CompanyPermission::ResourceSpecCreate], &now2).unwrap().into_vec();
+        let mods = testfn(&state).unwrap().into_vec();
         assert_eq!(mods.len(), 1);
         let member2 = mods[0].clone().expect_op::<Member>(Op::Update).unwrap();
         assert_eq!(member2.permissions(), &vec![CompanyPermission::ResourceSpecCreate]);
-        assert!(!member.can(&CompanyPermission::ResourceSpecCreate));
+        assert!(!state.model().can(&CompanyPermission::ResourceSpecCreate));
         assert!(member2.can(&CompanyPermission::ResourceSpecCreate));
         assert_eq!(member2.updated(), &now2);
 
-        let mut user2 = user.clone();
-        user2.set_roles(vec![]);
-        let res = set_permissions(&user2, &existing_member, member.clone(), vec![CompanyPermission::ResourceSpecCreate], &now2);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
-
-        let mut member3 = member2.clone();
-        member3.set_class(MemberClass::User(MemberUser::new()));
-        let res = set_permissions(&user, &existing_member, member3.clone(), vec![CompanyPermission::ResourceSpecCreate], &now2);
+        let mut state2 = state.clone();
+        state2.model_mut().set_class(MemberClass::User(MemberUser::new()));
+        let res = testfn(&state2);
         assert!(res.is_ok());
-        member3.set_class(MemberClass::Company(MemberCompany::new()));
-        let res = set_permissions(&user, &existing_member, member3.clone(), vec![CompanyPermission::ResourceSpecCreate], &now2);
+        state2.model_mut().set_class(MemberClass::Company(MemberCompany::new()));
+        let res = testfn(&state2);
         assert!(res.is_ok());
     }
 
@@ -277,42 +285,35 @@ mod tests {
     fn can_set_compensation() {
         let now = util::time::now();
         let id = MemberID::create();
-        let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
+        let mut state = TestState::standard(vec![CompanyPermission::MemberCreate, CompanyPermission::MemberSetCompensation], &now);
         let occupation_id = OccupationID::create();
-        let user = make_user(&UserID::create(), None, &now);
         let new_user = make_user(&UserID::create(), None, &now);
-        let mut existing_member = make_member_worker(&MemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::MemberCreate], &now);
         let new_class = MemberClass::Worker(MemberWorker::new(occupation_id.clone(), None));
-
-        let mods = create(&user, &existing_member, id.clone(), new_user.clone(), company.clone(), new_class.clone(), vec![], None, true, &now).unwrap().into_vec();
+        let mods = create(state.user(), state.member(), id.clone(), new_user.clone(), state.company().clone(), new_class.clone(), vec![], None, true, &now).unwrap().into_vec();
         let member = mods[0].clone().expect_op::<Member>(Op::Create).unwrap();
+        state.model = Some(member);
 
         let compensation = Compensation::new_hourly(32 as u32, AccountID::create());
         let now2 = util::time::now();
-        // fails because existing_member doesn't have set_perms perm
-        let res = set_compensation(&user, &existing_member, member.clone(), compensation.clone(), &now2);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
+        let testfn = |state: &TestState<Member, Member>| {
+            set_compensation(state.user(), state.member(), state.company(), state.model().clone(), compensation.clone(), &now2)
+        };
+        test::standard_transaction_tests(&state, &testfn);
 
-        existing_member.set_permissions(vec![CompanyPermission::MemberSetCompensation]);
-        let mods = set_compensation(&user, &existing_member, member.clone(), compensation.clone(), &now2).unwrap().into_vec();
+        let mods = testfn(&state).unwrap().into_vec();
         assert_eq!(mods.len(), 1);
         let member2 = mods[0].clone().expect_op::<Member>(Op::Update).unwrap();
-        assert_eq!(member.compensation(), None);
+        assert_eq!(state.model().compensation(), None);
         assert_eq!(member2.compensation().unwrap().wage(), &Measure::new(dec!(32), Unit::Hour));
         assert_eq!(member2.compensation().unwrap(), &compensation);
         assert_eq!(member2.updated(), &now2);
 
-        let mut user2 = user.clone();
-        user2.set_roles(vec![]);
-        let res = set_compensation(&user2, &existing_member, member.clone(), compensation.clone(), &now2);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
-
-        let mut member3 = member2.clone();
-        member3.set_class(MemberClass::User(MemberUser::new()));
-        let res = set_compensation(&user, &existing_member, member3.clone(), compensation.clone(), &now2);
+        let mut state2 = state.clone();
+        state2.model_mut().set_class(MemberClass::User(MemberUser::new()));
+        let res = testfn(&state2);
         assert_eq!(res, Err(Error::MemberMustBeWorker));
-        member3.set_class(MemberClass::Company(MemberCompany::new()));
-        let res = set_compensation(&user, &existing_member, member3.clone(), compensation.clone(), &now2);
+        state2.model_mut().set_class(MemberClass::Company(MemberCompany::new()));
+        let res = testfn(&state2);
         assert_eq!(res, Err(Error::MemberMustBeWorker));
     }
 
@@ -320,37 +321,28 @@ mod tests {
     fn can_delete() {
         let now = util::time::now();
         let id = MemberID::create();
-        let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
+        let mut state = TestState::standard(vec![CompanyPermission::MemberCreate, CompanyPermission::MemberDelete], &now);
         let occupation_id = OccupationID::create();
-        let user = make_user(&UserID::create(), None, &now);
         let new_user = make_user(&UserID::create(), None, &now);
-        let mut existing_member = make_member_worker(&MemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::MemberCreate], &now);
         let new_class = MemberClass::Worker(MemberWorker::new(occupation_id.clone(), None));
-
-        let mods = create(&user, &existing_member, id.clone(), new_user.clone(), company.clone(), new_class.clone(), vec![], None, true, &now).unwrap().into_vec();
+        let mods = create(state.user(), state.member(), id.clone(), new_user.clone(), state.company().clone(), new_class.clone(), vec![], None, true, &now).unwrap().into_vec();
         let member = mods[0].clone().expect_op::<Member>(Op::Create).unwrap();
+        state.model = Some(member);
 
         let now2 = util::time::now();
-        // fails because existing_member doesn't have memberdelete perms
-        let res = delete(&user, &existing_member, member.clone(), &now2);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
+        let testfn = |state: &TestState<Member, Member>| {
+            delete(state.user(), state.member(), state.company(), state.model().clone(), &now2)
+        };
+        test::standard_transaction_tests(&state, &testfn);
+        test::double_deleted_tester(&state, "member", &testfn);
 
-        existing_member.set_permissions(vec![CompanyPermission::MemberDelete]);
-        let mods = delete(&user, &existing_member, member.clone(), &now2).unwrap().into_vec();
+        let mods = testfn(&state).unwrap().into_vec();
         assert_eq!(mods.len(), 1);
-
         let member2 = mods[0].clone().expect_op::<Member>(Op::Delete).unwrap();
         assert_eq!(member2.deleted(), &Some(now2.clone()));
         assert!(member2.is_deleted());
         assert!(member2.active());
         assert!(!member2.is_active());
-
-        let mut user2 = user.clone();
-        user2.set_roles(vec![]);
-        let res = delete(&user2, &existing_member, member.clone(), &now2);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
-
-        double_deleted_tester!(member, "member", |subject| delete(&user, &existing_member, subject, &now2));
     }
 }
 

--- a/src/transactions/member.rs
+++ b/src/transactions/member.rs
@@ -350,10 +350,7 @@ mod tests {
         let res = delete(&user2, &existing_member, member.clone(), &now2);
         assert_eq!(res, Err(Error::InsufficientPrivileges));
 
-        let mut member3 = member.clone();
-        member3.set_deleted(Some(now2.clone()));
-        let res = delete(&user, &existing_member, member3.clone(), &now2);
-        assert_eq!(res, Err(Error::ObjectIsDeleted("member".into())));
+        double_deleted_tester!(member, "member", |subject| delete(&user, &existing_member, subject, &now2));
     }
 }
 

--- a/src/transactions/member.rs
+++ b/src/transactions/member.rs
@@ -16,7 +16,7 @@ use crate::{
         member::{Compensation, Member, MemberID, MemberClass},
         lib::{
             agent::Agent,
-            basis_model::{ActiveState, Deletable},
+            basis_model::Model,
         },
         occupation::OccupationID,
         user::User,
@@ -125,7 +125,7 @@ mod tests {
             member::*,
             lib::{
                 agent::Agent,
-                basis_model::ActiveState,
+                basis_model::Model,
             },
             user::UserID,
             testutils::{deleted_company_tester, make_user, make_company, make_member_worker},

--- a/src/transactions/occupation.rs
+++ b/src/transactions/occupation.rs
@@ -144,10 +144,7 @@ mod tests {
         let res = delete(&user2, subject2, &now);
         assert_eq!(res, Err(Error::InsufficientPrivileges));
 
-        let mut subject3 = subject.clone();
-        subject3.set_deleted(Some(now.clone()));
-        let res = delete(&user, subject3.clone(), &now);
-        assert_eq!(res, Err(Error::ObjectIsDeleted("occupation".into())));
+        double_deleted_tester!(subject, "occupation", |subject| delete(&user, subject, &now));
     }
 }
 

--- a/src/transactions/occupation.rs
+++ b/src/transactions/occupation.rs
@@ -12,7 +12,7 @@ use crate::{
     models::{
         Op,
         Modifications,
-        lib::basis_model::Deletable,
+        lib::basis_model::Model,
         occupation::{Occupation, OccupationID},
         user::User,
     },

--- a/src/transactions/process.rs
+++ b/src/transactions/process.rs
@@ -270,10 +270,7 @@ mod tests {
             delete(&user, &member, &company, process.clone(), &now2)
         });
 
-        let mut process3 = process.clone();
-        process3.set_deleted(Some(now2.clone()));
-        let res = delete(&user, &member, &company, process3.clone(), &now2);
-        assert_eq!(res, Err(Error::ObjectIsDeleted("process".into())));
+        double_deleted_tester!(process, "process", |subject| delete(&user, &member, &company, subject, &now2));
     }
 }
 

--- a/src/transactions/process.rs
+++ b/src/transactions/process.rs
@@ -29,7 +29,7 @@ use crate::{
         member::Member,
         lib::{
             agent::AgentID,
-            basis_model::{ActiveState, Deletable},
+            basis_model::Model,
         },
         process::{Process, ProcessID},
         process_spec::ProcessSpecID,

--- a/src/transactions/process.rs
+++ b/src/transactions/process.rs
@@ -127,27 +127,25 @@ mod tests {
     use super::*;
     use crate::{
         models::{
-            company::CompanyID,
-            member::MemberID,
             lib::agent::Agent,
-            occupation::OccupationID,
             process_spec::ProcessSpecID,
-            testutils::{deleted_company_tester, make_user, make_company, make_member_worker, make_process_spec},
-            user::UserID,
         },
-        util,
+        util::{self, test::{self, *}},
     };
 
     #[test]
     fn can_create() {
         let now = util::time::now();
         let id = ProcessID::create();
-        let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
-        let user = make_user(&UserID::create(), None, &now);
-        let member = make_member_worker(&MemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::ProcessCreate], &now);
-        let spec = make_process_spec(&ProcessSpecID::create(), company.id(), "Make Gazelle Freestyle", true, &now);
+        let state = TestState::standard(vec![CompanyPermission::ProcessCreate], &now);
+        let spec = make_process_spec(&ProcessSpecID::create(), state.company().id(), "Make Gazelle Freestyle", true, &now);
 
-        let mods = create(&user, &member, &company, id.clone(), spec.id().clone(), "Gazelle Freestyle Marathon", "tony making me build five of these stupid things", vec!["https://www.wikidata.org/wiki/Q1141557".parse().unwrap()], Some(now.clone()), None, vec![], true, &now).unwrap().into_vec();
+        let testfn = |state: &TestState<Process, Process>| {
+            create(state.user(), state.member(), state.company(), id.clone(), spec.id().clone(), "Gazelle Freestyle Marathon", "tony making me build five of these stupid things", vec!["https://www.wikidata.org/wiki/Q1141557".parse().unwrap()], Some(now.clone()), None, vec![], true, &now)
+        };
+        test::standard_transaction_tests(&state, &testfn);
+
+        let mods = testfn(&state).unwrap().into_vec();
         assert_eq!(mods.len(), 1);
 
         let process = mods[0].clone().expect_op::<Process>(Op::Create).unwrap();
@@ -159,45 +157,32 @@ mod tests {
         assert_eq!(process.inner().in_scope_of(), &vec![]);
         assert_eq!(process.inner().name(), "Gazelle Freestyle Marathon");
         assert_eq!(process.inner().note(), &Some("tony making me build five of these stupid things".into()));
-        assert_eq!(process.company_id(), company.id());
+        assert_eq!(process.company_id(), state.company().id());
         assert!(process.costs().is_zero());
         assert_eq!(process.active(), &true);
         assert_eq!(process.created(), &now);
         assert_eq!(process.updated(), &now);
         assert_eq!(process.deleted(), &None);
-
-        let mut member2 = member.clone();
-        member2.set_permissions(vec![CompanyPermission::ProcessDelete]);
-        let res = create(&user, &member2, &company, id.clone(), spec.id().clone(), "Gazelle Freestyle Marathon", "tony making me build five of these stupid things", vec!["https://www.wikidata.org/wiki/Q1141557".parse().unwrap()], Some(now.clone()), None, vec![], true, &now);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
-
-        let mut user2 = user.clone();
-        user2.set_roles(vec![]);
-        let res = create(&user2, &member, &company, id.clone(), spec.id().clone(), "Gazelle Freestyle Marathon", "tony making me build five of these stupid things", vec!["https://www.wikidata.org/wiki/Q1141557".parse().unwrap()], Some(now.clone()), None, vec![], true, &now);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
-
-        deleted_company_tester(company.clone(), &now, |company: Company| {
-            create(&user, &member, &company, id.clone(), spec.id().clone(), "Gazelle Freestyle Marathon", "tony making me build five of these stupid things", vec!["https://www.wikidata.org/wiki/Q1141557".parse().unwrap()], Some(now.clone()), None, vec![], true, &now)
-        });
     }
 
     #[test]
     fn can_update() {
         let now = util::time::now();
         let id = ProcessID::create();
-        let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
-        let user = make_user(&UserID::create(), None, &now);
-        let mut member = make_member_worker(&MemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::ProcessCreate], &now);
-        let spec = make_process_spec(&ProcessSpecID::create(), company.id(), "Make Gazelle Freestyle", true, &now);
-        let mods = create(&user, &member, &company, id.clone(), spec.id().clone(), "Gazelle Freestyle Marathon", "tony making me build five of these stupid things", vec!["https://www.wikidata.org/wiki/Q1141557".parse().unwrap()], Some(now.clone()), None, vec![], true, &now).unwrap().into_vec();
+        let mut state = TestState::standard(vec![CompanyPermission::ProcessCreate, CompanyPermission::ProcessUpdate], &now);
+        let spec = make_process_spec(&ProcessSpecID::create(), state.company().id(), "Make Gazelle Freestyle", true, &now);
+
+        let mods = create(state.user(), state.member(), state.company(), id.clone(), spec.id().clone(), "Gazelle Freestyle Marathon", "tony making me build five of these stupid things", vec!["https://www.wikidata.org/wiki/Q1141557".parse().unwrap()], Some(now.clone()), None, vec![], true, &now).unwrap().into_vec();
         let process = mods[0].clone().expect_op::<Process>(Op::Create).unwrap();
+        state.model = Some(process);
 
-        let res = update(&user, &member, &company, process.clone(), Some("Make a GaZeLLe fReeStYlE".into()), None, None, Some(true), None, Some(now.clone()), Some(vec![company.agent_id()]), Some(false), &now);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
-
-        member.set_permissions(vec![CompanyPermission::ProcessUpdate]);
         let now2 = util::time::now();
-        let mods = update(&user, &member, &company, process.clone(), Some("Make a GaZeLLe fReeStYlE".into()), None, None, Some(true), None, Some(now2.clone()), Some(vec![company.agent_id()]), Some(false), &now2).unwrap().into_vec();
+        let testfn = |state: &TestState<Process, Process>| {
+            update(state.user(), state.member(), state.company(), state.model().clone(), Some("Make a GaZeLLe fReeStYlE".into()), None, None, Some(true), None, Some(now2.clone()), Some(vec![state.company().agent_id()]), Some(false), &now2)
+        };
+        test::standard_transaction_tests(&state, &testfn);
+
+        let mods = testfn(&state).unwrap().into_vec();
         assert_eq!(mods.len(), 1);
 
         let process2 = mods[0].clone().expect_op::<Process>(Op::Update).unwrap();
@@ -206,43 +191,36 @@ mod tests {
         assert_eq!(process2.inner().classified_as(), &vec!["https://www.wikidata.org/wiki/Q1141557".parse().unwrap()]);
         assert_eq!(process2.inner().has_beginning(), &Some(now.clone()));
         assert_eq!(process2.inner().has_end(), &Some(now2.clone()));
-        assert_eq!(process2.inner().in_scope_of(), &vec![company.agent_id()]);
+        assert_eq!(process2.inner().in_scope_of(), &vec![state.company().agent_id()]);
         assert_eq!(process2.inner().name(), "Make a GaZeLLe fReeStYlE");
         assert_eq!(process2.inner().note(), &Some("tony making me build five of these stupid things".into()));
-        assert_eq!(process2.company_id(), company.id());
+        assert_eq!(process2.company_id(), state.company().id());
         assert!(process2.costs().is_zero());
         assert_eq!(process2.active(), &false);
         assert_eq!(process2.created(), &now);
         assert_eq!(process2.updated(), &now2);
         assert_eq!(process2.deleted(), &None);
-
-        let mut user2 = user.clone();
-        user2.set_roles(vec![]);
-        let res = update(&user2, &member, &company, process.clone(), Some("Make a GaZeLLe fReeStYlE".into()), None, None, Some(true), None, Some(now2.clone()), Some(vec![company.agent_id()]), Some(false), &now2);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
-
-        deleted_company_tester(company.clone(), &now2, |company: Company| {
-            update(&user, &member, &company, process.clone(), Some("Make a GaZeLLe fReeStYlE".into()), None, None, Some(true), None, Some(now2.clone()), Some(vec![company.agent_id()]), Some(false), &now2)
-        });
     }
 
     #[test]
     fn can_delete() {
         let now = util::time::now();
         let id = ProcessID::create();
-        let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
-        let user = make_user(&UserID::create(), None, &now);
-        let mut member = make_member_worker(&MemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::ProcessCreate], &now);
-        let spec = make_process_spec(&ProcessSpecID::create(), company.id(), "Make Gazelle Freestyle", true, &now);
-        let mods = create(&user, &member, &company, id.clone(), spec.id().clone(), "Gazelle Freestyle Marathon", "tony making me build five of these stupid things", vec!["https://www.wikidata.org/wiki/Q1141557".parse().unwrap()], Some(now.clone()), None, vec![], true, &now).unwrap().into_vec();
+        let mut state = TestState::standard(vec![CompanyPermission::CommitmentCreate, CompanyPermission::ProcessCreate, CompanyPermission::ProcessDelete], &now);
+        let spec = make_process_spec(&ProcessSpecID::create(), state.company().id(), "Make Gazelle Freestyle", true, &now);
+
+        let mods = create(state.user(), state.member(), state.company(), id.clone(), spec.id().clone(), "Gazelle Freestyle Marathon", "tony making me build five of these stupid things", vec!["https://www.wikidata.org/wiki/Q1141557".parse().unwrap()], Some(now.clone()), None, vec![], true, &now).unwrap().into_vec();
         let process = mods[0].clone().expect_op::<Process>(Op::Create).unwrap();
+        state.model = Some(process);
 
         let now2 = util::time::now();
-        let res = delete(&user, &member, &company, process.clone(), &now2);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
+        let testfn = |state: &TestState<Process, Process>| {
+            delete(state.user(), state.member(), state.company(), state.model().clone(), &now2)
+        };
+        test::standard_transaction_tests(&state, &testfn);
+        test::double_deleted_tester(&state, "process", &testfn);
 
-        member.set_permissions(vec![CompanyPermission::ProcessDelete]);
-        let mods = delete(&user, &member, &company, process.clone(), &now2).unwrap().into_vec();
+        let mods = testfn(&state).unwrap().into_vec();
         assert_eq!(mods.len(), 1);
 
         let process2 = mods[0].clone().expect_op::<Process>(Op::Delete).unwrap();
@@ -254,23 +232,12 @@ mod tests {
         assert_eq!(process2.inner().in_scope_of(), &vec![]);
         assert_eq!(process2.inner().name(), "Gazelle Freestyle Marathon");
         assert_eq!(process2.inner().note(), &Some("tony making me build five of these stupid things".into()));
-        assert_eq!(process2.company_id(), company.id());
+        assert_eq!(process2.company_id(), state.company().id());
         assert!(process2.costs().is_zero());
         assert_eq!(process2.active(), &true);
         assert_eq!(process2.created(), &now);
         assert_eq!(process2.updated(), &now);
         assert_eq!(process2.deleted(), &Some(now2.clone()));
-
-        let mut user2 = user.clone();
-        user2.set_roles(vec![]);
-        let res = delete(&user2, &member, &company, process.clone(), &now2);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
-
-        deleted_company_tester(company.clone(), &now2, |company: Company| {
-            delete(&user, &member, &company, process.clone(), &now2)
-        });
-
-        double_deleted_tester!(process, "process", |subject| delete(&user, &member, &company, subject, &now2));
     }
 }
 

--- a/src/transactions/process_spec.rs
+++ b/src/transactions/process_spec.rs
@@ -18,7 +18,7 @@ use crate::{
         Modifications,
         company::{Company, Permission as CompanyPermission},
         member::Member,
-        lib::basis_model::{ActiveState, Deletable},
+        lib::basis_model::Model,
         process_spec::{ProcessSpec, ProcessSpecID},
         user::User,
     },

--- a/src/transactions/process_spec.rs
+++ b/src/transactions/process_spec.rs
@@ -209,10 +209,7 @@ mod tests {
             delete(&user, &member, &company, procspec.clone(), &now2)
         });
 
-        let mut procspec3 = procspec.clone();
-        procspec3.set_deleted(Some(now2.clone()));
-        let res = delete(&user, &member, &company, procspec3.clone(), &now2);
-        assert_eq!(res, Err(Error::ObjectIsDeleted("process_spec".into())));
+        double_deleted_tester!(procspec, "process_spec", |subject| delete(&user, &member, &company, subject, &now2));
     }
 }
 

--- a/src/transactions/process_spec.rs
+++ b/src/transactions/process_spec.rs
@@ -89,127 +89,90 @@ mod tests {
     use super::*;
     use crate::{
         models::{
-            company::CompanyID,
-            member::MemberID,
-            occupation::OccupationID,
             process_spec::{ProcessSpec, ProcessSpecID},
-            testutils::{deleted_company_tester, make_user, make_company, make_member_worker},
-            user::UserID,
         },
-        util,
+        util::{self, test::{self, *}},
     };
 
     #[test]
     fn can_create() {
         let now = util::time::now();
         let id = ProcessSpecID::create();
-        let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
-        let user = make_user(&UserID::create(), None, &now);
-        let member = make_member_worker(&MemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::ProcessSpecCreate], &now);
+        let state = TestState::standard(vec![CompanyPermission::ProcessSpecCreate], &now);
 
-        let mods = create(&user, &member, &company, id.clone(), "SEIZE THE MEANS OF PRODUCTION", "our first process", true, &now).unwrap().into_vec();
+        let testfn = |state: &TestState<ProcessSpec, ProcessSpec>| {
+            create(state.user(), state.member(), state.company(), id.clone(), "SEIZE THE MEANS OF PRODUCTION", "our first process", true, &now)
+        };
+
+        let mods = testfn(&state).unwrap().into_vec();
         assert_eq!(mods.len(), 1);
 
         let recspec = mods[0].clone().expect_op::<ProcessSpec>(Op::Create).unwrap();
         assert_eq!(recspec.id(), &id);
         assert_eq!(recspec.inner().name(), "SEIZE THE MEANS OF PRODUCTION");
         assert_eq!(recspec.inner().note(), &Some("our first process".into()));
-        assert_eq!(recspec.company_id(), company.id());
+        assert_eq!(recspec.company_id(), state.company().id());
         assert_eq!(recspec.active(), &true);
         assert_eq!(recspec.created(), &now);
         assert_eq!(recspec.updated(), &now);
         assert_eq!(recspec.deleted(), &None);
-
-        let mut member2 = member.clone();
-        member2.set_permissions(vec![CompanyPermission::ProcessSpecDelete]);
-        let res = create(&user, &member2, &company, id.clone(), "SEIZE THE MEANS OF PRODUCTION", "our first process", true, &now);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
-
-        let mut user2 = user.clone();
-        user2.set_roles(vec![]);
-        let res = create(&user2, &member, &company, id.clone(), "SEIZE THE MEANS OF PRODUCTION", "our first process", true, &now);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
-
-        deleted_company_tester(company.clone(), &now, |company: Company| {
-            create(&user, &member, &company, id.clone(), "SEIZE THE MEANS OF PRODUCTION", "our first process", true, &now)
-        });
     }
 
     #[test]
     fn can_update() {
         let now = util::time::now();
         let id = ProcessSpecID::create();
-        let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
-        let user = make_user(&UserID::create(), None, &now);
-        let mut member = make_member_worker(&MemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::ProcessSpecCreate], &now);
-        let mods = create(&user, &member, &company, id.clone(), "SEIZE THE MEANS OF PRODUCTION", "our first process", true, &now).unwrap().into_vec();
-        let recspec = mods[0].clone().expect_op::<ProcessSpec>(Op::Create).unwrap();
+        let mut state = TestState::standard(vec![CompanyPermission::ProcessSpecCreate, CompanyPermission::ProcessSpecUpdate], &now);
+        let mods = create(state.user(), state.member(), state.company(), id.clone(), "SEIZE THE MEANS OF PRODUCTION", "our first process", true, &now).unwrap().into_vec();
+        let procspec = mods[0].clone().expect_op::<ProcessSpec>(Op::Create).unwrap();
+        state.model = Some(procspec);
 
-        let res = update(&user, &member, &company, recspec.clone(), Some("best widget".into()), None, Some(false), &now);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
-
-        member.set_permissions(vec![CompanyPermission::ProcessSpecUpdate]);
         let now2 = util::time::now();
-        let mods = update(&user, &member, &company, recspec.clone(), Some("best widget".into()), None, Some(false), &now2).unwrap().into_vec();
+        let testfn = |state: &TestState<ProcessSpec, ProcessSpec>| {
+            update(state.user(), state.member(), state.company(), state.model().clone(), Some("best widget".into()), None, Some(false), &now2)
+        };
+
+        let mods = testfn(&state).unwrap().into_vec();
         assert_eq!(mods.len(), 1);
 
-        let recspec2 = mods[0].clone().expect_op::<ProcessSpec>(Op::Update).unwrap();
-        assert_eq!(recspec2.id(), &id);
-        assert_eq!(recspec2.inner().name(), "best widget");
-        assert_eq!(recspec2.inner().note(), &Some("our first process".into()));
-        assert_eq!(recspec2.company_id(), company.id());
-        assert_eq!(recspec2.active(), &false);
-        assert_eq!(recspec2.created(), &now);
-        assert_eq!(recspec2.updated(), &now2);
-        assert_eq!(recspec2.deleted(), &None);
-
-        let mut user2 = user.clone();
-        user2.set_roles(vec![]);
-        let res = update(&user2, &member, &company, recspec.clone(), Some("best widget".into()), None, Some(false), &now2);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
-
-        deleted_company_tester(company.clone(), &now2, |company: Company| {
-            update(&user, &member, &company, recspec.clone(), Some("best widget".into()), None, Some(false), &now2)
-        });
+        let procspec2 = mods[0].clone().expect_op::<ProcessSpec>(Op::Update).unwrap();
+        assert_eq!(procspec2.id(), &id);
+        assert_eq!(procspec2.inner().name(), "best widget");
+        assert_eq!(procspec2.inner().note(), &Some("our first process".into()));
+        assert_eq!(procspec2.company_id(), state.company().id());
+        assert_eq!(procspec2.active(), &false);
+        assert_eq!(procspec2.created(), &now);
+        assert_eq!(procspec2.updated(), &now2);
+        assert_eq!(procspec2.deleted(), &None);
     }
 
     #[test]
     fn can_delete() {
         let now = util::time::now();
         let id = ProcessSpecID::create();
-        let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
-        let user = make_user(&UserID::create(), None, &now);
-        let mut member = make_member_worker(&MemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::ProcessSpecCreate], &now);
-        let mods = create(&user, &member, &company, id.clone(), "SEIZE THE MEANS OF PRODUCTION", "our first process", true, &now).unwrap().into_vec();
+        let mut state = TestState::standard(vec![CompanyPermission::ProcessSpecCreate, CompanyPermission::ProcessSpecDelete], &now);
+        let mods = create(state.user(), state.member(), state.company(), id.clone(), "SEIZE THE MEANS OF PRODUCTION", "our first process", true, &now).unwrap().into_vec();
         let procspec = mods[0].clone().expect_op::<ProcessSpec>(Op::Create).unwrap();
+        state.model = Some(procspec);
 
         let now2 = util::time::now();
-        let res = delete(&user, &member, &company, procspec.clone(), &now2);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
+        let testfn = |state: &TestState<ProcessSpec, ProcessSpec>| {
+            delete(state.user(), state.member(), state.company(), state.model().clone(), &now2)
+        };
+        test::standard_transaction_tests(&state, &testfn);
+        test::double_deleted_tester(&state, "process_spec", &testfn);
 
-        member.set_permissions(vec![CompanyPermission::ProcessSpecDelete]);
-        let mods = delete(&user, &member, &company, procspec.clone(), &now2).unwrap().into_vec();
+        let mods = testfn(&state).unwrap().into_vec();
         assert_eq!(mods.len(), 1);
 
         let procspec2 = mods[0].clone().expect_op::<ProcessSpec>(Op::Delete).unwrap();
         assert_eq!(procspec2.id(), &id);
         assert_eq!(procspec2.inner().name(), "SEIZE THE MEANS OF PRODUCTION");
-        assert_eq!(procspec2.company_id(), company.id());
+        assert_eq!(procspec2.company_id(), state.company().id());
         assert_eq!(procspec2.active(), &true);
         assert_eq!(procspec2.created(), &now);
         assert_eq!(procspec2.updated(), &now);
         assert_eq!(procspec2.deleted(), &Some(now2.clone()));
-
-        let mut user2 = user.clone();
-        user2.set_roles(vec![]);
-        let res = delete(&user2, &member, &company, procspec.clone(), &now2);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
-
-        deleted_company_tester(company.clone(), &now2, |company: Company| {
-            delete(&user, &member, &company, procspec.clone(), &now2)
-        });
-
-        double_deleted_tester!(procspec, "process_spec", |subject| delete(&user, &member, &company, subject, &now2));
     }
 }
 

--- a/src/transactions/resource.rs
+++ b/src/transactions/resource.rs
@@ -119,29 +119,26 @@ mod tests {
     use super::*;
     use crate::{
         models::{
-            company::CompanyID,
-            member::MemberID,
-            occupation::OccupationID,
             resource_spec::ResourceSpecID,
-            testutils::{deleted_company_tester, make_user, make_company, make_member_worker, make_resource_spec},
-            user::UserID,
         },
-        util,
+        util::{self, test::{self, *}},
     };
 
     #[test]
     fn can_create() {
         let now = util::time::now();
         let id = ResourceID::create();
-        let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
-        let user = make_user(&UserID::create(), None, &now);
-        let member = make_member_worker(&MemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::ResourceCreate], &now);
-        let spec = make_resource_spec(&ResourceSpecID::create(), company.id(), "widgets, baby", &now);
+        let state = TestState::standard(vec![CompanyPermission::ResourceCreate], &now);
+        let spec = make_resource_spec(&ResourceSpecID::create(), state.company().id(), "widgets, baby", &now);
         let lot = dfc::ProductBatch::builder()
             .batch_number("123")
             .build().unwrap();
 
-        let mods = create(&user, &member, &company, id.clone(), spec.id().clone(), Some(lot.clone()), Some("widget batch".into()), None, vec!["https://www.wikidata.org/wiki/Q605117".parse().unwrap()], Some("niceee".into()), Some(Unit::Hour), true, &now).unwrap().into_vec();
+        let testfn = |state: &TestState<Resource, Resource>| {
+            create(state.user(), state.member(), state.company(), id.clone(), spec.id().clone(), Some(lot.clone()), Some("widget batch".into()), None, vec!["https://www.wikidata.org/wiki/Q605117".parse().unwrap()], Some("niceee".into()), Some(Unit::Hour), true, &now)
+        };
+
+        let mods = testfn(&state).unwrap().into_vec();
         assert_eq!(mods.len(), 1);
 
         let resource = mods[0].clone().expect_op::<Resource>(Op::Create).unwrap();
@@ -149,51 +146,37 @@ mod tests {
         assert_eq!(resource.inner().name(), &Some("widget batch".into()));
         assert_eq!(resource.inner().lot(), &Some(lot.clone()));
         assert_eq!(resource.inner().classified_as(), &vec!["https://www.wikidata.org/wiki/Q605117".parse().unwrap()]);
-        assert_eq!(resource.inner().primary_accountable(), &Some(company.agent_id()));
+        assert_eq!(resource.inner().primary_accountable(), &Some(state.company().agent_id()));
         assert_eq!(resource.inner().tracking_identifier(), &None);
         assert_eq!(resource.inner().note(), &Some("niceee".into()));
         assert_eq!(resource.inner().unit_of_effort(), &Some(Unit::Hour));
-        assert_eq!(resource.in_custody_of(), &company.agent_id());
+        assert_eq!(resource.in_custody_of(), &state.company().agent_id());
         assert!(resource.costs().is_zero());
         assert_eq!(resource.active(), &true);
         assert_eq!(resource.created(), &now);
         assert_eq!(resource.updated(), &now);
         assert_eq!(resource.deleted(), &None);
-
-        let mut member2 = member.clone();
-        member2.set_permissions(vec![CompanyPermission::ResourceDelete]);
-        let res = create(&user, &member2, &company, id.clone(), spec.id().clone(), Some(lot.clone()), Some("widget batch".into()), None, vec!["https://www.wikidata.org/wiki/Q605117".parse().unwrap()], Some("niceee".into()), Some(Unit::Hour), true, &now);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
-
-        let mut user2 = user.clone();
-        user2.set_roles(vec![]);
-        let res = create(&user2, &member, &company, id.clone(), spec.id().clone(), Some(lot.clone()), Some("widget batch".into()), None, vec!["https://www.wikidata.org/wiki/Q605117".parse().unwrap()], Some("niceee".into()), Some(Unit::Hour), true, &now);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
-
-        deleted_company_tester(company.clone(), &now, |company: Company| {
-            create(&user, &member, &company, id.clone(), spec.id().clone(), Some(lot.clone()), Some("widget batch".into()), None, vec!["https://www.wikidata.org/wiki/Q605117".parse().unwrap()], Some("niceee".into()), Some(Unit::Hour), true, &now)
-        });
     }
 
     #[test]
     fn can_update() {
         let now = util::time::now();
         let id = ResourceID::create();
-        let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
-        let user = make_user(&UserID::create(), None, &now);
-        let mut member = make_member_worker(&MemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::ResourceCreate], &now);
-        let spec = make_resource_spec(&ResourceSpecID::create(), company.id(), "widgets, baby", &now);
+        let mut state = TestState::standard(vec![CompanyPermission::ResourceCreate, CompanyPermission::ResourceUpdate], &now);
+        let spec = make_resource_spec(&ResourceSpecID::create(), state.company().id(), "widgets, baby", &now);
         let lot = dfc::ProductBatch::builder()
             .batch_number("123")
             .build().unwrap();
-        let mods = create(&user, &member, &company, id.clone(), spec.id().clone(), Some(lot.clone()), Some("widget batch".into()), None, vec!["https://www.wikidata.org/wiki/Q605117".parse().unwrap()], Some("niceee".into()), Some(Unit::Hour), true, &now).unwrap().into_vec();
+        let mods = create(state.user(), state.member(), state.company(), id.clone(), spec.id().clone(), Some(lot.clone()), Some("widget batch".into()), None, vec!["https://www.wikidata.org/wiki/Q605117".parse().unwrap()], Some("niceee".into()), Some(Unit::Hour), true, &now).unwrap().into_vec();
         let resource = mods[0].clone().expect_op::<Resource>(Op::Create).unwrap();
+        state.model = Some(resource);
 
-        let res = update(&user, &member, &company, resource.clone(), None, Some("better widgets".into()), Some("444-computers-and-equipment".into()), None, None, Some(Unit::WattHour), Some(false), &now);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
+        let now2 = util::time::now();
+        let testfn = |state: &TestState<Resource, Resource>| {
+            update(state.user(), state.member(), state.company(), state.model().clone(), None, Some("better widgets".into()), Some("444-computers-and-equipment".into()), None, None, Some(Unit::WattHour), Some(false), &now2)
+        };
 
-        member.set_permissions(vec![CompanyPermission::ResourceUpdate]);
-        let mods = update(&user, &member, &company, resource.clone(), None, Some("better widgets".into()), Some("444-computers-and-equipment".into()), None, None, Some(Unit::WattHour), Some(false), &now).unwrap().into_vec();
+        let mods = testfn(&state).unwrap().into_vec();
         assert_eq!(mods.len(), 1);
 
         let resource2 = mods[0].clone().expect_op::<Resource>(Op::Update).unwrap();
@@ -201,46 +184,38 @@ mod tests {
         assert_eq!(resource2.inner().name(), &Some("better widgets".into()));
         assert_eq!(resource2.inner().lot(), &Some(lot.clone()));
         assert_eq!(resource2.inner().classified_as(), &vec!["https://www.wikidata.org/wiki/Q605117".parse().unwrap()]);
-        assert_eq!(resource2.inner().primary_accountable(), &Some(company.agent_id()));
+        assert_eq!(resource2.inner().primary_accountable(), &Some(state.company().agent_id()));
         assert_eq!(resource2.inner().tracking_identifier(), &Some("444-computers-and-equipment".into()));
         assert_eq!(resource2.inner().note(), &Some("niceee".into()));
         assert_eq!(resource2.inner().unit_of_effort(), &Some(Unit::WattHour));
-        assert_eq!(resource2.in_custody_of(), &company.agent_id());
+        assert_eq!(resource2.in_custody_of(), &state.company().agent_id());
         assert_eq!(resource2.active(), &false);
         assert_eq!(resource2.created(), &now);
-        assert_eq!(resource2.updated(), &now);
+        assert_eq!(resource2.updated(), &now2);
         assert_eq!(resource2.deleted(), &None);
-
-        let mut user2 = user.clone();
-        user2.set_roles(vec![]);
-        let res = update(&user2, &member, &company, resource.clone(), None, Some("better widgets".into()), Some("444-computers-and-equipment".into()), None, None, Some(Unit::WattHour), Some(false), &now);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
-
-        deleted_company_tester(company.clone(), &now, |company: Company| {
-            update(&user, &member, &company, resource.clone(), None, Some("better widgets".into()), Some("444-computers-and-equipment".into()), None, None, Some(Unit::WattHour), Some(false), &now)
-        });
     }
 
     #[test]
     fn can_delete() {
         let now = util::time::now();
         let id = ResourceID::create();
-        let company = make_company(&CompanyID::create(), "jerry's widgets", &now);
-        let user = make_user(&UserID::create(), None, &now);
-        let mut member = make_member_worker(&MemberID::create(), user.id(), company.id(), &OccupationID::create(), vec![CompanyPermission::ResourceCreate], &now);
-        let spec = make_resource_spec(&ResourceSpecID::create(), company.id(), "widgets, baby", &now);
+        let mut state = TestState::standard(vec![CompanyPermission::ResourceCreate, CompanyPermission::ResourceDelete], &now);
+        let spec = make_resource_spec(&ResourceSpecID::create(), state.company().id(), "widgets, baby", &now);
         let lot = dfc::ProductBatch::builder()
             .batch_number("123")
             .build().unwrap();
-        let mods = create(&user, &member, &company, id.clone(), spec.id().clone(), Some(lot.clone()), Some("widget batch".into()), None, vec!["https://www.wikidata.org/wiki/Q605117".parse().unwrap()], Some("niceee".into()), Some(Unit::Hour), true, &now).unwrap().into_vec();
+        let mods = create(state.user(), state.member(), state.company(), id.clone(), spec.id().clone(), Some(lot.clone()), Some("widget batch".into()), None, vec!["https://www.wikidata.org/wiki/Q605117".parse().unwrap()], Some("niceee".into()), Some(Unit::Hour), true, &now).unwrap().into_vec();
         let resource = mods[0].clone().expect_op::<Resource>(Op::Create).unwrap();
+        state.model = Some(resource);
 
         let now2 = util::time::now();
-        let res = delete(&user, &member, &company, resource.clone(), &now2);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
+        let testfn = |state: &TestState<Resource, Resource>| {
+            delete(state.user(), state.member(), state.company(), state.model().clone(), &now2)
+        };
+        test::standard_transaction_tests(&state, &testfn);
+        test::double_deleted_tester(&state, "resource", &testfn);
 
-        member.set_permissions(vec![CompanyPermission::ResourceDelete]);
-        let mods = delete(&user, &member, &company, resource.clone(), &now2).unwrap().into_vec();
+        let mods = testfn(&state).unwrap().into_vec();
         assert_eq!(mods.len(), 1);
 
         let resource2 = mods[0].clone().expect_op::<Resource>(Op::Delete).unwrap();
@@ -248,26 +223,15 @@ mod tests {
         assert_eq!(resource2.inner().name(), &Some("widget batch".into()));
         assert_eq!(resource2.inner().lot(), &Some(lot.clone()));
         assert_eq!(resource2.inner().classified_as(), &vec!["https://www.wikidata.org/wiki/Q605117".parse().unwrap()]);
-        assert_eq!(resource2.inner().primary_accountable(), &Some(company.agent_id()));
+        assert_eq!(resource2.inner().primary_accountable(), &Some(state.company().agent_id()));
         assert_eq!(resource2.inner().tracking_identifier(), &None);
         assert_eq!(resource2.inner().note(), &Some("niceee".into()));
         assert_eq!(resource2.inner().unit_of_effort(), &Some(Unit::Hour));
-        assert_eq!(resource2.in_custody_of(), &company.agent_id());
+        assert_eq!(resource2.in_custody_of(), &state.company().agent_id());
         assert_eq!(resource2.active(), &true);
         assert_eq!(resource2.created(), &now);
         assert_eq!(resource2.updated(), &now);
         assert_eq!(resource2.deleted(), &Some(now2.clone()));
-
-        let mut user2 = user.clone();
-        user2.set_roles(vec![]);
-        let res = delete(&user2, &member, &company, resource.clone(), &now2);
-        assert_eq!(res, Err(Error::InsufficientPrivileges));
-
-        deleted_company_tester(company.clone(), &now2, |company: Company| {
-            delete(&user, &member, &company, resource.clone(), &now2)
-        });
-
-        double_deleted_tester!(resource, "resource", |subject| delete(&user, &member, &company, subject, &now2));
     }
 }
 

--- a/src/transactions/resource.rs
+++ b/src/transactions/resource.rs
@@ -267,10 +267,7 @@ mod tests {
             delete(&user, &member, &company, resource.clone(), &now2)
         });
 
-        let mut resource3 = resource.clone();
-        resource3.set_deleted(Some(now2.clone()));
-        let res = delete(&user, &member, &company, resource3.clone(), &now2);
-        assert_eq!(res, Err(Error::ObjectIsDeleted("resource".into())));
+        double_deleted_tester!(resource, "resource", |subject| delete(&user, &member, &company, subject, &now2));
     }
 }
 

--- a/src/transactions/resource.rs
+++ b/src/transactions/resource.rs
@@ -22,7 +22,7 @@ use crate::{
         member::Member,
         lib::{
             agent::Agent,
-            basis_model::{ActiveState, Deletable},
+            basis_model::Model,
         },
         resource::{Resource, ResourceID},
         resource_spec::ResourceSpecID,

--- a/src/transactions/resource_spec.rs
+++ b/src/transactions/resource_spec.rs
@@ -19,7 +19,7 @@ use crate::{
         Modifications,
         company::{Company, Permission as CompanyPermission},
         member::Member,
-        lib::basis_model::{ActiveState, Deletable},
+        lib::basis_model::Model,
         resource_spec::{ResourceSpec, ResourceSpecID},
         user::User,
     },

--- a/src/transactions/resource_spec.rs
+++ b/src/transactions/resource_spec.rs
@@ -233,10 +233,7 @@ mod tests {
             delete(&user, &member, &company, recspec.clone(), &now2)
         });
 
-        let mut recspec3 = recspec.clone();
-        recspec3.set_deleted(Some(now2.clone()));
-        let res = delete(&user, &member, &company, recspec3.clone(), &now2);
-        assert_eq!(res, Err(Error::ObjectIsDeleted("resource_spec".into())));
+        double_deleted_tester!(recspec, "resource_spec", |subject| delete(&user, &member, &company, subject, &now2));
     }
 }
 

--- a/src/transactions/user.rs
+++ b/src/transactions/user.rs
@@ -206,10 +206,7 @@ mod tests {
         let res = delete(&deleted.clone(), deleted, &now);
         assert_eq!(res, Err(Error::InsufficientPrivileges));
 
-        let mut user3 = user.clone();
-        user3.set_deleted(Some(now.clone()));
-        let res = delete(&user, user3.clone(), &now);
-        assert_eq!(res, Err(Error::ObjectIsDeleted("user".into())));
+        double_deleted_tester!(user, "user", |subject| delete(&user, subject, &now));
     }
 }
 

--- a/src/transactions/user.rs
+++ b/src/transactions/user.rs
@@ -11,7 +11,7 @@ use crate::{
     models::{
         Op,
         Modifications,
-        lib::basis_model::Deletable,
+        lib::basis_model::Model,
         user::{User, UserID},
     },
 };

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,3 +1,7 @@
 pub mod measure;
 pub mod time;
 
+#[cfg(test)]
+#[macro_use]
+pub mod test;
+

--- a/src/util/test.rs
+++ b/src/util/test.rs
@@ -1,78 +1,309 @@
+use chrono::{DateTime, Utc};
 use crate::{
+    access::Role,
+    costs::Costs,
     error::{Error, Result},
     models::{
         Modifications,
 
-        company::Company,
-        lib::basis_model::Model,
+        agreement::{Agreement, AgreementID},
+        company::{Company, CompanyID, Permission as CompanyPermission},
+        lib::{
+            agent::AgentID,
+            basis_model::Model,
+        },
         member::*,
-        user::User,
+        occupation::OccupationID,
+        process::{Process, ProcessID},
+        process_spec::{ProcessSpec, ProcessSpecID},
+        resource::{Resource, ResourceID},
+        resource_spec::{ResourceSpec, ResourceSpecID},
+        user::{User, UserID},
     },
     util,
 };
+use om2::Measure;
+use vf_rs::{vf, geo::SpatialThing};
 
-pub fn deleted_company_tester<T, F>(user: User, member: Member, company: Company, subject: Option<T>, testfn: F)
-    where T: Model,
-          F: Fn(User, Member, Company, Option<T>) -> Result<Modifications> + Clone
+#[derive(Clone, Debug, PartialEq, getset::Setters, derive_builder::Builder)]
+#[builder(pattern = "owned", setter(into))]
+#[getset(set = "pub(crate)")]
+pub(crate) struct TestState<M1: Model, M2: Model> {
+    #[builder(default)]
+    pub(crate) user: Option<User>,
+    #[builder(default)]
+    pub(crate) member: Option<Member>,
+    #[builder(default)]
+    pub(crate) company: Option<Company>,
+    #[builder(default)]
+    pub(crate) model: Option<M1>,
+    #[builder(default)]
+    pub(crate) model2: Option<M2>,
+    #[builder(default)]
+    pub(crate) loc: Option<SpatialThing>
+}
+
+impl<M1: Model, M2: Model> TestState<M1, M2> {
+    pub(crate) fn builder() -> TestStateBuilder<M1, M2> {
+        TestStateBuilder {
+            user: None,
+            member: None,
+            company: None,
+            model: None,
+            model2: None,
+            loc: None,
+        }
+    }
+
+    pub(crate) fn standard(permissions: Vec<CompanyPermission>, now: &DateTime<Utc>) -> TestState<M1, M2> {
+        let company = make_company(&CompanyID::create(), "larry's chairs", now);
+        let user = make_user(&UserID::create(), None, now);
+        let member = make_member_worker(&MemberID::create(), user.id(), company.id(), &OccupationID::create(), permissions, now);
+        let loc = SpatialThing::builder()
+            .mappable_address(Some("444 Checkmate lane, LOGIC and FACTS, MN, 33133".into()))
+            .build().unwrap();
+        Self::builder()
+            .user(user)
+            .member(member)
+            .company(company)
+            .loc(loc)
+            .build().unwrap()
+    }
+
+    pub(crate) fn user(&self) -> &User {
+        self.user.as_ref().unwrap()
+    }
+
+    pub(crate) fn member(&self) -> &Member {
+        self.member.as_ref().unwrap()
+    }
+
+    pub(crate) fn company(&self) -> &Company {
+        self.company.as_ref().unwrap()
+    }
+
+    pub(crate) fn model(&self) -> &M1 {
+        self.model.as_ref().unwrap()
+    }
+
+    pub(crate) fn model2(&self) -> &M2 {
+        self.model2.as_ref().unwrap()
+    }
+
+    pub(crate) fn loc(&self) -> &SpatialThing {
+        self.loc.as_ref().unwrap()
+    }
+
+    pub(crate) fn user_mut(&mut self) -> &mut User {
+        self.user.as_mut().unwrap()
+    }
+
+    pub(crate) fn member_mut(&mut self) -> &mut Member {
+        self.member.as_mut().unwrap()
+    }
+
+    pub(crate) fn company_mut(&mut self) -> &mut Company {
+        self.company.as_mut().unwrap()
+    }
+
+    pub(crate) fn model_mut(&mut self) -> &mut M1 {
+        self.model.as_mut().unwrap()
+    }
+
+    pub(crate) fn model2_mut(&mut self) -> &mut M2 {
+        self.model2.as_mut().unwrap()
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn loc_mut(&mut self) -> &mut SpatialThing {
+        self.loc.as_mut().unwrap()
+    }
+}
+
+pub(crate) fn deleted_company_tester<M1, M2, F>(state: &TestState<M1, M2>, testfn: &F)
+    where M1: Model,
+          M2: Model,
+          F: Fn(&TestState<M1, M2>) -> Result<Modifications> + Clone,
 {
     let now = util::time::now();
 
-    let mut company1 = company.clone();
-    company1.set_deleted(None);
-    company1.set_active(true);
-    let res = testfn(user.clone(), member.clone(), company1, subject.clone());
-    assert!(res.is_ok());
+    let mut state1 = state.clone();
+    state1.company_mut().set_deleted(None);
+    state1.company_mut().set_active(true);
+    let res = testfn(&state1);
+    if !res.is_ok() {
+        panic!("deleted company tester: expected Ok: {:?}", res);
+    }
 
-    let mut company2 = company.clone();
-    company2.set_deleted(Some(now.clone()));
-    company2.set_active(true);
-    let res = testfn(user.clone(), member.clone(), company2, subject.clone());
+    let mut state2 = state.clone();
+    state2.company_mut().set_deleted(Some(now.clone()));
+    state2.company_mut().set_active(true);
+    let res = testfn(&state2);
     assert_eq!(res, Err(Error::ObjectIsInactive("company".into())));
 
-    let mut company3 = company.clone();
-    company3.set_deleted(None);
-    company3.set_active(false);
-    let res = testfn(user.clone(), member.clone(), company3, subject.clone());
+    let mut state3 = state.clone();
+    state3.company_mut().set_deleted(None);
+    state3.company_mut().set_active(false);
+    let res = testfn(&state3);
     assert_eq!(res, Err(Error::ObjectIsInactive("company".into())));
 
-    let mut company4 = company.clone();
-    company4.set_deleted(Some(now.clone()));
-    company4.set_active(false);
-    let res = testfn(user.clone(), member.clone(), company4, subject.clone());
+    let mut state4 = state.clone();
+    state4.company_mut().set_deleted(Some(now.clone()));
+    state4.company_mut().set_active(false);
+    let res = testfn(&state4);
     assert_eq!(res, Err(Error::ObjectIsInactive("company".into())));
 }
 
-pub fn permissions_checks<T, F>(user: User, member: Member, company: Company, subject: Option<T>, testfn: F)
-    where T: Model,
-          F: Fn(User, Member, Company, Option<T>) -> Result<Modifications> + Clone
+pub(crate) fn permissions_checks<M1, M2, F>(state: &TestState<M1, M2>, testfn: &F)
+    where M1: Model,
+          M2: Model,
+          F: Fn(&TestState<M1, M2>) -> Result<Modifications> + Clone,
 {
-    let mut member2 = member.clone();
-    member2.set_permissions(vec![]);
-    let res = testfn(user.clone(), member2, company.clone(), subject.clone());
+    let mut state1 = state.clone();
+    state1.member_mut().set_permissions(vec![]);
+    let res = testfn(&state1);
     assert_eq!(res, Err(Error::InsufficientPrivileges));
 
-    let mut user2 = user.clone();
-    user2.set_roles(vec![]);
-    let res = testfn(user2, member.clone(), company.clone(), subject.clone());
+    let mut state2 = state.clone();
+    state2.user_mut().set_roles(vec![]);
+    let res = testfn(&state1);
     assert_eq!(res, Err(Error::InsufficientPrivileges));
 }
 
-pub fn double_deleted_tester<T, F, S>(user: User, member: Member, company: Company, mut subject: T, tystr: S, testfn: F)
-    where T: Model,
-          F: Fn(User, Member, Company, Option<T>) -> Result<Modifications> + Clone,
-          S: Into<String>
+pub(crate) fn double_deleted_tester<M1, M2, F, S>(state: &TestState<M1, M2>, tystr: S, testfn: &F)
+    where M1: Model,
+          M2: Model,
+          F: Fn(&TestState<M1, M2>) -> Result<Modifications> + Clone,
+          S: Into<String>,
 {
-    subject.set_deleted(Some(util::time::now()));
-    let res: Result<Modifications> = testfn(user.clone(), member.clone(), company.clone(), Some(subject));
+    let mut state1 = state.clone();
+    state1.model_mut().set_deleted(Some(util::time::now()));
+    let res = testfn(&state1);
     assert_eq!(res, Err(Error::ObjectIsDeleted(tystr.into())));
 }
 
-pub fn standard_transaction_tests<T, F>(user: User, member: Member, company: Company, subject: Option<T>, testfn: F)
-    where T: Model,
-          F: Fn(User, Member, Company, Option<T>) -> Result<Modifications> + Clone
+pub(crate) fn standard_transaction_tests<M1, M2, F>(state: &TestState<M1, M2>, testfn: &F)
+    where M1: Model,
+          M2: Model,
+          F: Fn(&TestState<M1, M2>) -> Result<Modifications> + Clone,
 {
-    deleted_company_tester(user.clone(), member.clone(), company.clone(), subject.clone(), testfn.clone());
-    permissions_checks(user.clone(), member.clone(), company.clone(), subject.clone(), testfn.clone());
+    deleted_company_tester(state, testfn);
+    permissions_checks(state, testfn);
 }
 
+pub fn make_agreement<T: Into<String>>(id: &AgreementID, participants: &Vec<AgentID>, name: T, note: T, now: &DateTime<Utc>) -> Agreement {
+    Agreement::builder()
+        .id(id.clone())
+        .inner(
+            vf::Agreement::builder()
+                .created(now.clone())
+                .name(Some(name.into()))
+                .note(Some(note.into()))
+                .build().unwrap()
+        )
+        .participants(participants.clone())
+        .active(true)
+        .created(now.clone())
+        .updated(now.clone())
+        .build().unwrap()
+}
 
+pub fn make_company<T: Into<String>>(id: &CompanyID, name: T, now: &DateTime<Utc>) -> Company {
+    Company::builder()
+        .id(id.clone())
+        .inner(vf::Agent::builder().name(name).build().unwrap())
+        .email("jerry@widgets.biz")
+        .active(true)
+        .created(now.clone())
+        .updated(now.clone())
+        .build().unwrap()
+}
+
+pub fn make_member_worker(member_id: &MemberID, user_id: &UserID, company_id: &CompanyID, occupation_id: &OccupationID, permissions: Vec<CompanyPermission>, now: &DateTime<Utc>) -> Member {
+    Member::builder()
+        .id(member_id.clone())
+        .inner(
+            vf::AgentRelationship::builder()
+                .subject(user_id.clone())
+                .object(company_id.clone())
+                .relationship(())
+                .build().unwrap()
+        )
+        .class(MemberClass::Worker(MemberWorker::new(occupation_id.clone(), None)))
+        .permissions(permissions)
+        .active(true)
+        .created(now.clone())
+        .updated(now.clone())
+        .build().unwrap()
+}
+
+pub fn make_process<T: Into<String>>(id: &ProcessID, company_id: &CompanyID, name: T, costs: &Costs, now: &DateTime<Utc>) -> Process {
+    Process::builder()
+        .id(id.clone())
+        .inner(vf::Process::builder().name(name).build().unwrap())
+        .company_id(company_id.clone())
+        .costs(costs.clone())
+        .active(true)
+        .created(now.clone())
+        .updated(now.clone())
+        .build().unwrap()
+}
+
+pub fn make_process_spec<T: Into<String>>(id: &ProcessSpecID, company_id: &CompanyID, name: T, active: bool, now: &DateTime<Utc>) -> ProcessSpec {
+    ProcessSpec::builder()
+        .id(id.clone())
+        .inner(
+            vf::ProcessSpecification::builder()
+                .name(name)
+                .build().unwrap()
+        )
+        .company_id(company_id.clone())
+        .active(active)
+        .created(now.clone())
+        .updated(now.clone())
+        .build().unwrap()
+}
+
+pub fn make_resource(id: &ResourceID, company_id: &CompanyID, quantity: &Measure, costs: &Costs, now: &DateTime<Utc>) -> Resource {
+    Resource::builder()
+        .id(id.clone())
+        .inner(
+            vf::EconomicResource::builder()
+                .accounting_quantity(Some(quantity.clone()))
+                .onhand_quantity(Some(quantity.clone()))
+                .primary_accountable(Some(company_id.clone().into()))
+                .conforms_to("6969")
+                .build().unwrap()
+        )
+        .in_custody_of(company_id.clone())
+        .costs(costs.clone())
+        .created(now.clone())
+        .updated(now.clone())
+        .build().unwrap()
+}
+
+pub fn make_resource_spec<T: Into<String>>(id: &ResourceSpecID, company_id: &CompanyID, name: T, now: &DateTime<Utc>) -> ResourceSpec {
+    ResourceSpec::builder()
+        .id(id.clone())
+        .inner(
+            vf::ResourceSpecification::builder()
+                .name(name)
+                .build().unwrap()
+        )
+        .company_id(company_id.clone())
+        .created(now.clone())
+        .updated(now.clone())
+        .build().unwrap()
+}
+
+pub fn make_user(user_id: &UserID, roles: Option<Vec<Role>>, now: &DateTime<Utc>) -> User {
+    User::builder()
+        .id(user_id.clone())
+        .roles(roles.unwrap_or(vec![Role::User]))
+        .email("surely@hotmail.com")   // don't call me shirley
+        .name("buzzin' frog")
+        .active(true)
+        .created(now.clone())
+        .updated(now.clone())
+        .build().unwrap()
+}

--- a/src/util/test.rs
+++ b/src/util/test.rs
@@ -4,61 +4,75 @@ use crate::{
         Modifications,
 
         company::Company,
+        lib::basis_model::Model,
         member::*,
         user::User,
     },
     util,
 };
 
-pub fn deleted_company_tester<F>(user: User, member: Member, company: Company, testfn: F)
-    where F: Fn(User, Member, Company) -> Result<Modifications>
+pub fn deleted_company_tester<T, F>(user: User, member: Member, company: Company, subject: Option<T>, testfn: F)
+    where T: Model,
+          F: Fn(User, Member, Company, Option<T>) -> Result<Modifications> + Clone
 {
     let now = util::time::now();
 
     let mut company1 = company.clone();
     company1.set_deleted(None);
     company1.set_active(true);
-    let res = testfn(user.clone(), member.clone(), company1);
+    let res = testfn(user.clone(), member.clone(), company1, subject.clone());
     assert!(res.is_ok());
 
     let mut company2 = company.clone();
     company2.set_deleted(Some(now.clone()));
     company2.set_active(true);
-    let res = testfn(user.clone(), member.clone(), company2);
+    let res = testfn(user.clone(), member.clone(), company2, subject.clone());
     assert_eq!(res, Err(Error::ObjectIsInactive("company".into())));
 
     let mut company3 = company.clone();
     company3.set_deleted(None);
     company3.set_active(false);
-    let res = testfn(user.clone(), member.clone(), company3);
+    let res = testfn(user.clone(), member.clone(), company3, subject.clone());
     assert_eq!(res, Err(Error::ObjectIsInactive("company".into())));
 
     let mut company4 = company.clone();
     company4.set_deleted(Some(now.clone()));
     company4.set_active(false);
-    let res = testfn(user.clone(), member.clone(), company4);
+    let res = testfn(user.clone(), member.clone(), company4, subject.clone());
     assert_eq!(res, Err(Error::ObjectIsInactive("company".into())));
 }
 
-pub fn permissions_checks<F>(user: User, member: Member, company: Company, testfn: F)
-    where F: Fn(User, Member, Company) -> Result<Modifications>
+pub fn permissions_checks<T, F>(user: User, member: Member, company: Company, subject: Option<T>, testfn: F)
+    where T: Model,
+          F: Fn(User, Member, Company, Option<T>) -> Result<Modifications> + Clone
 {
     let mut member2 = member.clone();
     member2.set_permissions(vec![]);
-    let res = testfn(user.clone(), member2, company.clone());
+    let res = testfn(user.clone(), member2, company.clone(), subject.clone());
     assert_eq!(res, Err(Error::InsufficientPrivileges));
 
     let mut user2 = user.clone();
     user2.set_roles(vec![]);
-    let res = testfn(user2, member.clone(), company.clone());
+    let res = testfn(user2, member.clone(), company.clone(), subject.clone());
     assert_eq!(res, Err(Error::InsufficientPrivileges));
 }
 
-pub fn standard_transaction_tests<F>(user: User, member: Member, company: Company, testfn: F)
-    where F: Fn(User, Member, Company) -> Result<Modifications> + Clone
+pub fn double_deleted_tester<T, F, S>(user: User, member: Member, company: Company, mut subject: T, tystr: S, testfn: F)
+    where T: Model,
+          F: Fn(User, Member, Company, Option<T>) -> Result<Modifications> + Clone,
+          S: Into<String>
 {
-    deleted_company_tester(user.clone(), member.clone(), company.clone(), testfn.clone());
-    permissions_checks(user.clone(), member.clone(), company.clone(), testfn.clone());
+    subject.set_deleted(Some(util::time::now()));
+    let res: Result<Modifications> = testfn(user.clone(), member.clone(), company.clone(), Some(subject));
+    assert_eq!(res, Err(Error::ObjectIsDeleted(tystr.into())));
+}
+
+pub fn standard_transaction_tests<T, F>(user: User, member: Member, company: Company, subject: Option<T>, testfn: F)
+    where T: Model,
+          F: Fn(User, Member, Company, Option<T>) -> Result<Modifications> + Clone
+{
+    deleted_company_tester(user.clone(), member.clone(), company.clone(), subject.clone(), testfn.clone());
+    permissions_checks(user.clone(), member.clone(), company.clone(), subject.clone(), testfn.clone());
 }
 
 

--- a/src/util/test.rs
+++ b/src/util/test.rs
@@ -1,0 +1,64 @@
+use crate::{
+    error::{Error, Result},
+    models::{
+        Modifications,
+
+        company::Company,
+        member::*,
+        user::User,
+    },
+    util,
+};
+
+pub fn deleted_company_tester<F>(user: User, member: Member, company: Company, testfn: F)
+    where F: Fn(User, Member, Company) -> Result<Modifications>
+{
+    let now = util::time::now();
+
+    let mut company1 = company.clone();
+    company1.set_deleted(None);
+    company1.set_active(true);
+    let res = testfn(user.clone(), member.clone(), company1);
+    assert!(res.is_ok());
+
+    let mut company2 = company.clone();
+    company2.set_deleted(Some(now.clone()));
+    company2.set_active(true);
+    let res = testfn(user.clone(), member.clone(), company2);
+    assert_eq!(res, Err(Error::ObjectIsInactive("company".into())));
+
+    let mut company3 = company.clone();
+    company3.set_deleted(None);
+    company3.set_active(false);
+    let res = testfn(user.clone(), member.clone(), company3);
+    assert_eq!(res, Err(Error::ObjectIsInactive("company".into())));
+
+    let mut company4 = company.clone();
+    company4.set_deleted(Some(now.clone()));
+    company4.set_active(false);
+    let res = testfn(user.clone(), member.clone(), company4);
+    assert_eq!(res, Err(Error::ObjectIsInactive("company".into())));
+}
+
+pub fn permissions_checks<F>(user: User, member: Member, company: Company, testfn: F)
+    where F: Fn(User, Member, Company) -> Result<Modifications>
+{
+    let mut member2 = member.clone();
+    member2.set_permissions(vec![]);
+    let res = testfn(user.clone(), member2, company.clone());
+    assert_eq!(res, Err(Error::InsufficientPrivileges));
+
+    let mut user2 = user.clone();
+    user2.set_roles(vec![]);
+    let res = testfn(user2, member.clone(), company.clone());
+    assert_eq!(res, Err(Error::InsufficientPrivileges));
+}
+
+pub fn standard_transaction_tests<F>(user: User, member: Member, company: Company, testfn: F)
+    where F: Fn(User, Member, Company) -> Result<Modifications> + Clone
+{
+    deleted_company_tester(user.clone(), member.clone(), company.clone(), testfn.clone());
+    permissions_checks(user.clone(), member.clone(), company.clone(), testfn.clone());
+}
+
+


### PR DESCRIPTION
This closes #106 and closes #107. They are lumped together because their fates are intertwined.