### PR TITLE
Inception-based cost credit tracking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ categories = ["algorithms", "data-structures"]
 chrono = { version = "0.4", features = ["serde"] }
 costs-derive = { path = "./costs-derive" }
 derive_builder = "0.9"
-fraction = { version = "0.6", features = ["with-serde-support"] }
 getset = "0.1"
 om2 = "0.1"
 rust_decimal = { version = "1.6", features = ["serde-float"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,20 +15,21 @@ keywords = ["economics", "socialism", "communism", "democracy"]
 categories = ["algorithms", "data-structures"]
 
 [dependencies]
-chrono = { version = "0.4.11", features = ["serde"] }
+chrono = { version = "0.4", features = ["serde"] }
 costs-derive = { path = "./costs-derive" }
-derive_builder = "0.9.0"
-getset = "0.1.0"
-om2 = "0.1.8"
-rust_decimal = { version = "1.6.0", features = ["serde-float"] }
-rust_decimal_macros = "1.6.0"
-serde = "1.0.105"
-serde_derive = "1.0.106"
-thiserror = "1.0.16"
-url = { version = "2.1.1", features = ["serde"] }
-uuid = { version = "0.8.1", features = ["v4"] }
+derive_builder = "0.9"
+fraction = { version = "0.6", features = ["with-serde-support"] }
+getset = "0.1"
+om2 = "0.1"
+rust_decimal = { version = "1.6", features = ["serde-float"] }
+rust_decimal_macros = "1.6"
+serde = "1.0"
+serde_derive = "1.0"
+thiserror = "1.0"
+url = { version = "2.1", features = ["serde"] }
+uuid = { version = "0.8", features = ["v4"] }
 vf-rs = { version = "0.3.15", default-features = false, features = ["getset_getmut", "getset_setters"] }
 
 [dev-dependencies]
-serde_json = "1.0.50"
+serde_json = "1.0"
 

--- a/costs-derive/src/lib.rs
+++ b/costs-derive/src/lib.rs
@@ -208,7 +208,6 @@ pub fn derive_costs(input: TokenStream) -> TokenStream {
             type Output = Self;
 
             fn mul(mut self, rhs: rust_decimal::Decimal) -> Self {
-                let rhs = Costs::do_round(&rhs);
                 self.credits *= rhs.clone();
                 #(
                     for (_, val) in self.#field_name_mut().iter_mut() {
@@ -227,7 +226,6 @@ pub fn derive_costs(input: TokenStream) -> TokenStream {
                 if self.is_zero() {
                     return self;
                 }
-                let rhs = Costs::do_round(&rhs);
                 if rhs == Decimal::zero() {
                     panic!("Costs::div() -- divide by zero");
                 }

--- a/src/costs.rs
+++ b/src/costs.rs
@@ -3,36 +3,38 @@
 //! multiplied, or divided.
 //!
 //! ```rust
-//! use basis_core::costs::Costs;
+//! use basis_core::{
+//!     costs::Costs,
+//!     num,
+//! };
 //! use rust_decimal::prelude::*;
-//! use rust_decimal_macros::*;
 //!
 //! let mut costs = Costs::new();
-//! costs.track_resource("gasoline", dec!(0.4), dec!(1.3));
-//! costs.track_resource("iron", dec!(2.2), dec!(0.0019));
-//! costs.track_labor("ceo", dec!(42.0));
-//! costs.track_labor("machinist", dec!(122.0));
-//! costs.track_labor_hours("ceo", dec!(2.0));
-//! costs.track_labor_hours("machinist", dec!(8.0));
-//! costs.track_currency("usd", dec!(42.00), dec!(0.99891));
+//! costs.track_resource("gasoline", num!(0.4), num!(1.3));
+//! costs.track_resource("iron", num!(2.2), num!(0.0019));
+//! costs.track_labor("ceo", num!(42.0));
+//! costs.track_labor("machinist", num!(122.0));
+//! costs.track_labor_hours("ceo", num!(2.0));
+//! costs.track_labor_hours("machinist", num!(8.0));
+//! costs.track_currency("usd", num!(42.00), num!(0.99891));
 //!
-//! let costs2 = costs * dec!(2.5);
-//! assert_eq!(costs2.get_resource("gasoline"), dec!(0.4) * dec!(2.5));
-//! assert_eq!(costs2.get_resource("iron"), dec!(2.2) * dec!(2.5));
-//! assert_eq!(costs2.get_labor("ceo"), dec!(42.0) * dec!(2.5));
-//! assert_eq!(costs2.get_labor("machinist"), dec!(122.0) * dec!(2.5));
-//! assert_eq!(costs2.get_labor_hours("ceo"), dec!(2.0) * dec!(2.5));
-//! assert_eq!(costs2.get_labor_hours("machinist"), dec!(8.0) * dec!(2.5));
-//! assert_eq!(costs2.get_currency("usd"), dec!(42.00) * dec!(2.5));
+//! let costs2 = costs * num!(2.5);
+//! assert_eq!(costs2.get_resource("gasoline"), num!(0.4) * num!(2.5));
+//! assert_eq!(costs2.get_resource("iron"), num!(2.2) * num!(2.5));
+//! assert_eq!(costs2.get_labor("ceo"), num!(42.0) * num!(2.5));
+//! assert_eq!(costs2.get_labor("machinist"), num!(122.0) * num!(2.5));
+//! assert_eq!(costs2.get_labor_hours("ceo"), num!(2.0) * num!(2.5));
+//! assert_eq!(costs2.get_labor_hours("machinist"), num!(8.0) * num!(2.5));
+//! assert_eq!(costs2.get_currency("usd"), num!(42.00) * num!(2.5));
 //!
-//! let costs3 = costs2 / dec!(3.2);
-//! assert_eq!(costs3.get_resource("gasoline"), (dec!(0.4) * dec!(2.5)) / dec!(3.2));
-//! assert_eq!(costs3.get_resource("iron"), (dec!(2.2) * dec!(2.5)) / dec!(3.2));
-//! assert_eq!(costs3.get_labor("ceo"), (dec!(42.0) * dec!(2.5)) / dec!(3.2));
-//! assert_eq!(costs3.get_labor("machinist"), (dec!(122.0) * dec!(2.5)) / dec!(3.2));
-//! assert_eq!(costs3.get_labor_hours("ceo"), (dec!(2.0) * dec!(2.5)) / dec!(3.2));
-//! assert_eq!(costs3.get_labor_hours("machinist"), (dec!(8.0) * dec!(2.5)) / dec!(3.2));
-//! assert_eq!(costs3.get_currency("usd"), (dec!(42.00) * dec!(2.5)) / dec!(3.2));
+//! let costs3 = costs2 / num!(3.2);
+//! assert_eq!(costs3.get_resource("gasoline"), (num!(0.4) * num!(2.5)) / num!(3.2));
+//! assert_eq!(costs3.get_resource("iron"), (num!(2.2) * num!(2.5)) / num!(3.2));
+//! assert_eq!(costs3.get_labor("ceo"), (num!(42.0) * num!(2.5)) / num!(3.2));
+//! assert_eq!(costs3.get_labor("machinist"), (num!(122.0) * num!(2.5)) / num!(3.2));
+//! assert_eq!(costs3.get_labor_hours("ceo"), (num!(2.0) * num!(2.5)) / num!(3.2));
+//! assert_eq!(costs3.get_labor_hours("machinist"), (num!(8.0) * num!(2.5)) / num!(3.2));
+//! assert_eq!(costs3.get_currency("usd"), (num!(42.00) * num!(2.5)) / num!(3.2));
 //! ```
 //!
 //! In effect, Costs are an abstraction around Basis' view of production. While
@@ -107,7 +109,6 @@ use crate::{
 };
 use getset::{Getters, MutGetters, Setters};
 use rust_decimal::prelude::*;
-use rust_decimal_macros::*;
 use serde::{Serialize, Deserialize};
 use std::collections::HashMap;
 use std::ops::{Add, Sub, Mul, Div};
@@ -333,7 +334,7 @@ pub(crate) trait CostMover {
         // ok, a bit weird, i know, but we want to know if this *addition* will
         // result in a negative, and since we don't have a is_add_lt_0 fn, we
         // use us_sub_lt_0 instead, but we have to invert it. sue me.
-        let negative = costs_to_receive.clone() * dec!(-1.0);
+        let negative = costs_to_receive.clone() * num!(-1.0);
         if Costs::is_sub_lt_0(self.costs(), &negative) {
             Err(Error::NegativeCosts)?;
         }
@@ -356,31 +357,31 @@ mod tests {
         let mut costs1 = Costs::new();
         let mut costs2 = Costs::new();
 
-        costs1.track_labor("miner", dec!(6.0));
-        costs1.track_resource("widget", dec!(3.1), dec!(1.0));
-        costs1.track_resource("iron", dec!(8.5), dec!(0.0019));
-        costs1.track_labor_hours("miner", dec!(0.5));
-        costs1.track_currency("usd", Decimal::new(500, 2), dec!(0.99891));
-        costs2.track_currency("eur", Decimal::new(230, 2), dec!(0.99891));
-        costs2.track_labor("miner", dec!(2.0));
-        costs2.track_labor("widgetmaker", dec!(3.0));
-        costs2.track_resource("widget", dec!(1.8), dec!(1.2));
-        costs2.track_resource("oil", dec!(5.6), dec!(3.2));
-        costs2.track_labor_hours("miner", dec!(0.7));
-        costs2.track_labor_hours("birthday clown", dec!(0.3));
-        costs2.track_currency("usd", Decimal::new(1490, 2), dec!(0.99891));
-        costs2.track_currency("cny", Decimal::new(3000, 0), dec!(0.99891));
+        costs1.track_labor("miner", num!(6.0));
+        costs1.track_resource("widget", num!(3.1), num!(1.0));
+        costs1.track_resource("iron", num!(8.5), num!(0.0019));
+        costs1.track_labor_hours("miner", num!(0.5));
+        costs1.track_currency("usd", Decimal::new(500, 2), num!(0.99891));
+        costs2.track_currency("eur", Decimal::new(230, 2), num!(0.99891));
+        costs2.track_labor("miner", num!(2.0));
+        costs2.track_labor("widgetmaker", num!(3.0));
+        costs2.track_resource("widget", num!(1.8), num!(1.2));
+        costs2.track_resource("oil", num!(5.6), num!(3.2));
+        costs2.track_labor_hours("miner", num!(0.7));
+        costs2.track_labor_hours("birthday clown", num!(0.3));
+        costs2.track_currency("usd", Decimal::new(1490, 2), num!(0.99891));
+        costs2.track_currency("cny", Decimal::new(3000, 0), num!(0.99891));
 
         let costs = costs1 + costs2;
-        assert_eq!(costs.get_labor("miner"), dec!(6.0) + dec!(2.0));
-        assert_eq!(costs.get_labor("widgetmaker"), dec!(3.0));
-        assert_eq!(costs.get_labor("joker"), dec!(0.0));
-        assert_eq!(costs.get_labor_hours("miner"), dec!(0.5) + dec!(0.7));
-        assert_eq!(costs.get_labor_hours("birthday clown"), dec!(0.3));
-        assert_eq!(costs.get_labor_hours("magical wish pony"), dec!(0.0));
-        assert_eq!(costs.get_resource("widget"), dec!(3.1) + dec!(1.8));
-        assert_eq!(costs.get_resource("iron"), dec!(8.5) + dec!(0.0));
-        assert_eq!(costs.get_resource("oil"), dec!(5.6) + dec!(0.0));
+        assert_eq!(costs.get_labor("miner"), num!(6.0) + num!(2.0));
+        assert_eq!(costs.get_labor("widgetmaker"), num!(3.0));
+        assert_eq!(costs.get_labor("joker"), num!(0.0));
+        assert_eq!(costs.get_labor_hours("miner"), num!(0.5) + num!(0.7));
+        assert_eq!(costs.get_labor_hours("birthday clown"), num!(0.3));
+        assert_eq!(costs.get_labor_hours("magical wish pony"), num!(0.0));
+        assert_eq!(costs.get_resource("widget"), num!(3.1) + num!(1.8));
+        assert_eq!(costs.get_resource("iron"), num!(8.5) + num!(0.0));
+        assert_eq!(costs.get_resource("oil"), num!(5.6) + num!(0.0));
         assert_eq!(costs.get_currency("usd"), Decimal::new(500, 2) + Decimal::new(1490, 2));
         assert_eq!(costs.get_currency("eur"), Decimal::new(230, 2));
         assert_eq!(costs.get_currency("cny"), Decimal::new(3000, 0));
@@ -392,32 +393,32 @@ mod tests {
         let mut costs1 = Costs::new();
         let mut costs2 = Costs::new();
 
-        costs1.track_labor("miner", dec!(6.0));
-        costs1.track_resource("widget", dec!(3.1), dec!(1.0));
-        costs1.track_resource("iron", dec!(8.5), dec!(0.0019));
-        costs1.track_labor_hours("miner", dec!(0.5));
-        costs1.track_currency("usd", Decimal::new(500, 2), dec!(0.99891));
-        costs2.track_currency("eur", Decimal::new(230, 2), dec!(0.99891));
-        costs2.track_labor("miner", dec!(2.0));
-        costs2.track_labor("widgetmaker", dec!(3.0));
-        costs2.track_resource("widget", dec!(1.8), dec!(0.99));
-        costs2.track_resource("oil", dec!(5.6), dec!(2.3));
-        costs2.track_labor_hours("miner", dec!(0.7));
-        costs2.track_labor_hours("birthday clown", dec!(0.3));
-        costs2.track_currency("usd", Decimal::new(1490, 2), dec!(0.99891));
-        costs2.track_currency("cny", Decimal::new(3000, 0), dec!(0.99891));
+        costs1.track_labor("miner", num!(6.0));
+        costs1.track_resource("widget", num!(3.1), num!(1.0));
+        costs1.track_resource("iron", num!(8.5), num!(0.0019));
+        costs1.track_labor_hours("miner", num!(0.5));
+        costs1.track_currency("usd", Decimal::new(500, 2), num!(0.99891));
+        costs2.track_currency("eur", Decimal::new(230, 2), num!(0.99891));
+        costs2.track_labor("miner", num!(2.0));
+        costs2.track_labor("widgetmaker", num!(3.0));
+        costs2.track_resource("widget", num!(1.8), num!(0.99));
+        costs2.track_resource("oil", num!(5.6), num!(2.3));
+        costs2.track_labor_hours("miner", num!(0.7));
+        costs2.track_labor_hours("birthday clown", num!(0.3));
+        costs2.track_currency("usd", Decimal::new(1490, 2), num!(0.99891));
+        costs2.track_currency("cny", Decimal::new(3000, 0), num!(0.99891));
 
         // negatives are ok
         let costs = costs1 - costs2;
-        assert_eq!(costs.get_labor("miner"), dec!(6.0) - dec!(2.0));
-        assert_eq!(costs.get_labor("widgetmaker"), dec!(-3.0));
-        assert_eq!(costs.get_labor("joker"), dec!(0.0));
-        assert_eq!(costs.get_labor_hours("miner"), dec!(0.5) - dec!(0.7));
-        assert_eq!(costs.get_labor_hours("birthday clown"), dec!(-0.3));
-        assert_eq!(costs.get_labor_hours("magical wish pony"), dec!(0.0));
-        assert_eq!(costs.get_resource("widget"), dec!(3.1) - dec!(1.8));
-        assert_eq!(costs.get_resource("iron"), dec!(8.5) - dec!(0.0));
-        assert_eq!(costs.get_resource("oil"), dec!(-5.6));
+        assert_eq!(costs.get_labor("miner"), num!(6.0) - num!(2.0));
+        assert_eq!(costs.get_labor("widgetmaker"), num!(-3.0));
+        assert_eq!(costs.get_labor("joker"), num!(0.0));
+        assert_eq!(costs.get_labor_hours("miner"), num!(0.5) - num!(0.7));
+        assert_eq!(costs.get_labor_hours("birthday clown"), num!(-0.3));
+        assert_eq!(costs.get_labor_hours("magical wish pony"), num!(0.0));
+        assert_eq!(costs.get_resource("widget"), num!(3.1) - num!(1.8));
+        assert_eq!(costs.get_resource("iron"), num!(8.5) - num!(0.0));
+        assert_eq!(costs.get_resource("oil"), num!(-5.6));
         assert_eq!(costs.get_currency("usd"), Decimal::new(500, 2) - Decimal::new(1490, 2));
         assert_eq!(costs.get_currency("eur"), Decimal::new(-230, 2));
         assert_eq!(costs.get_currency("cny"), Decimal::new(-3000, 0));
@@ -427,19 +428,19 @@ mod tests {
     #[test]
     fn mul() {
         let mut costs1 = Costs::new();
-        costs1.track_labor("miner", dec!(6.0));
-        costs1.track_labor("widgetmaker", dec!(3.0));
-        costs1.track_resource("widget", dec!(3.1), dec!(1.0));
-        costs1.track_resource("iron", dec!(8.5), dec!(0.0019));
-        costs1.track_labor_hours("miner", dec!(3.0));
-        costs1.track_currency("cny", Decimal::new(140000, 2), dec!(0.99891));
+        costs1.track_labor("miner", num!(6.0));
+        costs1.track_labor("widgetmaker", num!(3.0));
+        costs1.track_resource("widget", num!(3.1), num!(1.0));
+        costs1.track_resource("iron", num!(8.5), num!(0.0019));
+        costs1.track_labor_hours("miner", num!(3.0));
+        costs1.track_currency("cny", Decimal::new(140000, 2), num!(0.99891));
 
-        let costs = costs1 * dec!(5.2);
-        assert_eq!(costs.get_labor("miner"), dec!(6.0) * dec!(5.2));
-        assert_eq!(costs.get_labor("widgetmaker"), dec!(3.0) * dec!(5.2));
-        assert_eq!(costs.get_resource("widget"), dec!(3.1) * dec!(5.2));
-        assert_eq!(costs.get_resource("iron"), dec!(8.5) * dec!(5.2));
-        assert_eq!(costs.get_labor_hours("miner"), dec!(3.0) * dec!(5.2));
+        let costs = costs1 * num!(5.2);
+        assert_eq!(costs.get_labor("miner"), num!(6.0) * num!(5.2));
+        assert_eq!(costs.get_labor("widgetmaker"), num!(3.0) * num!(5.2));
+        assert_eq!(costs.get_resource("widget"), num!(3.1) * num!(5.2));
+        assert_eq!(costs.get_resource("iron"), num!(8.5) * num!(5.2));
+        assert_eq!(costs.get_labor_hours("miner"), num!(3.0) * num!(5.2));
         assert_eq!(costs.get_currency("cny"), Decimal::new(140000, 2) * Decimal::from_f64(5.2).unwrap());
     }
 
@@ -447,17 +448,17 @@ mod tests {
     fn div_f64() {
         let mut costs1 = Costs::new();
 
-        costs1.track_labor("widgetmaker", dec!(6.0));
-        costs1.track_resource("widget", dec!(3.1), dec!(1));
-        costs1.track_resource("oil", dec!(5.6), dec!(2.2));
-        costs1.track_labor_hours("doctor", dec!(14.0));
-        costs1.track_currency("eur", Decimal::new(43301, 2), dec!(0.99891));
+        costs1.track_labor("widgetmaker", num!(6.0));
+        costs1.track_resource("widget", num!(3.1), num!(1));
+        costs1.track_resource("oil", num!(5.6), num!(2.2));
+        costs1.track_labor_hours("doctor", num!(14.0));
+        costs1.track_currency("eur", Decimal::new(43301, 2), num!(0.99891));
 
-        let costs = costs1 / dec!(1.3);
-        assert_eq!(costs.get_labor("widgetmaker"), dec!(6.0) / dec!(1.3));
-        assert_eq!(costs.get_resource("widget"), dec!(3.1) / dec!(1.3));
-        assert_eq!(costs.get_resource("oil"), dec!(5.6) / dec!(1.3));
-        assert_eq!(costs.get_labor_hours("doctor"), dec!(14.0) / dec!(1.3));
+        let costs = costs1 / num!(1.3);
+        assert_eq!(costs.get_labor("widgetmaker"), num!(6.0) / num!(1.3));
+        assert_eq!(costs.get_resource("widget"), num!(3.1) / num!(1.3));
+        assert_eq!(costs.get_resource("oil"), num!(5.6) / num!(1.3));
+        assert_eq!(costs.get_labor_hours("doctor"), num!(14.0) / num!(1.3));
         assert_eq!(costs.get_currency("eur"), Decimal::new(43301, 2) / Decimal::from_f64(1.3).unwrap());
     }
 
@@ -466,8 +467,8 @@ mod tests {
         let mut costs = Costs::new();
         costs.track_labor("hippie", 0);
         costs.track_labor_hours("treeslider", 0);
-        costs.track_currency("usd", 0, dec!(0.99891));
-        costs.track_resource("oil", 0, dec!(3.2));
+        costs.track_currency("usd", 0, num!(0.99891));
+        costs.track_resource("oil", 0, num!(3.2));
         assert_eq!(costs, Costs::new());
     }
 
@@ -489,39 +490,39 @@ mod tests {
 
     #[test]
     fn div_0_by_0() {
-        let costs1 = Costs::new_with_labor("clown", dec!(0.0));
+        let costs1 = Costs::new_with_labor("clown", num!(0.0));
 
-        let costs = costs1 / dec!(0);
-        assert_eq!(costs.get_labor("clown"), dec!(0.0));
+        let costs = costs1 / num!(0);
+        assert_eq!(costs.get_labor("clown"), num!(0.0));
     }
 
     #[test]
     fn is_sub_lt_0() {
-        let costs1 = Costs::new_with_labor("clown", dec!(0.0));
+        let costs1 = Costs::new_with_labor("clown", num!(0.0));
         let costs2 = Costs::new();
         assert_eq!(Costs::is_sub_lt_0(&costs1, &costs2), false);
         assert_eq!(Costs::is_sub_lt_0(&costs2, &costs1), false);
 
-        let costs1 = Costs::new_with_labor("clown", dec!(32.0));
+        let costs1 = Costs::new_with_labor("clown", num!(32.0));
         let costs2 = Costs::new();
         assert_eq!(Costs::is_sub_lt_0(&costs1, &costs2), false);
         assert_eq!(Costs::is_sub_lt_0(&costs2, &costs1), true);
 
-        let costs1 = Costs::new_with_labor("machinist", dec!(42.0));
-        let costs2 = Costs::new_with_resource("steel", dec!(13.0), dec!(0.031));
+        let costs1 = Costs::new_with_labor("machinist", num!(42.0));
+        let costs2 = Costs::new_with_resource("steel", num!(13.0), num!(0.031));
         assert_eq!(Costs::is_sub_lt_0(&costs1, &costs2), true);
         assert_eq!(Costs::is_sub_lt_0(&costs2, &costs1), true);
 
         let mut costs1 = Costs::new();
-        costs1.track_labor("machinist", dec!(42.0));
-        costs1.track_labor("janitor", dec!(16.0));
-        costs1.track_labor("doctor", dec!(49.0));
-        costs1.track_labor_hours("machinist", dec!(3.001));
-        costs1.track_labor_hours("janitor", dec!(1.2));
-        costs1.track_labor_hours("doctor", dec!(0.89002));
-        costs1.track_resource("steel", dec!(13.0002292), dec!(0.03));
-        costs1.track_resource("crude oil", dec!(1.34411), dec!(1.2));
-        costs1.track_currency("usd", Decimal::new(4298, 2), dec!(1.0019));
+        costs1.track_labor("machinist", num!(42.0));
+        costs1.track_labor("janitor", num!(16.0));
+        costs1.track_labor("doctor", num!(49.0));
+        costs1.track_labor_hours("machinist", num!(3.001));
+        costs1.track_labor_hours("janitor", num!(1.2));
+        costs1.track_labor_hours("doctor", num!(0.89002));
+        costs1.track_resource("steel", num!(13.0002292), num!(0.03));
+        costs1.track_resource("crude oil", num!(1.34411), num!(1.2));
+        costs1.track_currency("usd", Decimal::new(4298, 2), num!(1.0019));
         let costs2 = costs1.clone();
         assert_eq!(Costs::is_sub_lt_0(&costs1, &costs2), false);
         assert_eq!(Costs::is_sub_lt_0(&costs2, &costs1), false);
@@ -532,9 +533,9 @@ mod tests {
         let mut costs = Costs::new();
         assert!(!costs.is_gt_0());
 
-        costs.track_labor("athlete", dec!(23.4));
-        costs.track_resource("water", dec!(4.6), dec!(0.004));
-        costs.track_currency("usd", dec!(3.42), dec!(0.99891));
+        costs.track_labor("athlete", num!(23.4));
+        costs.track_resource("water", num!(4.6), num!(0.004));
+        costs.track_currency("usd", num!(3.42), num!(0.99891));
         assert!(costs.is_gt_0());
 
         let costs2 = costs.clone() - Costs::new_with_labor("plumber", 50);
@@ -546,23 +547,23 @@ mod tests {
     fn div_f64_by_0() {
         let mut costs1 = Costs::new();
 
-        costs1.track_labor("dancer", dec!(6.0));
-        costs1.track_resource("widget", dec!(3.1), dec!(1.2));
-        costs1.track_resource("oil", dec!(5.6), dec!(0.0401));
+        costs1.track_labor("dancer", num!(6.0));
+        costs1.track_resource("widget", num!(3.1), num!(1.2));
+        costs1.track_resource("oil", num!(5.6), num!(0.0401));
 
-        let costs = costs1 / dec!(0.0);
-        assert_eq!(costs.get_labor("dancer"), dec!(6.0) / dec!(0.0));
-        assert_eq!(costs.get_resource("widget"), dec!(3.1) / dec!(0.0));
-        assert_eq!(costs.get_resource("oil"), dec!(5.6) / dec!(0.0));
+        let costs = costs1 / num!(0.0);
+        assert_eq!(costs.get_labor("dancer"), num!(6.0) / num!(0.0));
+        assert_eq!(costs.get_resource("widget"), num!(3.1) / num!(0.0));
+        assert_eq!(costs.get_resource("oil"), num!(5.6) / num!(0.0));
     }
 
     #[test]
     fn is_zero() {
         let mut costs = Costs::new();
         assert!(costs.is_zero());
-        costs.track_resource("widget", dec!(5.0), dec!(0.3));
+        costs.track_resource("widget", num!(5.0), num!(0.3));
         assert!(!costs.is_zero());
-        assert!(!Costs::new_with_labor("dictator", dec!(4.0)).is_zero());
+        assert!(!Costs::new_with_labor("dictator", num!(4.0)).is_zero());
     }
 
     #[test]
@@ -572,28 +573,28 @@ mod tests {
         costs1.track_labor("leash maker", 42);
         costs1.track_resource("oil", 17, 3);
         costs1.track_resource("linen", 20, 1);
-        costs1.track_currency("usd", dec!(3.14), dec!(0.991592654));
-        assert!(Costs::is_ratio_of(&costs1, &(costs1.clone() * dec!(0.333))));
+        costs1.track_currency("usd", num!(3.14), num!(0.991592654));
+        assert!(Costs::is_ratio_of(&costs1, &(costs1.clone() * num!(0.333))));
 
         let mut costs2 = Costs::new();
         costs2.track_labor("dog walker", 42);
         costs2.track_labor("leash maker", 42);
         costs2.track_resource("oil", 17, 3);
         costs2.track_resource("linen", 20, 1);
-        costs2.track_currency("usd", dec!(3.14), dec!(0.991592654));
-        assert!(Costs::is_ratio_of(&costs2, &(costs2.clone() * dec!(0.67723))));
+        costs2.track_currency("usd", num!(3.14), num!(0.991592654));
+        assert!(Costs::is_ratio_of(&costs2, &(costs2.clone() * num!(0.67723))));
 
         let mut costs3 = Costs::new();
         costs3.track_labor("dog walker", 42);
         costs3.track_labor("leash maker", 42);
         costs3.track_resource("oil", 17, 3);
         costs3.track_resource("linen", 20, 1);
-        costs3.track_currency("usd", dec!(3.14), dec!(0.991592654));
-        let mut compare = costs3.clone() * dec!(0.522);
-        compare.track_labor("leash maker", dec!(0.01));
+        costs3.track_currency("usd", num!(3.14), num!(0.991592654));
+        let mut compare = costs3.clone() * num!(0.522);
+        compare.track_labor("leash maker", num!(0.01));
         assert!(!Costs::is_ratio_of(&costs3, &compare));
 
-        let costs4 = Costs::new_with_labor("machinist", dec!(34.91));
+        let costs4 = Costs::new_with_labor("machinist", num!(34.91));
         assert!(Costs::is_ratio_of(&costs4, &Costs::new_with_labor("machinist", 30)));
     }
 
@@ -630,20 +631,20 @@ mod tests {
         let mut rec = Resource::default();
         let mut proc = Process::default();
 
-        match rec.release_costs(&Costs::new_with_labor("jumper", dec!(34.2))) {
+        match rec.release_costs(&Costs::new_with_labor("jumper", num!(34.2))) {
             Err(Error::NegativeCosts) => {}
             _ => panic!("should have gotten NegativeCosts error"),
         }
 
-        rec.costs.track_labor("firefighter", dec!(12.1));
-        match rec.move_costs_to(&mut proc, &Costs::new_with_labor("firefighter", dec!(12.2))) {
+        rec.costs.track_labor("firefighter", num!(12.1));
+        match rec.move_costs_to(&mut proc, &Costs::new_with_labor("firefighter", num!(12.2))) {
             Err(Error::NegativeCosts) => {}
             _ => panic!("should have gotten NegativeCosts error"),
         }
 
-        rec.move_costs_to(&mut proc, &Costs::new_with_labor("firefighter", dec!(12.0))).unwrap();
-        assert_eq!(rec.costs, Costs::new_with_labor("firefighter", dec!(12.1) - dec!(12.0)));
-        assert_eq!(proc.costs, Costs::new_with_labor("firefighter", dec!(12.0)));
+        rec.move_costs_to(&mut proc, &Costs::new_with_labor("firefighter", num!(12.0))).unwrap();
+        assert_eq!(rec.costs, Costs::new_with_labor("firefighter", num!(12.1) - num!(12.0)));
+        assert_eq!(proc.costs, Costs::new_with_labor("firefighter", num!(12.0)));
     }
 }
 

--- a/src/costs.rs
+++ b/src/costs.rs
@@ -592,6 +592,9 @@ mod tests {
         let mut compare = costs3.clone() * dec!(0.522);
         compare.track_labor("leash maker", dec!(0.01));
         assert!(!Costs::is_ratio_of(&costs3, &compare));
+
+        let costs4 = Costs::new_with_labor("machinist", dec!(34.91));
+        assert!(Costs::is_ratio_of(&costs4, &Costs::new_with_labor("machinist", 30)));
     }
 
     #[test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,6 +6,7 @@ use crate::{
         event::EventError,
     },
 };
+use rust_decimal::Decimal;
 use thiserror::Error;
 
 /// This is our error enum. It contains an entry for any part of the system in
@@ -27,16 +28,15 @@ pub enum Error {
     /// commitment doesn't match the action being performed.
     #[error("commitment is invalid")]
     CommitmentInvalid,
-    /// When trying to move a set of Costs from a Costs object where all values
-    /// of the moving Cost to not have the same proportion to the original cost.
-    #[error("costs being moved are not proportional")]
-    CostsNotProportional,
     /// An error while processing an event.
     #[error("event error {0:?}")]
     Event(#[from] EventError),
     /// You don't have permission to perform this action
     #[error("insufficient privileges")]
     InsufficientPrivileges,
+    /// The given ratio is not a value between 0 and 1 (inclusive)
+    #[error("invalid ratio {0} (must be 0 <= R <= 1")]
+    InvalidRatio(Decimal),
     /// We get this when trying to pull a measure out of a resource and come up
     /// blank, for instance when using `consume` on a resource that hasn't had
     /// its quantities initialized via `produce`/`raise`/`transfer`/etc.

--- a/src/error.rs
+++ b/src/error.rs
@@ -27,6 +27,10 @@ pub enum Error {
     /// commitment doesn't match the action being performed.
     #[error("commitment is invalid")]
     CommitmentInvalid,
+    /// When trying to move a set of Costs from a Costs object where all values
+    /// of the moving Cost to not have the same proportion to the original cost.
+    #[error("costs being moved are not proportional")]
+    CostsNotProportional,
     /// An error while processing an event.
     #[error("event error {0:?}")]
     Event(#[from] EventError),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,7 @@
 //! [transactions]: transactions/
 
 pub mod error;
+#[macro_use]
 mod util;
 #[macro_use]
 pub mod access;

--- a/src/models/account.rs
+++ b/src/models/account.rs
@@ -26,7 +26,7 @@ pub struct Multisig {
 
 impl Multisig {
     /// Create a new multisig obj
-    pub(crate) fn new(signatures_required: u64) -> Self {
+    pub fn new(signatures_required: u64) -> Self {
         Self {
             signatures_required,
         }

--- a/src/models/account.rs
+++ b/src/models/account.rs
@@ -71,22 +71,21 @@ mod tests {
     use crate::{
         util::{self, test::*},
     };
-    use rust_decimal_macros::*;
 
     #[test]
     fn account_cannot_go_negative() {
         let now = util::time::now();
-        let mut account = make_account(&AccountID::create(), &UserID::create(), dec!(50.0), "my account", &now);
-        let amount = account.adjust_balance(dec!(-49)).unwrap();
-        assert_eq!(amount, &dec!(1));
-        assert_eq!(account.balance(), &dec!(1));
-        let amount = account.adjust_balance(dec!(-0.6)).unwrap();
-        assert_eq!(amount, &dec!(0.4));
-        assert_eq!(account.balance(), &dec!(0.4));
-        let amount = account.adjust_balance(dec!(-0.4)).unwrap();
-        assert_eq!(amount, &dec!(0));
-        assert_eq!(account.balance(), &dec!(0));
-        let res = account.adjust_balance(dec!(-0.1));
+        let mut account = make_account(&AccountID::create(), &UserID::create(), num!(50.0), "my account", &now);
+        let amount = account.adjust_balance(num!(-49)).unwrap();
+        assert_eq!(amount, &num!(1));
+        assert_eq!(account.balance(), &num!(1));
+        let amount = account.adjust_balance(num!(-0.6)).unwrap();
+        assert_eq!(amount, &num!(0.4));
+        assert_eq!(account.balance(), &num!(0.4));
+        let amount = account.adjust_balance(num!(-0.4)).unwrap();
+        assert_eq!(amount, &num!(0));
+        assert_eq!(account.balance(), &num!(0));
+        let res = account.adjust_balance(num!(-0.1));
         assert_eq!(res, Err(Error::NegativeAccountBalance));
     }
 }

--- a/src/models/company.rs
+++ b/src/models/company.rs
@@ -205,7 +205,6 @@ mod tests {
         util::{self, test::*},
     };
     use om2::{Measure, Unit};
-    use rust_decimal_macros::*;
 
     #[test]
     fn totals_costs() {
@@ -213,27 +212,27 @@ mod tests {
         let company = make_company(&company_id, "jerry's delicious widgets", &util::time::now());
 
         let now = util::time::now();
-        let process1 = make_process(&ProcessID::create(), &company_id, "make widgets", &Costs::new_with_labor("lumberjack", dec!(16.9)), &now);
-        let process2 = make_process(&ProcessID::create(), &company_id, "market widgets", &Costs::new_with_labor("marketer", dec!(123.4)), &now);
-        let resource1 = make_resource(&ResourceID::create(), &company_id, &Measure::new(dec!(10.0), Unit::One), &Costs::new_with_labor("lumberjack", dec!(23.1)), &now);
-        let resource2 = make_resource(&ResourceID::create(), &company_id, &Measure::new(dec!(10.0), Unit::One), &Costs::new_with_labor("trucker", dec!(12.5)), &now);
+        let process1 = make_process(&ProcessID::create(), &company_id, "make widgets", &Costs::new_with_labor("lumberjack", num!(16.9)), &now);
+        let process2 = make_process(&ProcessID::create(), &company_id, "market widgets", &Costs::new_with_labor("marketer", num!(123.4)), &now);
+        let resource1 = make_resource(&ResourceID::create(), &company_id, &Measure::new(num!(10.0), Unit::One), &Costs::new_with_labor("lumberjack", num!(23.1)), &now);
+        let resource2 = make_resource(&ResourceID::create(), &company_id, &Measure::new(num!(10.0), Unit::One), &Costs::new_with_labor("trucker", num!(12.5)), &now);
 
         let costs = company.total_costs(&vec![process1, process2], &vec![resource1, resource2]);
         let mut expected_costs = Costs::new();
-        expected_costs.track_labor("lumberjack", dec!(40));
-        expected_costs.track_labor("trucker", dec!(12.5));
-        expected_costs.track_labor("marketer", dec!(123.4));
+        expected_costs.track_labor("lumberjack", num!(40));
+        expected_costs.track_labor("trucker", num!(12.5));
+        expected_costs.track_labor("marketer", num!(123.4));
         assert_eq!(costs, expected_costs);
 
-        let process1 = make_process(&ProcessID::create(), &CompanyID::create(), "make widgets", &Costs::new_with_labor("lumberjack", dec!(16.9)), &now);
-        let process2 = make_process(&ProcessID::create(), &company_id, "market widgets", &Costs::new_with_labor("marketer", dec!(123.4)), &now);
-        let resource1 = make_resource(&ResourceID::create(), &CompanyID::create(), &Measure::new(dec!(10.0), Unit::One), &Costs::new_with_labor("lumberjack", dec!(23.1)), &now);
-        let resource2 = make_resource(&ResourceID::create(), &company_id, &Measure::new(dec!(10.0), Unit::One), &Costs::new_with_labor("trucker", dec!(12.5)), &now);
+        let process1 = make_process(&ProcessID::create(), &CompanyID::create(), "make widgets", &Costs::new_with_labor("lumberjack", num!(16.9)), &now);
+        let process2 = make_process(&ProcessID::create(), &company_id, "market widgets", &Costs::new_with_labor("marketer", num!(123.4)), &now);
+        let resource1 = make_resource(&ResourceID::create(), &CompanyID::create(), &Measure::new(num!(10.0), Unit::One), &Costs::new_with_labor("lumberjack", num!(23.1)), &now);
+        let resource2 = make_resource(&ResourceID::create(), &company_id, &Measure::new(num!(10.0), Unit::One), &Costs::new_with_labor("trucker", num!(12.5)), &now);
 
         let costs = company.total_costs(&vec![process1, process2], &vec![resource1, resource2]);
         let mut expected_costs = Costs::new();
-        expected_costs.track_labor("trucker", dec!(12.5));
-        expected_costs.track_labor("marketer", dec!(123.4));
+        expected_costs.track_labor("trucker", num!(12.5));
+        expected_costs.track_labor("marketer", num!(123.4));
         assert_eq!(costs, expected_costs);
     }
 }

--- a/src/models/event.rs
+++ b/src/models/event.rs
@@ -147,7 +147,11 @@ basis_model! {
         /// The event's core VF type
         inner: vf::EconomicEvent<Url, AgentID, ProcessID, AgentID, AgreementID, (), ResourceSpecID, ResourceID, EventID>,
         /// If this event is an input/output of a process or resource, move some
-        /// fixed amount of costs between the two objects.
+        /// fixed amount of costs between the two objects. Note that the values
+        /// of the costs being moved *must all* be of the same ratio. In other
+        /// words, if you're moving 50% of the labor::CEO costs, you must also
+        /// move 50% of all the other costs. Failure to do so will result in a
+        /// transaction error.
         move_costs: Option<Costs>,
         /// The type of move (if using `Action::Move`). Can be cost-based
         /// (exclusively for moving costs between resources and processes) or

--- a/src/models/process.rs
+++ b/src/models/process.rs
@@ -55,7 +55,6 @@ mod tests {
         },
         util::{self, test::*},
     };
-    use rust_decimal_macros::*;
 
     #[test]
     fn compare() {
@@ -64,9 +63,9 @@ mod tests {
         let id2 = ProcessID::new("widget2");
         let company_id1 = CompanyID::new("jerry's widgets");
         let company_id2 = CompanyID::new("frank's widgets");
-        let costs = Costs::new_with_labor("machinist", dec!(23.2));
+        let costs = Costs::new_with_labor("machinist", num!(23.2));
         let mut costs2 = costs.clone();
-        costs2.track_labor("mayor", dec!(2.4));
+        costs2.track_labor("mayor", num!(2.4));
         let process1 = make_process(&id1, &company_id1, "make widgets", &costs, &now);
         let process2 = make_process(&id2, &company_id2, "burn widgets", &costs, &now);
 
@@ -85,7 +84,7 @@ mod tests {
         assert!(process1 == process3);
         process3.set_costs(costs2);
         assert!(process1 != process3);
-        process3.set_costs(Costs::new_with_labor("machinist", dec!(23.2)));
+        process3.set_costs(Costs::new_with_labor("machinist", num!(23.2)));
         assert!(process1 == process3);
     }
 }

--- a/src/models/resource.rs
+++ b/src/models/resource.rs
@@ -76,7 +76,6 @@ mod tests {
         util::{self, test::*},
     };
     use om2::{Measure, Unit};
-    use rust_decimal_macros::*;
 
     #[test]
     fn compare() {
@@ -86,7 +85,7 @@ mod tests {
         let company_id1 = CompanyID::new("jerry's widgets");
         let company_id2 = CompanyID::new("frank's widgets");
         let measure = Measure::new(50, Unit::Kilogram);
-        let costs = Costs::new_with_labor("machinist", dec!(23.2));
+        let costs = Costs::new_with_labor("machinist", num!(23.2));
         let resource1 = make_resource(&id1, &company_id1, &measure, &costs, &now);
         let resource2 = make_resource(&id2, &company_id2, &measure, &costs, &now);
 
@@ -103,9 +102,9 @@ mod tests {
         assert!(resource1 != resource3);
         resource3.inner_mut().set_primary_accountable(Some(company_id1.clone().into()));
         assert!(resource1 == resource3);
-        resource3.set_costs(Costs::new_with_labor("machinist", dec!(23.1)));
+        resource3.set_costs(Costs::new_with_labor("machinist", num!(23.1)));
         assert!(resource1 != resource3);
-        resource3.set_costs(Costs::new_with_labor("machinist", dec!(23.2)));
+        resource3.set_costs(Costs::new_with_labor("machinist", num!(23.2)));
         assert!(resource1 == resource3);
     }
 

--- a/src/transactions/account.rs
+++ b/src/transactions/account.rs
@@ -110,7 +110,6 @@ mod tests {
     use crate::{
         util::{self, test::{self, *}},
     };
-    use rust_decimal_macros::*;
 
     #[test]
     fn can_create() {
@@ -135,7 +134,7 @@ mod tests {
         assert_eq!(account.multisig(), &multisig);
         assert_eq!(account.name(), "Jerry's account");
         assert_eq!(account.description(), "Hi I'm Jerry");
-        assert_eq!(account.balance(), &dec!(0));
+        assert_eq!(account.balance(), &num!(0));
         assert_eq!(account.ubi(), &false);
         assert_eq!(account.active(), &true);
         assert_eq!(account.created(), &now);
@@ -225,8 +224,8 @@ mod tests {
     fn can_transfer() {
         let now = util::time::now();
         let mut state = TestState::standard(vec![], &now);
-        let account1 = make_account(&AccountID::create(), state.user().id(), dec!(50), "Jerry's account", &now);
-        let account2 = make_account(&AccountID::create(), &UserID::create(), dec!(0), "Larry's account", &now);
+        let account1 = make_account(&AccountID::create(), state.user().id(), num!(50), "Jerry's account", &now);
+        let account2 = make_account(&AccountID::create(), &UserID::create(), num!(0), "Larry's account", &now);
         state.company = None;
         state.member = None;
         state.model = Some(account1);
@@ -237,14 +236,14 @@ mod tests {
             transfer(state.user(), state.model().clone(), state.model2().clone(), amount, &now2)
         };
         let testfn = |state: &TestState<Account, Account>| {
-            testfn_inner(state, dec!(10))
+            testfn_inner(state, num!(10))
         };
         test::standard_transaction_tests(&state, &testfn);
 
         let mods = testfn(&state).unwrap().into_vec();
         assert_eq!(mods.len(), 2);
         let account3 = mods[0].clone().expect_op::<Account>(Op::Update).unwrap();
-        assert_eq!(account3.balance(), &dec!(40));
+        assert_eq!(account3.balance(), &num!(40));
         assert_eq!(account3.id(), state.model().id());
         assert_eq!(account3.user_ids(), state.model().user_ids());
         assert_eq!(account3.multisig(), state.model().multisig());
@@ -255,7 +254,7 @@ mod tests {
         assert_eq!(account3.updated(), &now2);
         assert_eq!(account3.deleted(), &None);
         let account4 = mods[1].clone().expect_op::<Account>(Op::Update).unwrap();
-        assert_eq!(account4.balance(), &dec!(10));
+        assert_eq!(account4.balance(), &num!(10));
         assert_eq!(account4.id(), state.model2().id());
         assert_eq!(account4.user_ids(), state.model2().user_ids());
         assert_eq!(account4.multisig(), state.model2().multisig());
@@ -274,7 +273,7 @@ mod tests {
         let res = testfn(&state2);
         assert_eq!(res, Err(Error::InsufficientPrivileges));
 
-        let res = testfn_inner(&state, dec!(56));
+        let res = testfn_inner(&state, num!(56));
         assert_eq!(res, Err(Error::NegativeAccountBalance));
     }
 
@@ -317,7 +316,7 @@ mod tests {
         assert_eq!(res, Err(Error::InsufficientPrivileges));
 
         let mut state3 = state.clone();
-        state3.model_mut().set_balance(dec!(21.55));
+        state3.model_mut().set_balance(num!(21.55));
         let res = testfn(&state3);
         assert_eq!(res, Err(Error::CannotEraseCredits));
     }

--- a/src/transactions/commitment.rs
+++ b/src/transactions/commitment.rs
@@ -198,7 +198,6 @@ mod tests {
         util::{self, test::{self, *}},
     };
     use om2::Unit;
-    use rust_decimal_macros::*;
 
     #[test]
     fn can_create() {
@@ -209,10 +208,10 @@ mod tests {
         let company_from = make_company(&CompanyID::create(), "bridget's widgets", &now);
         let agreement = make_agreement(&AgreementID::create(), &vec![company_from.agent_id(), state.company().agent_id()], "order 111222", "UwU big order of widgetzzz", &now);
         let costs = Costs::new_with_labor("widgetmaker", 42);
-        let resource = make_resource(&ResourceID::new("widget1"), company_from.id(), &Measure::new(dec!(30), Unit::One), &Costs::new_with_labor("widgetmaker", dec!(50)), &now);
+        let resource = make_resource(&ResourceID::new("widget1"), company_from.id(), &Measure::new(num!(30), Unit::One), &Costs::new_with_labor("widgetmaker", num!(50)), &now);
 
         let testfn_inner = |state: &TestState<Commitment, Commitment>, agreement: &Agreement, company_from: &Company, company_to: &Company| {
-            create(state.user(), state.member(), state.company(), &agreement, id.clone(), costs.clone(), OrderAction::Transfer, None, Some(state.loc().clone()), Some(now.clone()), None, None, Some(false), None, None, None, vec![], None, Some("widgetzz".into()), Some("sending widgets to larry".into()), None, company_from.agent_id(), company_to.agent_id(), None, Some(resource.id().clone()), Some(Measure::new(dec!(10), Unit::One)), true, &now)
+            create(state.user(), state.member(), state.company(), &agreement, id.clone(), costs.clone(), OrderAction::Transfer, None, Some(state.loc().clone()), Some(now.clone()), None, None, Some(false), None, None, None, vec![], None, Some("widgetzz".into()), Some("sending widgets to larry".into()), None, company_from.agent_id(), company_to.agent_id(), None, Some(resource.id().clone()), Some(Measure::new(num!(10), Unit::One)), true, &now)
         };
         let testfn = |state: &TestState<Commitment, Commitment>| {
             testfn_inner(state, &agreement, &company_from, &company_to)
@@ -244,7 +243,7 @@ mod tests {
         assert_eq!(commitment.inner().receiver(), &state.company().agent_id());
         assert_eq!(commitment.inner().resource_conforms_to(), &None);
         assert_eq!(commitment.inner().resource_inventoried_as(), &Some(ResourceID::new("widget1")));
-        assert_eq!(commitment.inner().resource_quantity(), &Some(Measure::new(dec!(10), Unit::One)));
+        assert_eq!(commitment.inner().resource_quantity(), &Some(Measure::new(num!(10), Unit::One)));
         assert_eq!(commitment.active(), &true);
         assert_eq!(commitment.created(), &now);
         assert_eq!(commitment.updated(), &now);
@@ -273,16 +272,16 @@ mod tests {
         let agreement = make_agreement(&AgreementID::create(), &vec![company_from.agent_id(), company_to.agent_id()], "order 111222", "UwU big order of widgetzzz", &now);
         let costs1 = Costs::new_with_labor("widgetmaker", 42);
         let costs2 = Costs::new_with_labor("widgetmaker", 31);
-        let resource = make_resource(&ResourceID::new("widget1"), company_from.id(), &Measure::new(dec!(30), Unit::One), &Costs::new_with_labor("widgetmaker", dec!(50)), &now);
+        let resource = make_resource(&ResourceID::new("widget1"), company_from.id(), &Measure::new(num!(30), Unit::One), &Costs::new_with_labor("widgetmaker", num!(50)), &now);
         let agreement_url: Url = "http://legalzoom.com/standard-widget-shopping-cart-agreement".parse().unwrap();
 
-        let mods = create(state.user(), state.member(), state.company(), &agreement, id.clone(), costs1.clone(), OrderAction::Transfer, None, Some(state.loc().clone()), Some(now.clone()), None, None, Some(false), None, None, None, vec![], None, Some("widgetzz".into()), Some("sending widgets to larry".into()), None, company_from.agent_id(), company_to.agent_id(), None, Some(resource.id().clone()), Some(Measure::new(dec!(10), Unit::One)), true, &now).unwrap().into_vec();
+        let mods = create(state.user(), state.member(), state.company(), &agreement, id.clone(), costs1.clone(), OrderAction::Transfer, None, Some(state.loc().clone()), Some(now.clone()), None, None, Some(false), None, None, None, vec![], None, Some("widgetzz".into()), Some("sending widgets to larry".into()), None, company_from.agent_id(), company_to.agent_id(), None, Some(resource.id().clone()), Some(Measure::new(num!(10), Unit::One)), true, &now).unwrap().into_vec();
         let commitment1 = mods[0].clone().expect_op::<Commitment>(Op::Create).unwrap();
         let now2 = util::time::now();
         state.model = Some(commitment1.clone());
 
         let testfn = |state: &TestState<Commitment, Commitment>| {
-            update(state.user(), state.member(), state.company(), state.model().clone(), Some(costs2.clone()), None, Some(Some(agreement_url.clone())), None, Some(Some(now2.clone())), None, None, Some(Some(true)), Some(Some(now.clone())), None, None, Some(vec![company_from.agent_id()]), None, None, Some(Some("here, larry".into())), None, None, None, Some(Some(Measure::new(dec!(50), Unit::One))), None, &now2)
+            update(state.user(), state.member(), state.company(), state.model().clone(), Some(costs2.clone()), None, Some(Some(agreement_url.clone())), None, Some(Some(now2.clone())), None, None, Some(Some(true)), Some(Some(now.clone())), None, None, Some(vec![company_from.agent_id()]), None, None, Some(Some("here, larry".into())), None, None, None, Some(Some(Measure::new(num!(50), Unit::One))), None, &now2)
         };
         test::standard_transaction_tests(&state, &testfn);
 
@@ -311,7 +310,7 @@ mod tests {
         assert_eq!(commitment2.inner().receiver(), commitment1.inner().receiver());
         assert_eq!(commitment2.inner().resource_conforms_to(), commitment1.inner().resource_conforms_to());
         assert_eq!(commitment2.inner().resource_inventoried_as(), commitment1.inner().resource_inventoried_as());
-        assert_eq!(commitment2.inner().resource_quantity(), &Some(Measure::new(dec!(50), Unit::One)));
+        assert_eq!(commitment2.inner().resource_quantity(), &Some(Measure::new(num!(50), Unit::One)));
         assert_eq!(commitment2.active(), &true);
         assert_eq!(commitment2.created(), &now);
         assert_eq!(commitment2.updated(), &now2);
@@ -326,10 +325,10 @@ mod tests {
         let company_from = make_company(&CompanyID::create(), "bridget's widgets", &now);
         let company_to = state.company().clone();
         let agreement = make_agreement(&AgreementID::create(), &vec![company_from.agent_id(), company_to.agent_id()], "order 111222", "UwU big order of widgetzzz", &now);
-        let resource = make_resource(&ResourceID::new("widget1"), company_from.id(), &Measure::new(dec!(30), Unit::One), &Costs::new_with_labor("widgetmaker", dec!(50)), &now);
+        let resource = make_resource(&ResourceID::new("widget1"), company_from.id(), &Measure::new(num!(30), Unit::One), &Costs::new_with_labor("widgetmaker", num!(50)), &now);
         let costs1 = Costs::new_with_labor("widgetmaker", 42);
 
-        let mods = create(state.user(), state.member(), state.company(), &agreement, id.clone(), costs1.clone(), OrderAction::Transfer, None, Some(state.loc().clone()), Some(now.clone()), None, None, Some(false), None, None, None, vec![], None, Some("widgetzz".into()), Some("sending widgets to larry".into()), None, company_from.agent_id(), company_to.agent_id(), None, Some(resource.id().clone()), Some(Measure::new(dec!(10), Unit::One)), true, &now).unwrap().into_vec();
+        let mods = create(state.user(), state.member(), state.company(), &agreement, id.clone(), costs1.clone(), OrderAction::Transfer, None, Some(state.loc().clone()), Some(now.clone()), None, None, Some(false), None, None, None, vec![], None, Some("widgetzz".into()), Some("sending widgets to larry".into()), None, company_from.agent_id(), company_to.agent_id(), None, Some(resource.id().clone()), Some(Measure::new(num!(10), Unit::One)), true, &now).unwrap().into_vec();
         let commitment1 = mods[0].clone().expect_op::<Commitment>(Op::Create).unwrap();
         let now2 = util::time::now();
         state.model = Some(commitment1.clone());

--- a/src/transactions/event/accounting.rs
+++ b/src/transactions/event/accounting.rs
@@ -248,14 +248,13 @@ mod tests {
         util::{self, test::{self, *}},
     };
     use om2::Unit;
-    use rust_decimal_macros::*;
 
     #[test]
     fn can_lower() {
         let now = util::time::now();
         let id = EventID::create();
         let mut state = TestState::standard(vec![CompanyPermission::Lower], &now);
-        let resource = make_resource(&ResourceID::new("widget"), state.company().id(), &Measure::new(dec!(15), Unit::One), &Costs::new_with_labor("homemaker", 157), &now);
+        let resource = make_resource(&ResourceID::new("widget"), state.company().id(), &Measure::new(num!(15), Unit::One), &Costs::new_with_labor("homemaker", 157), &now);
         state.model = Some(resource);
 
         let testfn = |state: &TestState<Resource, Resource>| {
@@ -283,8 +282,8 @@ mod tests {
         assert_eq!(event.updated(), &now);
 
         assert_eq!(resource2.id(), state.model().id());
-        assert_eq!(resource2.inner().accounting_quantity(), &Some(Measure::new(dec!(7), Unit::One)));
-        assert_eq!(resource2.inner().onhand_quantity(), &Some(Measure::new(dec!(7), Unit::One)));
+        assert_eq!(resource2.inner().accounting_quantity(), &Some(Measure::new(num!(7), Unit::One)));
+        assert_eq!(resource2.inner().onhand_quantity(), &Some(Measure::new(num!(7), Unit::One)));
         assert_eq!(resource2.costs(), state.model().costs());
 
         // a company that doesn't own a resource can't lower it
@@ -306,9 +305,9 @@ mod tests {
         let id = EventID::create();
         let mut state = TestState::standard(vec![CompanyPermission::MoveCosts], &now);
         let occupation_id = OccupationID::new("lawyer");
-        let process_from = make_process(&ProcessID::create(), state.company().id(), "various lawyerings", &Costs::new_with_labor(occupation_id.clone(), dec!(177.25)), &now);
-        let process_to = make_process(&ProcessID::create(), state.company().id(), "overflow labor", &Costs::new_with_labor(occupation_id.clone(), dec!(804)), &now);
-        let costs_to_move = process_from.costs().clone() * dec!(0.45);
+        let process_from = make_process(&ProcessID::create(), state.company().id(), "various lawyerings", &Costs::new_with_labor(occupation_id.clone(), num!(177.25)), &now);
+        let process_to = make_process(&ProcessID::create(), state.company().id(), "overflow labor", &Costs::new_with_labor(occupation_id.clone(), num!(804)), &now);
+        let costs_to_move = process_from.costs().clone() * num!(0.45);
         state.model = Some(process_from);
         state.model2 = Some(process_to);
 
@@ -338,7 +337,7 @@ mod tests {
         assert_eq!(event.updated(), &now);
 
         let mut costs2 = Costs::new();
-        costs2.track_labor("lawyer", dec!(177.25) - dec!(100));
+        costs2.track_labor("lawyer", num!(177.25) - num!(100));
         assert_eq!(process_from2.id(), state.model().id());
         assert_eq!(process_from2.company_id(), state.company().id());
         assert_eq!(process_from2.costs(), &(state.model().costs().clone() - costs_to_move.clone()));
@@ -365,9 +364,9 @@ mod tests {
         let now = util::time::now();
         let id = EventID::create();
         let mut state = TestState::standard(vec![CompanyPermission::MoveResource], &now);
-        let resource = make_resource(&ResourceID::new("plank"), state.company().id(), &Measure::new(dec!(15), Unit::One), &Costs::new_with_labor("homemaker", 157), &now);
-        let resource_to = make_resource(&ResourceID::new("plank"), state.company().id(), &Measure::new(dec!(3), Unit::One), &Costs::new_with_labor("homemaker", 2), &now);
-        let costs_to_move = resource.costs().clone() * (dec!(8) / dec!(15));
+        let resource = make_resource(&ResourceID::new("plank"), state.company().id(), &Measure::new(num!(15), Unit::One), &Costs::new_with_labor("homemaker", 157), &now);
+        let resource_to = make_resource(&ResourceID::new("plank"), state.company().id(), &Measure::new(num!(3), Unit::One), &Costs::new_with_labor("homemaker", 2), &now);
+        let costs_to_move = resource.costs().clone() * (num!(8) / num!(15));
         state.model = Some(resource);
         state.model2 = Some(resource_to);
 
@@ -407,15 +406,15 @@ mod tests {
 
         assert_eq!(resource_from2.id(), state.model().id());
         assert_eq!(resource_from2.inner().primary_accountable(), &Some(state.company().agent_id()));
-        assert_eq!(resource_from2.inner().accounting_quantity(), &Some(Measure::new(dec!(15) - dec!(8), Unit::One)));
-        assert_eq!(resource_from2.inner().onhand_quantity(), &Some(Measure::new(dec!(15) - dec!(8), Unit::One)));
+        assert_eq!(resource_from2.inner().accounting_quantity(), &Some(Measure::new(num!(15) - num!(8), Unit::One)));
+        assert_eq!(resource_from2.inner().onhand_quantity(), &Some(Measure::new(num!(15) - num!(8), Unit::One)));
         assert_eq!(resource_from2.in_custody_of(), &state.company().agent_id());
         assert_eq!(resource_from2.costs(), &(state.model().costs().clone() - costs_to_move.clone()));
 
         assert_eq!(resource_to2.id(), state.model2().id());
         assert_eq!(resource_to2.inner().primary_accountable(), &Some(state.company().agent_id()));
-        assert_eq!(resource_to2.inner().accounting_quantity(), &Some(Measure::new(dec!(8) + dec!(3), Unit::One)));
-        assert_eq!(resource_to2.inner().onhand_quantity(), &Some(Measure::new(dec!(8) + dec!(3), Unit::One)));
+        assert_eq!(resource_to2.inner().accounting_quantity(), &Some(Measure::new(num!(8) + num!(3), Unit::One)));
+        assert_eq!(resource_to2.inner().onhand_quantity(), &Some(Measure::new(num!(8) + num!(3), Unit::One)));
         assert_eq!(resource_to2.in_custody_of(), &state.company().agent_id());
         assert_eq!(resource_to2.costs(), &(state.model2().costs().clone() + costs_to_move.clone()));
 
@@ -442,15 +441,15 @@ mod tests {
 
         assert_eq!(resource_from3.id(), state.model().id());
         assert_eq!(resource_from3.inner().primary_accountable(), &Some(state.company().agent_id()));
-        assert_eq!(resource_from3.inner().accounting_quantity(), &Some(Measure::new(dec!(15) - dec!(8), Unit::One)));
-        assert_eq!(resource_from3.inner().onhand_quantity(), &Some(Measure::new(dec!(15) - dec!(8), Unit::One)));
+        assert_eq!(resource_from3.inner().accounting_quantity(), &Some(Measure::new(num!(15) - num!(8), Unit::One)));
+        assert_eq!(resource_from3.inner().onhand_quantity(), &Some(Measure::new(num!(15) - num!(8), Unit::One)));
         assert_eq!(resource_from3.in_custody_of(), &state.company().agent_id());
         assert_eq!(resource_from3.costs(), &(state.model().costs().clone() - costs_to_move.clone()));
 
         assert_eq!(resource_created.id(), state.model2().id());
         assert_eq!(resource_created.inner().primary_accountable(), &Some(state.company().agent_id()));
-        assert_eq!(resource_created.inner().accounting_quantity(), &Some(Measure::new(dec!(8), Unit::One)));
-        assert_eq!(resource_created.inner().onhand_quantity(), &Some(Measure::new(dec!(8), Unit::One)));
+        assert_eq!(resource_created.inner().accounting_quantity(), &Some(Measure::new(num!(8), Unit::One)));
+        assert_eq!(resource_created.inner().onhand_quantity(), &Some(Measure::new(num!(8), Unit::One)));
         assert_eq!(resource_created.in_custody_of(), &state.company().agent_id());
         assert_eq!(resource_created.costs(), &(costs_to_move.clone()));
 
@@ -482,7 +481,7 @@ mod tests {
         let now = util::time::now();
         let id = EventID::create();
         let mut state = TestState::standard(vec![CompanyPermission::Raise], &now);
-        let resource = make_resource(&ResourceID::new("widget"), state.company().id(), &Measure::new(dec!(15), Unit::One), &Costs::new_with_labor("homemaker", 157), &now);
+        let resource = make_resource(&ResourceID::new("widget"), state.company().id(), &Measure::new(num!(15), Unit::One), &Costs::new_with_labor("homemaker", 157), &now);
         state.model = Some(resource);
 
         let testfn = |state: &TestState<Resource, Resource>| {
@@ -510,8 +509,8 @@ mod tests {
         assert_eq!(event.updated(), &now);
 
         assert_eq!(resource2.id(), state.model().id());
-        assert_eq!(resource2.inner().accounting_quantity(), &Some(Measure::new(dec!(23), Unit::One)));
-        assert_eq!(resource2.inner().onhand_quantity(), &Some(Measure::new(dec!(23), Unit::One)));
+        assert_eq!(resource2.inner().accounting_quantity(), &Some(Measure::new(num!(23), Unit::One)));
+        assert_eq!(resource2.inner().onhand_quantity(), &Some(Measure::new(num!(23), Unit::One)));
         assert_eq!(resource2.costs(), state.model().costs());
 
         // a company that doesn't own a resource can't raise it

--- a/src/transactions/event/delivery.rs
+++ b/src/transactions/event/delivery.rs
@@ -139,7 +139,6 @@ mod tests {
         util::{self, test::{self, *}},
     };
     use om2::{Measure, Unit};
-    use rust_decimal_macros::*;
 
     #[test]
     fn can_dropoff() {
@@ -147,9 +146,9 @@ mod tests {
         let id = EventID::create();
         let mut state = TestState::standard(vec![CompanyPermission::Dropoff], &now);
         let occupation_id = OccupationID::new("trucker");
-        let costs = Costs::new_with_labor(occupation_id.clone(), dec!(42.2));
+        let costs = Costs::new_with_labor(occupation_id.clone(), num!(42.2));
         let process = make_process(&ProcessID::create(), state.company().id(), "deliver widgets", &costs, &now);
-        let resource = make_resource(&ResourceID::new("widget"), state.company().id(), &Measure::new(dec!(15), Unit::One), &Costs::new_with_labor("machinist", 157), &now);
+        let resource = make_resource(&ResourceID::new("widget"), state.company().id(), &Measure::new(num!(15), Unit::One), &Costs::new_with_labor("machinist", 157), &now);
         state.model = Some(process);
         state.model2 = Some(resource);
 
@@ -182,14 +181,14 @@ mod tests {
         assert_eq!(process2.costs(), &Costs::new());
 
         let mut costs2 = Costs::new();
-        costs2.track_labor(occupation_id.clone(), dec!(42.2));
+        costs2.track_labor(occupation_id.clone(), num!(42.2));
         costs2.track_labor("machinist", 157);
         assert_eq!(resource2.id(), state.model2().id());
         assert_eq!(resource2.inner().primary_accountable(), &Some(state.company().agent_id()));
         assert_eq!(resource2.in_custody_of(), &state.company().agent_id());
-        assert_eq!(resource2.inner().accounting_quantity(), &Some(Measure::new(dec!(15), Unit::One)));
+        assert_eq!(resource2.inner().accounting_quantity(), &Some(Measure::new(num!(15), Unit::One)));
         assert_eq!(event.inner().note(), &Some("memo".into()));
-        assert_eq!(resource2.inner().onhand_quantity(), &Some(Measure::new(dec!(15), Unit::One)));
+        assert_eq!(resource2.inner().onhand_quantity(), &Some(Measure::new(num!(15), Unit::One)));
         assert_eq!(resource2.inner().current_location(), &Some(state.loc().clone()));
         assert_eq!(resource2.costs(), &costs2);
 
@@ -216,7 +215,7 @@ mod tests {
         let now = util::time::now();
         let id = EventID::create();
         let mut state = TestState::standard(vec![CompanyPermission::Pickup], &now);
-        let resource = make_resource(&ResourceID::new("widget"), state.company().id(), &Measure::new(dec!(15), Unit::One), &Costs::new_with_labor("homemaker", 157), &now);
+        let resource = make_resource(&ResourceID::new("widget"), state.company().id(), &Measure::new(num!(15), Unit::One), &Costs::new_with_labor("homemaker", 157), &now);
         let process = make_process(&ProcessID::create(), state.company().id(), "make widgets", &Costs::new(), &now);
         state.model = Some(resource);
         state.model2 = Some(process);

--- a/src/transactions/event/modification.rs
+++ b/src/transactions/event/modification.rs
@@ -154,7 +154,7 @@ mod tests {
         let now = util::time::now();
         let id = EventID::create();
         let mut state = TestState::standard(vec![CompanyPermission::Accept], &now);
-        let resource = make_resource(&ResourceID::new("widget"), state.company().id(), &Measure::new(dec!(15), Unit::One), &Costs::new_with_resource("steel", 157), &now);
+        let resource = make_resource(&ResourceID::new("widget"), state.company().id(), &Measure::new(dec!(15), Unit::One), &Costs::new_with_resource("steel", 157, dec!(0.01)), &now);
         let process = make_process(&ProcessID::create(), state.company().id(), "make widgets", &Costs::new(), &now);
         state.model = Some(resource);
         state.model2 = Some(process);
@@ -187,7 +187,7 @@ mod tests {
         assert_eq!(resource2.in_custody_of(), &state.company().agent_id());
         assert_eq!(resource2.inner().accounting_quantity(), &Some(Measure::new(dec!(15), Unit::One)));
         assert_eq!(resource2.inner().onhand_quantity(), &Some(Measure::new(dec!(12), Unit::One)));
-        assert_eq!(resource2.costs(), &Costs::new_with_resource("steel", 157));
+        assert_eq!(resource2.costs(), &Costs::new_with_resource("steel", 157, dec!(0.01)));
 
         // can't accept into a process you don't own
         let mut state2 = state.clone();
@@ -216,7 +216,7 @@ mod tests {
         let occupation_id = OccupationID::new("mechanic");
         let costs = Costs::new_with_labor(occupation_id.clone(), dec!(102.3));
         let process = make_process(&ProcessID::create(), state.company().id(), "repair car", &costs, &now);
-        let resource = make_resource(&ResourceID::new("car"), state.company().id(), &Measure::new(dec!(3), Unit::One), &Costs::new_with_resource("steel", 157), &now);
+        let resource = make_resource(&ResourceID::new("car"), state.company().id(), &Measure::new(dec!(3), Unit::One), &Costs::new_with_resource("steel", 157, dec!(0.01)), &now);
         state.model = Some(process);
         state.model2 = Some(resource);
 
@@ -251,7 +251,7 @@ mod tests {
 
         let mut costs2 = Costs::new();
         costs2.track_labor(occupation_id.clone(), dec!(102.3));
-        costs2.track_resource("steel", 157);
+        costs2.track_resource("steel", 157, dec!(0.01));
         assert_eq!(resource2.id(), state.model2().id());
         assert_eq!(resource2.inner().primary_accountable(), &Some(state.company().agent_id()));
         assert_eq!(resource2.in_custody_of(), &state.company().agent_id());

--- a/src/transactions/event/modification.rs
+++ b/src/transactions/event/modification.rs
@@ -147,14 +147,13 @@ mod tests {
         util::{self, test::{self, *}},
     };
     use om2::{Measure, Unit};
-    use rust_decimal_macros::*;
 
     #[test]
     fn can_accept() {
         let now = util::time::now();
         let id = EventID::create();
         let mut state = TestState::standard(vec![CompanyPermission::Accept], &now);
-        let resource = make_resource(&ResourceID::new("widget"), state.company().id(), &Measure::new(dec!(15), Unit::One), &Costs::new_with_resource("steel", 157, dec!(0.01)), &now);
+        let resource = make_resource(&ResourceID::new("widget"), state.company().id(), &Measure::new(num!(15), Unit::One), &Costs::new_with_resource("steel", 157, num!(0.01)), &now);
         let process = make_process(&ProcessID::create(), state.company().id(), "make widgets", &Costs::new(), &now);
         state.model = Some(resource);
         state.model2 = Some(process);
@@ -185,9 +184,9 @@ mod tests {
         assert_eq!(resource2.id(), state.model().id());
         assert_eq!(resource2.inner().primary_accountable(), &Some(state.company().agent_id()));
         assert_eq!(resource2.in_custody_of(), &state.company().agent_id());
-        assert_eq!(resource2.inner().accounting_quantity(), &Some(Measure::new(dec!(15), Unit::One)));
-        assert_eq!(resource2.inner().onhand_quantity(), &Some(Measure::new(dec!(12), Unit::One)));
-        assert_eq!(resource2.costs(), &Costs::new_with_resource("steel", 157, dec!(0.01)));
+        assert_eq!(resource2.inner().accounting_quantity(), &Some(Measure::new(num!(15), Unit::One)));
+        assert_eq!(resource2.inner().onhand_quantity(), &Some(Measure::new(num!(12), Unit::One)));
+        assert_eq!(resource2.costs(), &Costs::new_with_resource("steel", 157, num!(0.01)));
 
         // can't accept into a process you don't own
         let mut state2 = state.clone();
@@ -214,9 +213,9 @@ mod tests {
         let id = EventID::create();
         let mut state = TestState::standard(vec![CompanyPermission::Modify], &now);
         let occupation_id = OccupationID::new("mechanic");
-        let costs = Costs::new_with_labor(occupation_id.clone(), dec!(102.3));
+        let costs = Costs::new_with_labor(occupation_id.clone(), num!(102.3));
         let process = make_process(&ProcessID::create(), state.company().id(), "repair car", &costs, &now);
-        let resource = make_resource(&ResourceID::new("car"), state.company().id(), &Measure::new(dec!(3), Unit::One), &Costs::new_with_resource("steel", 157, dec!(0.01)), &now);
+        let resource = make_resource(&ResourceID::new("car"), state.company().id(), &Measure::new(num!(3), Unit::One), &Costs::new_with_resource("steel", 157, num!(0.01)), &now);
         state.model = Some(process);
         state.model2 = Some(resource);
 
@@ -250,13 +249,13 @@ mod tests {
         assert_eq!(process2.costs(), &Costs::new());
 
         let mut costs2 = Costs::new();
-        costs2.track_labor(occupation_id.clone(), dec!(102.3));
-        costs2.track_resource("steel", 157, dec!(0.01));
+        costs2.track_labor(occupation_id.clone(), num!(102.3));
+        costs2.track_resource("steel", 157, num!(0.01));
         assert_eq!(resource2.id(), state.model2().id());
         assert_eq!(resource2.inner().primary_accountable(), &Some(state.company().agent_id()));
         assert_eq!(resource2.in_custody_of(), &state.company().agent_id());
-        assert_eq!(resource2.inner().accounting_quantity(), &Some(Measure::new(dec!(3), Unit::One)));
-        assert_eq!(resource2.inner().onhand_quantity(), &Some(Measure::new(dec!(15), Unit::One)));
+        assert_eq!(resource2.inner().accounting_quantity(), &Some(Measure::new(num!(3), Unit::One)));
+        assert_eq!(resource2.inner().onhand_quantity(), &Some(Measure::new(num!(15), Unit::One)));
         assert_eq!(resource2.costs(), &costs2);
 
         // can't modify from a process you don't own

--- a/src/transactions/event/production.rs
+++ b/src/transactions/event/production.rs
@@ -270,7 +270,6 @@ mod tests {
         util::{self, test::{self, *}},
     };
     use om2::Unit;
-    use rust_decimal_macros::*;
 
     #[test]
     fn can_cite() {
@@ -279,11 +278,11 @@ mod tests {
         let mut state = TestState::standard(vec![CompanyPermission::Cite], &now);
         let occupation_id = OccupationID::new("machinist");
         let mut costs = Costs::new();
-        costs.track_labor(occupation_id.clone(), dec!(42.2));
-        costs.track_labor("homemaker", dec!(13.6));
-        let resource = make_resource(&ResourceID::new("widget"), state.company().id(), &Measure::new(dec!(15), Unit::One), &Costs::new_with_labor("homemaker", 157), &now);
+        costs.track_labor(occupation_id.clone(), num!(42.2));
+        costs.track_labor("homemaker", num!(13.6));
+        let resource = make_resource(&ResourceID::new("widget"), state.company().id(), &Measure::new(num!(15), Unit::One), &Costs::new_with_labor("homemaker", 157), &now);
         let process = make_process(&ProcessID::create(), state.company().id(), "make widgets", &costs, &now);
-        let costs_to_move = resource.costs().clone() * dec!(0.02);
+        let costs_to_move = resource.costs().clone() * num!(0.02);
         state.model = Some(resource);
         state.model2 = Some(process);
 
@@ -311,8 +310,8 @@ mod tests {
         assert_eq!(event.updated(), &now);
 
         assert_eq!(resource2.id(), state.model().id());
-        assert_eq!(resource2.inner().accounting_quantity(), &Some(Measure::new(dec!(15), Unit::One)));
-        assert_eq!(resource2.inner().onhand_quantity(), &Some(Measure::new(dec!(15), Unit::One)));
+        assert_eq!(resource2.inner().accounting_quantity(), &Some(Measure::new(num!(15), Unit::One)));
+        assert_eq!(resource2.inner().onhand_quantity(), &Some(Measure::new(num!(15), Unit::One)));
         assert_eq!(resource2.costs(), &(state.model().costs().clone() - costs_to_move.clone()));
 
         assert_eq!(process2.id(), state.model2().id());
@@ -346,11 +345,11 @@ mod tests {
         let mut state = TestState::standard(vec![CompanyPermission::Consume], &now);
         let occupation_id = OccupationID::new("machinist");
         let mut costs = Costs::new();
-        costs.track_labor(occupation_id.clone(), dec!(42.2));
-        costs.track_labor("homemaker", dec!(13.6));
-        let resource = make_resource(&ResourceID::new("widget"), state.company().id(), &Measure::new(dec!(15), Unit::One), &Costs::new_with_labor("homemaker", 157), &now);
+        costs.track_labor(occupation_id.clone(), num!(42.2));
+        costs.track_labor("homemaker", num!(13.6));
+        let resource = make_resource(&ResourceID::new("widget"), state.company().id(), &Measure::new(num!(15), Unit::One), &Costs::new_with_labor("homemaker", 157), &now);
         let resource_costs = resource.costs().clone();
-        let move_costs = resource_costs.clone() * (dec!(8) / dec!(15));
+        let move_costs = resource_costs.clone() * (num!(8) / num!(15));
         let process = make_process(&ProcessID::create(), state.company().id(), "make widgets", &costs, &now);
         state.model = Some(resource);
         state.model2 = Some(process);
@@ -384,10 +383,10 @@ mod tests {
         assert_eq!(process2.costs(), &(costs.clone() + move_costs.clone()));
 
         let mut costs3 = Costs::new();
-        costs3.track_labor("homemaker", dec!(157) - dec!(23));
+        costs3.track_labor("homemaker", num!(157) - num!(23));
         assert_eq!(resource2.id(), state.model().id());
-        assert_eq!(resource2.inner().accounting_quantity(), &Some(Measure::new(dec!(7), Unit::One)));
-        assert_eq!(resource2.inner().onhand_quantity(), &Some(Measure::new(dec!(7), Unit::One)));
+        assert_eq!(resource2.inner().accounting_quantity(), &Some(Measure::new(num!(7), Unit::One)));
+        assert_eq!(resource2.inner().onhand_quantity(), &Some(Measure::new(num!(7), Unit::One)));
         assert_eq!(resource2.costs(), &(resource_costs.clone() - move_costs.clone()));
 
         // can't consume into a process you don't own
@@ -416,11 +415,11 @@ mod tests {
         let mut state = TestState::standard(vec![CompanyPermission::Produce], &now);
         let occupation_id = OccupationID::new("machinist");
         let mut costs = Costs::new();
-        costs.track_labor(occupation_id.clone(), dec!(42.2));
-        costs.track_labor("homemaker", dec!(89.3));
+        costs.track_labor(occupation_id.clone(), num!(42.2));
+        costs.track_labor("homemaker", num!(89.3));
         let process = make_process(&ProcessID::create(), state.company().id(), "make widgets", &costs, &now);
-        let resource = make_resource(&ResourceID::new("widget"), state.company().id(), &Measure::new(dec!(15), Unit::One), &Costs::new_with_labor("homemaker", 157), &now);
-        let costs_to_move = process.costs().clone() * dec!(0.5777);
+        let resource = make_resource(&ResourceID::new("widget"), state.company().id(), &Measure::new(num!(15), Unit::One), &Costs::new_with_labor("homemaker", 157), &now);
+        let costs_to_move = process.costs().clone() * num!(0.5777);
         state.model = Some(process);
         state.model2 = Some(resource);
 
@@ -454,8 +453,8 @@ mod tests {
         assert_eq!(process2.costs(), &(state.model().costs().clone() - costs_to_move.clone()));
 
         assert_eq!(resource2.id(), state.model2().id());
-        assert_eq!(resource2.inner().accounting_quantity(), &Some(Measure::new(dec!(23), Unit::One)));
-        assert_eq!(resource2.inner().onhand_quantity(), &Some(Measure::new(dec!(23), Unit::One)));
+        assert_eq!(resource2.inner().accounting_quantity(), &Some(Measure::new(num!(23), Unit::One)));
+        assert_eq!(resource2.inner().onhand_quantity(), &Some(Measure::new(num!(23), Unit::One)));
         assert_eq!(resource2.costs(), &(state.model2().costs().clone() + costs_to_move.clone()));
 
         // can't produce from a process you don't own
@@ -484,11 +483,11 @@ mod tests {
         let mut state = TestState::standard(vec![CompanyPermission::Use], &now);
         let occupation_id = OccupationID::new("machinist");
         let mut costs = Costs::new();
-        costs.track_labor(occupation_id.clone(), dec!(42.2));
-        costs.track_labor("homemaker", dec!(13.6));
-        let resource = make_resource(&ResourceID::new("widget"), state.company().id(), &Measure::new(dec!(15), Unit::One), &Costs::new_with_labor("homemaker", 157), &now);
+        costs.track_labor(occupation_id.clone(), num!(42.2));
+        costs.track_labor("homemaker", num!(13.6));
+        let resource = make_resource(&ResourceID::new("widget"), state.company().id(), &Measure::new(num!(15), Unit::One), &Costs::new_with_labor("homemaker", 157), &now);
         let process = make_process(&ProcessID::create(), state.company().id(), "make widgets", &costs, &now);
-        let costs_to_move = resource.costs().clone() * (dec!(8) / dec!(15));
+        let costs_to_move = resource.costs().clone() * (num!(8) / num!(15));
         state.model = Some(resource);
         state.model2 = Some(process);
 
@@ -516,8 +515,8 @@ mod tests {
         assert_eq!(event.updated(), &now);
 
         assert_eq!(resource2.id(), state.model().id());
-        assert_eq!(resource2.inner().accounting_quantity(), &Some(Measure::new(dec!(15), Unit::One)));
-        assert_eq!(resource2.inner().onhand_quantity(), &Some(Measure::new(dec!(15), Unit::One)));
+        assert_eq!(resource2.inner().accounting_quantity(), &Some(Measure::new(num!(15), Unit::One)));
+        assert_eq!(resource2.inner().onhand_quantity(), &Some(Measure::new(num!(15), Unit::One)));
         assert_eq!(resource2.costs(), &(state.model().costs().clone() - costs_to_move.clone()));
 
         assert_eq!(process2.id(), state.model2().id());

--- a/src/transactions/event/production.rs
+++ b/src/transactions/event/production.rs
@@ -5,7 +5,6 @@
 use chrono::{DateTime, Utc};
 use crate::{
     access::Permission,
-    costs::Costs,
     error::{Error, Result},
     models::{
         Op,
@@ -18,6 +17,7 @@ use crate::{
         resource::Resource,
         user::User,
     },
+    util::number::Ratio,
 };
 use om2::{Measure, NumericUnion};
 use vf_rs::vf;
@@ -31,15 +31,16 @@ use vf_rs::vf;
 /// Note that the resource *can* have a cost, and those costs can be moved by
 /// citing. For instance, if it took a year of research to derive a formula,
 /// the costs of that research would be imbued in the formula.
-pub fn cite(caller: &User, member: &Member, company: &Company, id: EventID, resource: Resource, process: Process, move_costs: Costs, note: Option<String>, now: &DateTime<Utc>) -> Result<Modifications> {
+pub fn cite(caller: &User, member: &Member, company: &Company, id: EventID, resource: Resource, process: Process, move_costs_ratio: Ratio, note: Option<String>, now: &DateTime<Utc>) -> Result<Modifications> {
     caller.access_check(Permission::EventCreate)?;
     member.access_check(caller.id(), company.id(), CompanyPermission::Cite)?;
     if !company.is_active() {
         Err(Error::ObjectIsInactive("company".into()))?;
     }
 
-    let process_id = process.id().clone();
     let resource_id = resource.id().clone();
+    let process_id = process.id().clone();
+    let move_costs = resource.costs().clone() * move_costs_ratio;
 
     let state = EventProcessState::builder()
         .input_of(process)
@@ -82,7 +83,7 @@ pub fn cite(caller: &User, member: &Member, company: &Company, id: EventID, reso
 /// If you make widgets out of steel, then steel is the resource, and the
 /// process would be the fabrication that "consumes" steel (with the output,
 /// ie `produce`, of a widget).
-pub fn consume<T: Into<NumericUnion>>(caller: &User, member: &Member, company: &Company, id: EventID, resource: Resource, process: Process, move_costs: Costs, move_measure: T, note: Option<String>, now: &DateTime<Utc>) -> Result<Modifications> {
+pub fn consume<T: Into<NumericUnion>>(caller: &User, member: &Member, company: &Company, id: EventID, resource: Resource, process: Process, move_costs_ratio: Ratio, move_measure: T, note: Option<String>, now: &DateTime<Utc>) -> Result<Modifications> {
     caller.access_check(Permission::EventCreate)?;
     member.access_check(caller.id(), company.id(), CompanyPermission::Consume)?;
     if !company.is_active() {
@@ -94,8 +95,9 @@ pub fn consume<T: Into<NumericUnion>>(caller: &User, member: &Member, company: &
         Measure::new(move_measure, unit)
     };
 
-    let process_id = process.id().clone();
     let resource_id = resource.id().clone();
+    let process_id = process.id().clone();
+    let move_costs = resource.costs().clone() * move_costs_ratio;
 
     let state = EventProcessState::builder()
         .input_of(process)
@@ -139,7 +141,7 @@ pub fn consume<T: Into<NumericUnion>>(caller: &User, member: &Member, company: &
 ///
 /// For instance, a process might `consume` steel and have a `work` input and
 /// then `produce` a widget.
-pub fn produce<T: Into<NumericUnion>>(caller: &User, member: &Member, company: &Company, id: EventID, process: Process, resource: Resource, move_costs: Costs, produce_measure: T, note: Option<String>, now: &DateTime<Utc>) -> Result<Modifications> {
+pub fn produce<T: Into<NumericUnion>>(caller: &User, member: &Member, company: &Company, id: EventID, process: Process, resource: Resource, move_costs_ratio: Ratio, produce_measure: T, note: Option<String>, now: &DateTime<Utc>) -> Result<Modifications> {
     caller.access_check(Permission::EventCreate)?;
     member.access_check(caller.id(), company.id(), CompanyPermission::Produce)?;
     if !company.is_active() {
@@ -153,6 +155,7 @@ pub fn produce<T: Into<NumericUnion>>(caller: &User, member: &Member, company: &
 
     let process_id = process.id().clone();
     let resource_id = resource.id().clone();
+    let move_costs = process.costs().clone() * move_costs_ratio;
 
     let state = EventProcessState::builder()
         .output_of(process)
@@ -209,15 +212,16 @@ pub fn produce<T: Into<NumericUnion>>(caller: &User, member: &Member, company: &
 /// If you're trying to express some resource being "used up" (for instance
 /// screws being used to build a chair) then you'll probably want `consume`
 /// instead of `use`.
-pub fn useeee(caller: &User, member: &Member, company: &Company, id: EventID, resource: Resource, process: Process, move_costs: Costs, effort_quantity: Option<Measure>, note: Option<String>, now: &DateTime<Utc>) -> Result<Modifications> {
+pub fn useeee(caller: &User, member: &Member, company: &Company, id: EventID, resource: Resource, process: Process, move_costs_ratio: Ratio, effort_quantity: Option<Measure>, note: Option<String>, now: &DateTime<Utc>) -> Result<Modifications> {
     caller.access_check(Permission::EventCreate)?;
     member.access_check(caller.id(), company.id(), CompanyPermission::Use)?;
     if !company.is_active() {
         Err(Error::ObjectIsInactive("company".into()))?;
     }
 
-    let process_id = process.id().clone();
     let resource_id = resource.id().clone();
+    let process_id = process.id().clone();
+    let move_costs = resource.costs().clone() * move_costs_ratio;
 
     let state = EventProcessState::builder()
         .input_of(process)
@@ -259,6 +263,7 @@ pub fn useeee(caller: &User, member: &Member, company: &Company, id: EventID, re
 mod tests {
     use super::*;
     use crate::{
+        costs::Costs,
         models::{
             company::CompanyID,
             event::{EventError, EventID},
@@ -282,12 +287,13 @@ mod tests {
         costs.track_labor("homemaker", num!(13.6));
         let resource = make_resource(&ResourceID::new("widget"), state.company().id(), &Measure::new(num!(15), Unit::One), &Costs::new_with_labor("homemaker", 157), &now);
         let process = make_process(&ProcessID::create(), state.company().id(), "make widgets", &costs, &now);
-        let costs_to_move = resource.costs().clone() * num!(0.02);
+        let move_costs_ratio = Ratio::new(num!(0.02)).unwrap();
+        let costs_to_move = resource.costs().clone() * move_costs_ratio.clone();
         state.model = Some(resource);
         state.model2 = Some(process);
 
         let testfn = |state: &TestState<Resource, Process>| {
-            cite(state.user(), state.member(), state.company(), id.clone(), state.model().clone(), state.model2().clone(), costs_to_move.clone(), Some("memo".into()), &now)
+            cite(state.user(), state.member(), state.company(), id.clone(), state.model().clone(), state.model2().clone(), move_costs_ratio.clone(), Some("memo".into()), &now)
         };
         test::standard_transaction_tests(&state, &testfn);
 
@@ -349,13 +355,14 @@ mod tests {
         costs.track_labor("homemaker", num!(13.6));
         let resource = make_resource(&ResourceID::new("widget"), state.company().id(), &Measure::new(num!(15), Unit::One), &Costs::new_with_labor("homemaker", 157), &now);
         let resource_costs = resource.costs().clone();
-        let move_costs = resource_costs.clone() * (num!(8) / num!(15));
+        let move_costs_ratio = Ratio::new(num!(8) / num!(15)).unwrap();
+        let costs_to_move = resource_costs.clone() * move_costs_ratio.clone();
         let process = make_process(&ProcessID::create(), state.company().id(), "make widgets", &costs, &now);
         state.model = Some(resource);
         state.model2 = Some(process);
 
         let testfn = |state: &TestState<Resource, Process>| {
-            consume(state.user(), state.member(), state.company(), id.clone(), state.model().clone(), state.model2().clone(), move_costs.clone(), 8, Some("memo".into()), &now)
+            consume(state.user(), state.member(), state.company(), id.clone(), state.model().clone(), state.model2().clone(), move_costs_ratio.clone(), 8, Some("memo".into()), &now)
         };
         test::standard_transaction_tests(&state, &testfn);
 
@@ -372,7 +379,7 @@ mod tests {
         assert_eq!(event.inner().note(), &Some("memo".into()));
         assert_eq!(event.inner().provider().clone(), state.company().agent_id());
         assert_eq!(event.inner().receiver().clone(), state.company().agent_id());
-        assert_eq!(event.move_costs(), &Some(move_costs.clone()));
+        assert_eq!(event.move_costs(), &Some(costs_to_move.clone()));
         assert_eq!(event.active(), &true);
         assert_eq!(event.created(), &now);
         assert_eq!(event.updated(), &now);
@@ -380,14 +387,14 @@ mod tests {
         assert_eq!(process2.id(), state.model2().id());
         assert_eq!(process2.company_id(), state.company().id());
         assert_eq!(process2.inner().name(), "make widgets");
-        assert_eq!(process2.costs(), &(costs.clone() + move_costs.clone()));
+        assert_eq!(process2.costs(), &(costs.clone() + costs_to_move.clone()));
 
         let mut costs3 = Costs::new();
         costs3.track_labor("homemaker", num!(157) - num!(23));
         assert_eq!(resource2.id(), state.model().id());
         assert_eq!(resource2.inner().accounting_quantity(), &Some(Measure::new(num!(7), Unit::One)));
         assert_eq!(resource2.inner().onhand_quantity(), &Some(Measure::new(num!(7), Unit::One)));
-        assert_eq!(resource2.costs(), &(resource_costs.clone() - move_costs.clone()));
+        assert_eq!(resource2.costs(), &(resource_costs.clone() - costs_to_move.clone()));
 
         // can't consume into a process you don't own
         let mut state2 = state.clone();
@@ -419,12 +426,13 @@ mod tests {
         costs.track_labor("homemaker", num!(89.3));
         let process = make_process(&ProcessID::create(), state.company().id(), "make widgets", &costs, &now);
         let resource = make_resource(&ResourceID::new("widget"), state.company().id(), &Measure::new(num!(15), Unit::One), &Costs::new_with_labor("homemaker", 157), &now);
-        let costs_to_move = process.costs().clone() * num!(0.5777);
+        let move_costs_ratio = Ratio::new(num!(0.5777)).unwrap();
+        let costs_to_move = process.costs().clone() * move_costs_ratio.clone();
         state.model = Some(process);
         state.model2 = Some(resource);
 
         let testfn = |state: &TestState<Process, Resource>| {
-            produce(state.user(), state.member(), state.company(), id.clone(), state.model().clone(), state.model2().clone(), costs_to_move.clone(), 8, Some("memo".into()), &now)
+            produce(state.user(), state.member(), state.company(), id.clone(), state.model().clone(), state.model2().clone(), move_costs_ratio.clone(), 8, Some("memo".into()), &now)
         };
         test::standard_transaction_tests(&state, &testfn);
 
@@ -487,12 +495,13 @@ mod tests {
         costs.track_labor("homemaker", num!(13.6));
         let resource = make_resource(&ResourceID::new("widget"), state.company().id(), &Measure::new(num!(15), Unit::One), &Costs::new_with_labor("homemaker", 157), &now);
         let process = make_process(&ProcessID::create(), state.company().id(), "make widgets", &costs, &now);
-        let costs_to_move = resource.costs().clone() * (num!(8) / num!(15));
+        let move_costs_ratio = Ratio::new(num!(8) / num!(15)).unwrap();
+        let costs_to_move = resource.costs().clone() * move_costs_ratio.clone();
         state.model = Some(resource);
         state.model2 = Some(process);
 
         let testfn = |state: &TestState<Resource, Process>| {
-            useeee(state.user(), state.member(), state.company(), id.clone(), state.model().clone(), state.model2().clone(), costs_to_move.clone(), Some(Measure::new(8, Unit::Hour)), Some("memo".into()), &now)
+            useeee(state.user(), state.member(), state.company(), id.clone(), state.model().clone(), state.model2().clone(), move_costs_ratio.clone(), Some(Measure::new(8, Unit::Hour)), Some("memo".into()), &now)
         };
         test::standard_transaction_tests(&state, &testfn);
 

--- a/src/transactions/event/service.rs
+++ b/src/transactions/event/service.rs
@@ -6,7 +6,6 @@
 use chrono::{DateTime, Utc};
 use crate::{
     access::Permission,
-    costs::Costs,
     error::{Error, Result},
     models::{
         Op,
@@ -22,12 +21,13 @@ use crate::{
         process::Process,
         user::User,
     },
+    util::number::Ratio,
 };
 use url::Url;
 use vf_rs::vf;
 
 /// Provide a service to another agent, moving costs along the way.
-pub fn deliver_service(caller: &User, member: &Member, company_from: &Company, company_to: &Company, agreement: &Agreement, id: EventID, process_from: Process, process_to: Process, move_costs: Costs, agreed_in: Option<Url>, note: Option<String>, now: &DateTime<Utc>) -> Result<Modifications> {
+pub fn deliver_service(caller: &User, member: &Member, company_from: &Company, company_to: &Company, agreement: &Agreement, id: EventID, process_from: Process, process_to: Process, move_costs_ratio: Ratio, agreed_in: Option<Url>, note: Option<String>, now: &DateTime<Utc>) -> Result<Modifications> {
     caller.access_check(Permission::EventCreate)?;
     member.access_check(caller.id(), company_from.id(), CompanyPermission::DeliverService)?;
     if !company_from.is_active() {
@@ -43,6 +43,7 @@ pub fn deliver_service(caller: &User, member: &Member, company_from: &Company, c
 
     let process_from_id = process_from.id().clone();
     let process_to_id = process_to.id().clone();
+    let move_costs = process_from.costs().clone() * move_costs_ratio;
 
     let state = EventProcessState::builder()
         .output_of(process_from)
@@ -86,6 +87,7 @@ pub fn deliver_service(caller: &User, member: &Member, company_from: &Company, c
 mod tests {
     use super::*;
     use crate::{
+        costs::Costs,
         models::{
             agreement::AgreementID,
             company::CompanyID,
@@ -109,12 +111,13 @@ mod tests {
         let occupation_id = OccupationID::new("lawyer");
         let process_from = make_process(&ProcessID::create(), company_from.id(), "various lawyerings", &Costs::new_with_labor(occupation_id.clone(), num!(177.25)), &now);
         let process_to = make_process(&ProcessID::create(), company_to.id(), "employee legal agreement drafting", &Costs::new_with_labor(occupation_id.clone(), num!(804)), &now);
-        let costs_to_move = process_from.costs().clone() * num!(0.777777777);
+        let move_costs_ratio = Ratio::new(num!(0.777777777)).unwrap();
+        let costs_to_move = process_from.costs().clone() * move_costs_ratio.clone();
         state.model = Some(process_from);
         state.model2 = Some(process_to);
 
         let testfn_inner = |state: &TestState<Process, Process>, company_from: &Company, company_to: &Company, agreement: &Agreement| {
-            deliver_service(state.user(), state.member(), company_from, company_to, agreement, id.clone(), state.model().clone(), state.model2().clone(), costs_to_move.clone(), Some(agreed_in.clone()), Some("making planks lol".into()), &now)
+            deliver_service(state.user(), state.member(), company_from, company_to, agreement, id.clone(), state.model().clone(), state.model2().clone(), move_costs_ratio.clone(), Some(agreed_in.clone()), Some("making planks lol".into()), &now)
         };
         let testfn_from = |state: &TestState<Process, Process>| {
             testfn_inner(state, state.company(), &company_to, &agreement)

--- a/src/transactions/event/service.rs
+++ b/src/transactions/event/service.rs
@@ -96,7 +96,6 @@ mod tests {
         },
         util::{self, test::{self, *}},
     };
-    use rust_decimal_macros::*;
 
     #[test]
     fn can_deliver_service() {
@@ -108,9 +107,9 @@ mod tests {
         let agreement = make_agreement(&AgreementID::create(), &vec![company_from.agent_id(), company_to.agent_id()], "order 1234", "gotta make some planks", &now);
         let agreed_in: Url = "https://legalzoom.com/my-dad-is-suing-your-dad-the-agreement".parse().unwrap();
         let occupation_id = OccupationID::new("lawyer");
-        let process_from = make_process(&ProcessID::create(), company_from.id(), "various lawyerings", &Costs::new_with_labor(occupation_id.clone(), dec!(177.25)), &now);
-        let process_to = make_process(&ProcessID::create(), company_to.id(), "employee legal agreement drafting", &Costs::new_with_labor(occupation_id.clone(), dec!(804)), &now);
-        let costs_to_move = process_from.costs().clone() * dec!(0.777777777);
+        let process_from = make_process(&ProcessID::create(), company_from.id(), "various lawyerings", &Costs::new_with_labor(occupation_id.clone(), num!(177.25)), &now);
+        let process_to = make_process(&ProcessID::create(), company_to.id(), "employee legal agreement drafting", &Costs::new_with_labor(occupation_id.clone(), num!(804)), &now);
+        let costs_to_move = process_from.costs().clone() * num!(0.777777777);
         state.model = Some(process_from);
         state.model2 = Some(process_to);
 

--- a/src/transactions/event/transfer.rs
+++ b/src/transactions/event/transfer.rs
@@ -251,7 +251,6 @@ mod tests {
         util::{self, test::{self, *}},
     };
     use om2::Unit;
-    use rust_decimal_macros::*;
 
     #[test]
     fn can_transfer() {
@@ -262,9 +261,9 @@ mod tests {
         let company_to = make_company(&CompanyID::create(), "jinkey's skateboards", &now);
         let agreement = make_agreement(&AgreementID::create(), &vec![company_from.agent_id(), company_to.agent_id()], "order 1234", "gotta get some planks", &now);
         let agreed_in: Url = "https://legalzoom.com/standard-boilerplate-hereto-notwithstanding-each-of-them-damage-to-the-hood-ornament-alone".parse().unwrap();
-        let resource_from = make_resource(&ResourceID::new("plank"), company_from.id(), &Measure::new(dec!(15), Unit::One), &Costs::new_with_labor("homemaker", 157), &now);
-        let resource_to = make_resource(&ResourceID::new("plank"), company_to.id(), &Measure::new(dec!(3), Unit::One), &Costs::new_with_labor("homemaker", 2), &now);
-        let costs_to_move = resource_from.costs().clone() * dec!(0.67777777);
+        let resource_from = make_resource(&ResourceID::new("plank"), company_from.id(), &Measure::new(num!(15), Unit::One), &Costs::new_with_labor("homemaker", 157), &now);
+        let resource_to = make_resource(&ResourceID::new("plank"), company_to.id(), &Measure::new(num!(3), Unit::One), &Costs::new_with_labor("homemaker", 2), &now);
+        let costs_to_move = resource_from.costs().clone() * num!(0.67777777);
         state.model = Some(resource_from);
         state.model2 = Some(resource_to);
 
@@ -306,15 +305,15 @@ mod tests {
 
         assert_eq!(resource2.id(), state.model().id());
         assert_eq!(resource2.inner().primary_accountable(), &Some(company_from.agent_id()));
-        assert_eq!(resource2.inner().accounting_quantity(), &Some(Measure::new(dec!(15) - dec!(8), Unit::One)));
-        assert_eq!(resource2.inner().onhand_quantity(), &Some(Measure::new(dec!(15) - dec!(8), Unit::One)));
+        assert_eq!(resource2.inner().accounting_quantity(), &Some(Measure::new(num!(15) - num!(8), Unit::One)));
+        assert_eq!(resource2.inner().onhand_quantity(), &Some(Measure::new(num!(15) - num!(8), Unit::One)));
         assert_eq!(resource2.in_custody_of(), &company_from.agent_id());
         assert_eq!(resource2.costs(), &(state.model().costs().clone() - costs_to_move.clone()));
 
         assert_eq!(resource_to2.id(), state.model2().id());
         assert_eq!(resource_to2.inner().primary_accountable(), &Some(company_to.agent_id()));
-        assert_eq!(resource_to2.inner().accounting_quantity(), &Some(Measure::new(dec!(8) + dec!(3), Unit::One)));
-        assert_eq!(resource_to2.inner().onhand_quantity(), &Some(Measure::new(dec!(8) + dec!(3), Unit::One)));
+        assert_eq!(resource_to2.inner().accounting_quantity(), &Some(Measure::new(num!(8) + num!(3), Unit::One)));
+        assert_eq!(resource_to2.inner().onhand_quantity(), &Some(Measure::new(num!(8) + num!(3), Unit::One)));
         assert_eq!(resource_to2.in_custody_of(), &company_to.agent_id());
         assert_eq!(resource_to2.costs(), &(state.model2().costs().clone() + costs_to_move.clone()));
 
@@ -340,15 +339,15 @@ mod tests {
 
         assert_eq!(resource3.id(), state.model().id());
         assert_eq!(resource3.inner().primary_accountable(), &Some(company_from.agent_id()));
-        assert_eq!(resource3.inner().accounting_quantity(), &Some(Measure::new(dec!(15) - dec!(8), Unit::One)));
-        assert_eq!(resource3.inner().onhand_quantity(), &Some(Measure::new(dec!(15) - dec!(8), Unit::One)));
+        assert_eq!(resource3.inner().accounting_quantity(), &Some(Measure::new(num!(15) - num!(8), Unit::One)));
+        assert_eq!(resource3.inner().onhand_quantity(), &Some(Measure::new(num!(15) - num!(8), Unit::One)));
         assert_eq!(resource3.in_custody_of(), &company_from.agent_id());
         assert_eq!(resource3.costs(), &(state.model().costs().clone() - costs_to_move.clone()));
 
         assert_eq!(resource_created.id(), state.model2().id());
         assert_eq!(resource_created.inner().primary_accountable(), &Some(company_to.agent_id()));
-        assert_eq!(resource_created.inner().accounting_quantity(), &Some(Measure::new(dec!(8), Unit::One)));
-        assert_eq!(resource_created.inner().onhand_quantity(), &Some(Measure::new(dec!(8), Unit::One)));
+        assert_eq!(resource_created.inner().accounting_quantity(), &Some(Measure::new(num!(8), Unit::One)));
+        assert_eq!(resource_created.inner().onhand_quantity(), &Some(Measure::new(num!(8), Unit::One)));
         assert_eq!(resource_created.in_custody_of(), &company_to.agent_id());
         assert_eq!(resource_created.costs(), &costs_to_move);
 
@@ -396,9 +395,9 @@ mod tests {
         let company_to = make_company(&CompanyID::create(), "jinkey's skateboards", &now);
         let agreement = make_agreement(&AgreementID::create(), &vec![company_from.agent_id(), company_to.agent_id()], "order 1234", "gotta get some planks", &now);
         let agreed_in: Url = "https://legalzoom.com/is-it-too-much-to-ask-for-todays-pedestrian-to-wear-at-least-one-piece-of-reflective-clothing".parse().unwrap();
-        let resource_from = make_resource(&ResourceID::new("plank"), company_from.id(), &Measure::new(dec!(15), Unit::One), &Costs::new_with_labor("homemaker", 157), &now);
-        let resource_to = make_resource(&ResourceID::new("plank"), company_to.id(), &Measure::new(dec!(3), Unit::One), &Costs::new_with_labor("homemaker", 2), &now);
-        let costs_to_move = resource_from.costs().clone() * dec!(0.1555232);
+        let resource_from = make_resource(&ResourceID::new("plank"), company_from.id(), &Measure::new(num!(15), Unit::One), &Costs::new_with_labor("homemaker", 157), &now);
+        let resource_to = make_resource(&ResourceID::new("plank"), company_to.id(), &Measure::new(num!(3), Unit::One), &Costs::new_with_labor("homemaker", 2), &now);
+        let costs_to_move = resource_from.costs().clone() * num!(0.1555232);
         state.model = Some(resource_from);
         state.model2 = Some(resource_to);
 
@@ -440,15 +439,15 @@ mod tests {
 
         assert_eq!(resource2.id(), state.model().id());
         assert_eq!(resource2.inner().primary_accountable(), &Some(company_from.agent_id()));
-        assert_eq!(resource2.inner().accounting_quantity(), &Some(Measure::new(dec!(15) - dec!(8), Unit::One)));
-        assert_eq!(resource2.inner().onhand_quantity(), &Some(Measure::new(dec!(15), Unit::One)));
+        assert_eq!(resource2.inner().accounting_quantity(), &Some(Measure::new(num!(15) - num!(8), Unit::One)));
+        assert_eq!(resource2.inner().onhand_quantity(), &Some(Measure::new(num!(15), Unit::One)));
         assert_eq!(resource2.in_custody_of(), &company_from.agent_id());
         assert_eq!(resource2.costs(), &(state.model().costs().clone() - costs_to_move.clone()));
 
         assert_eq!(resource_to2.id(), state.model2().id());
         assert_eq!(resource_to2.inner().primary_accountable(), &Some(company_to.agent_id()));
-        assert_eq!(resource_to2.inner().accounting_quantity(), &Some(Measure::new(dec!(8) + dec!(3), Unit::One)));
-        assert_eq!(resource_to2.inner().onhand_quantity(), &Some(Measure::new(dec!(3), Unit::One)));
+        assert_eq!(resource_to2.inner().accounting_quantity(), &Some(Measure::new(num!(8) + num!(3), Unit::One)));
+        assert_eq!(resource_to2.inner().onhand_quantity(), &Some(Measure::new(num!(3), Unit::One)));
         assert_eq!(resource_to2.in_custody_of(), &company_to.agent_id());
         assert_eq!(resource_to2.costs(), &(state.model2().costs().clone() + costs_to_move.clone()));
 
@@ -473,20 +472,20 @@ mod tests {
         assert_eq!(event.updated(), &now);
 
         let mut costs2 = Costs::new();
-        costs2.track_labor("homemaker", dec!(157) - dec!(23));
+        costs2.track_labor("homemaker", num!(157) - num!(23));
         assert_eq!(resource3.id(), state.model().id());
         assert_eq!(resource3.inner().primary_accountable(), &Some(company_from.agent_id()));
-        assert_eq!(resource3.inner().accounting_quantity(), &Some(Measure::new(dec!(15) - dec!(8), Unit::One)));
-        assert_eq!(resource3.inner().onhand_quantity(), &Some(Measure::new(dec!(15), Unit::One)));
+        assert_eq!(resource3.inner().accounting_quantity(), &Some(Measure::new(num!(15) - num!(8), Unit::One)));
+        assert_eq!(resource3.inner().onhand_quantity(), &Some(Measure::new(num!(15), Unit::One)));
         assert_eq!(resource3.in_custody_of(), &company_from.agent_id());
         assert_eq!(resource3.costs(), &(state.model().costs().clone() - costs_to_move.clone()));
 
         let mut costs2 = Costs::new();
-        costs2.track_labor("homemaker", dec!(23));
+        costs2.track_labor("homemaker", num!(23));
         assert_eq!(resource_created.id(), state.model2().id());
         assert_eq!(resource_created.inner().primary_accountable(), &Some(company_to.agent_id()));
-        assert_eq!(resource_created.inner().accounting_quantity(), &Some(Measure::new(dec!(8), Unit::One)));
-        assert_eq!(resource_created.inner().onhand_quantity(), &Some(Measure::new(dec!(0), Unit::One)));
+        assert_eq!(resource_created.inner().accounting_quantity(), &Some(Measure::new(num!(8), Unit::One)));
+        assert_eq!(resource_created.inner().onhand_quantity(), &Some(Measure::new(num!(0), Unit::One)));
         assert_eq!(resource_created.in_custody_of(), &company_from.agent_id());
         assert_eq!(resource_created.costs(), &costs_to_move);
 
@@ -526,9 +525,9 @@ mod tests {
         let company_to = make_company(&CompanyID::create(), "jinkey's skateboards", &now);
         let agreement = make_agreement(&AgreementID::create(), &vec![company_from.agent_id(), company_to.agent_id()], "order 1234", "gotta get some planks", &now);
         let agreed_in: Url = "https://legaldoom.com/trade-secrets-trade-secrets".parse().unwrap();
-        let resource_from = make_resource(&ResourceID::new("plank"), company_from.id(), &Measure::new(dec!(15), Unit::One), &Costs::new_with_labor("homemaker", 157), &now);
-        let resource_to = make_resource(&ResourceID::new("plank"), company_to.id(), &Measure::new(dec!(3), Unit::One), &Costs::new_with_labor("homemaker", 2), &now);
-        let costs_to_move = resource_from.costs().clone() * (dec!(8) / dec!(15));
+        let resource_from = make_resource(&ResourceID::new("plank"), company_from.id(), &Measure::new(num!(15), Unit::One), &Costs::new_with_labor("homemaker", 157), &now);
+        let resource_to = make_resource(&ResourceID::new("plank"), company_to.id(), &Measure::new(num!(3), Unit::One), &Costs::new_with_labor("homemaker", 2), &now);
+        let costs_to_move = resource_from.costs().clone() * (num!(8) / num!(15));
         state.model = Some(resource_from);
         state.model2 = Some(resource_to);
 
@@ -570,15 +569,15 @@ mod tests {
 
         assert_eq!(resource2.id(), state.model().id());
         assert_eq!(resource2.inner().primary_accountable(), &Some(company_from.agent_id()));
-        assert_eq!(resource2.inner().accounting_quantity(), &Some(Measure::new(dec!(15), Unit::One)));
-        assert_eq!(resource2.inner().onhand_quantity(), &Some(Measure::new(dec!(15) - dec!(8), Unit::One)));
+        assert_eq!(resource2.inner().accounting_quantity(), &Some(Measure::new(num!(15), Unit::One)));
+        assert_eq!(resource2.inner().onhand_quantity(), &Some(Measure::new(num!(15) - num!(8), Unit::One)));
         assert_eq!(resource2.in_custody_of(), &company_from.agent_id());
         assert_eq!(resource2.costs(), &(state.model().costs().clone() - costs_to_move.clone()));
 
         assert_eq!(resource_to2.id(), state.model2().id());
         assert_eq!(resource_to2.inner().primary_accountable(), &Some(company_to.agent_id()));
-        assert_eq!(resource_to2.inner().accounting_quantity(), &Some(Measure::new(dec!(3), Unit::One)));
-        assert_eq!(resource_to2.inner().onhand_quantity(), &Some(Measure::new(dec!(8) + dec!(3), Unit::One)));
+        assert_eq!(resource_to2.inner().accounting_quantity(), &Some(Measure::new(num!(3), Unit::One)));
+        assert_eq!(resource_to2.inner().onhand_quantity(), &Some(Measure::new(num!(8) + num!(3), Unit::One)));
         assert_eq!(resource_to2.in_custody_of(), &company_to.agent_id());
         assert_eq!(resource_to2.costs(), &(state.model2().costs().clone() + costs_to_move.clone()));
 
@@ -602,20 +601,20 @@ mod tests {
         assert_eq!(event.updated(), &now);
 
         let mut costs2 = Costs::new();
-        costs2.track_labor("homemaker", dec!(157) - dec!(23));
+        costs2.track_labor("homemaker", num!(157) - num!(23));
         assert_eq!(resource3.id(), state.model().id());
         assert_eq!(resource3.inner().primary_accountable(), &Some(company_from.agent_id()));
-        assert_eq!(resource3.inner().accounting_quantity(), &Some(Measure::new(dec!(15), Unit::One)));
-        assert_eq!(resource3.inner().onhand_quantity(), &Some(Measure::new(dec!(15) - dec!(8), Unit::One)));
+        assert_eq!(resource3.inner().accounting_quantity(), &Some(Measure::new(num!(15), Unit::One)));
+        assert_eq!(resource3.inner().onhand_quantity(), &Some(Measure::new(num!(15) - num!(8), Unit::One)));
         assert_eq!(resource3.in_custody_of(), &company_from.agent_id());
         assert_eq!(resource3.costs(), &(state.model().costs().clone() - costs_to_move.clone()));
 
         let mut costs2 = Costs::new();
-        costs2.track_labor("homemaker", dec!(23));
+        costs2.track_labor("homemaker", num!(23));
         assert_eq!(resource_created.id(), state.model2().id());
         assert_eq!(resource_created.inner().primary_accountable(), &Some(company_from.agent_id()));
-        assert_eq!(resource_created.inner().accounting_quantity(), &Some(Measure::new(dec!(0), Unit::One)));
-        assert_eq!(resource_created.inner().onhand_quantity(), &Some(Measure::new(dec!(8), Unit::One)));
+        assert_eq!(resource_created.inner().accounting_quantity(), &Some(Measure::new(num!(0), Unit::One)));
+        assert_eq!(resource_created.inner().onhand_quantity(), &Some(Measure::new(num!(8), Unit::One)));
         assert_eq!(resource_created.in_custody_of(), &company_to.agent_id());
         assert_eq!(resource_created.costs(), &costs_to_move);
 

--- a/src/transactions/event/work.rs
+++ b/src/transactions/event/work.rs
@@ -110,7 +110,6 @@ mod tests {
         },
         util::test::{self, *},
     };
-    use rust_decimal_macros::*;
 
     #[test]
     fn can_work() {
@@ -120,12 +119,12 @@ mod tests {
         let mut state = TestState::standard(vec![CompanyPermission::Work], &now);
         let occupation_id = state.member().occupation_id().unwrap().clone();
         let worker = state.member().clone();
-        let process = make_process(&ProcessID::create(), state.company().id(), "make widgets", &Costs::new_with_labor(occupation_id.clone(), dec!(177.5)), &now);
+        let process = make_process(&ProcessID::create(), state.company().id(), "make widgets", &Costs::new_with_labor(occupation_id.clone(), num!(177.5)), &now);
         state.model = Some(worker);
         state.model2 = Some(process);
 
         let testfn = |state: &TestState<Member, Process>| {
-            work(state.user(), state.member(), state.company(), id.clone(), state.model().clone(), state.model2().clone(), Some(dec!(78.4)), now.clone(), now2.clone(), Some("just doing some work".into()), &now2)
+            work(state.user(), state.member(), state.company(), id.clone(), state.model().clone(), state.model2().clone(), Some(num!(78.4)), now.clone(), now2.clone(), Some("just doing some work".into()), &now2)
         };
         test::standard_transaction_tests(&state, &testfn);
 
@@ -141,14 +140,14 @@ mod tests {
         assert_eq!(event.inner().note(), &Some("just doing some work".into()));
         assert_eq!(event.inner().provider().clone(), state.model().agent_id());
         assert_eq!(event.inner().receiver().clone(), state.company().agent_id());
-        assert_eq!(event.move_costs(), &Some(Costs::new_with_labor(occupation_id.clone(), dec!(78.4))));
+        assert_eq!(event.move_costs(), &Some(Costs::new_with_labor(occupation_id.clone(), num!(78.4))));
         assert_eq!(event.active(), &true);
         assert_eq!(event.created(), &now2);
         assert_eq!(event.updated(), &now2);
 
         let mut costs2 = Costs::new();
-        costs2.track_labor(occupation_id.clone(), dec!(177.5) + dec!(78.4));
-        costs2.track_labor_hours(occupation_id.clone(), dec!(6.8666666666666666666666666666));
+        costs2.track_labor(occupation_id.clone(), num!(177.5) + num!(78.4));
+        costs2.track_labor_hours(occupation_id.clone(), num!(6.8666666666666666666666666666));
         let process2 = mods[1].clone().expect_op::<Process>(Op::Update).unwrap();
         assert_eq!(process2.id(), state.model2().id());
         assert_eq!(process2.company_id(), state.company().id());
@@ -173,14 +172,14 @@ mod tests {
         assert_eq!(event.inner().note(), &Some("just doing some work".into()));
         assert_eq!(event.inner().provider().clone(), state2.model().agent_id());
         assert_eq!(event.inner().receiver().clone(), state.company().agent_id());
-        assert_eq!(event.move_costs(), &Some(Costs::new_with_labor(occupation_id.clone(), dec!(78.4))));
+        assert_eq!(event.move_costs(), &Some(Costs::new_with_labor(occupation_id.clone(), num!(78.4))));
         assert_eq!(event.active(), &true);
         assert_eq!(event.created(), &now2);
         assert_eq!(event.updated(), &now2);
 
         let mut costs2 = Costs::new();
-        costs2.track_labor(occupation_id.clone(), dec!(177.5) + dec!(78.4));
-        costs2.track_labor_hours(occupation_id.clone(), dec!(6.8666666666666666666666666666));
+        costs2.track_labor(occupation_id.clone(), num!(177.5) + num!(78.4));
+        costs2.track_labor_hours(occupation_id.clone(), num!(6.8666666666666666666666666666));
         let process2 = mods[1].clone().expect_op::<Process>(Op::Update).unwrap();
 
         assert_eq!(process2.id(), state.model2().id());

--- a/src/transactions/member.rs
+++ b/src/transactions/member.rs
@@ -155,7 +155,6 @@ mod tests {
         },
         util::{self, test::{self, *}},
     };
-    use rust_decimal_macros::*;
     use om2::{Measure, Unit};
 
     #[test]
@@ -304,7 +303,7 @@ mod tests {
         assert_eq!(mods.len(), 1);
         let member2 = mods[0].clone().expect_op::<Member>(Op::Update).unwrap();
         assert_eq!(state.model().compensation(), None);
-        assert_eq!(member2.compensation().unwrap().wage(), &Measure::new(dec!(32), Unit::Hour));
+        assert_eq!(member2.compensation().unwrap().wage(), &Measure::new(num!(32), Unit::Hour));
         assert_eq!(member2.compensation().unwrap(), &compensation);
         assert_eq!(member2.updated(), &now2);
 

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,7 +1,9 @@
-pub mod measure;
-pub mod time;
+pub(crate) mod measure;
+#[macro_use]
+pub mod number;
+pub(crate) mod time;
 
 #[cfg(test)]
 #[macro_use]
-pub mod test;
+pub(crate) mod test;
 

--- a/src/util/number.rs
+++ b/src/util/number.rs
@@ -1,0 +1,15 @@
+//! A set of utilities for working with numbers in the Basis costs system.
+
+/// Create a number.
+///
+/// This is mostly a wrapper around difference number types that makes it easier
+/// to swap out test values/Costs types project-wide without having to change
+/// each instance by hand, but can also be used by callers of the core to create
+/// numbers more seamlessly.
+#[macro_export]
+macro_rules! num {
+    ($val:expr) => {
+        rust_decimal_macros::dec!($val)
+    }
+}
+

--- a/src/util/number.rs
+++ b/src/util/number.rs
@@ -24,7 +24,7 @@ macro_rules! num {
 }
 
 /// Represents a ratio: a value such that `0 <= v <= 1`.
-#[derive(Default, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Ratio {
     /// The inner ratio value.
     inner: Decimal,

--- a/src/util/number.rs
+++ b/src/util/number.rs
@@ -8,12 +8,21 @@ use rust_decimal::prelude::*;
 use serde::{Serialize, Deserialize};
 use std::ops::Mul;
 
-/// Create a number.
+/// Create a number used in the costing system.
 ///
 /// This is mostly a wrapper around a standard number type that makes it easier
 /// to swap out test values/Costs types project-wide without having to change
 /// each instance by hand, but can also be used by callers of the core to create
 /// numbers more seamlessly.
+///
+/// ```rust
+/// use basis_core::{
+///     costs::Costs,
+///     models::occupation::OccupationID,
+///     num
+/// };
+/// let costs = Costs::new_with_labor(OccupationID::new("plumber"), num!(45.8));
+/// ```
 ///
 /// Right now, this wraps `rust_decimal::Decimal`'s `dec!()` macro.
 #[macro_export]

--- a/src/util/number.rs
+++ b/src/util/number.rs
@@ -1,15 +1,99 @@
 //! A set of utilities for working with numbers in the Basis costs system.
 
+use crate::{
+    costs::Costs,
+    error::{Error, Result},
+};
+use rust_decimal::prelude::*;
+use serde::{Serialize, Deserialize};
+use std::ops::Mul;
+
 /// Create a number.
 ///
-/// This is mostly a wrapper around difference number types that makes it easier
+/// This is mostly a wrapper around a standard number type that makes it easier
 /// to swap out test values/Costs types project-wide without having to change
 /// each instance by hand, but can also be used by callers of the core to create
 /// numbers more seamlessly.
+///
+/// Right now, this wraps `rust_decimal::Decimal`'s `dec!()` macro.
 #[macro_export]
 macro_rules! num {
     ($val:expr) => {
         rust_decimal_macros::dec!($val)
+    }
+}
+
+/// Represents a ratio: a value such that `0 <= v <= 1`.
+#[derive(Default, Debug, PartialEq, Serialize, Deserialize)]
+pub struct Ratio {
+    /// The inner ratio value.
+    inner: Decimal,
+}
+
+impl Ratio {
+    /// Create a new ratio from a Decimal.
+    pub fn new<T: Into<Decimal>>(ratio_val: T) -> Result<Self> {
+        let ratio: Decimal = ratio_val.into();
+        if ratio < Decimal::zero() || ratio > num!(1) {
+            Err(Error::InvalidRatio(ratio))?;
+        }
+        Ok(Self {
+            inner: ratio,
+        })
+    }
+
+    /// Grab this ratio's inner value
+    pub fn inner(&self) -> &Decimal {
+        &self.inner
+    }
+}
+
+impl Mul<Costs> for Ratio {
+    type Output = Costs;
+
+    fn mul(self, rhs: Costs) -> Costs {
+        rhs * self.inner().clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn create_ratio() {
+        Ratio::new(0).unwrap();
+        Ratio::new(1).unwrap();
+        Ratio::new(num!(0.999999999999999999999999)).unwrap();
+        Ratio::new(num!(0.000000000000000000000001)).unwrap();
+        Ratio::new(num!(0.5050)).unwrap();
+        assert_eq!(Ratio::new(2), Err(Error::InvalidRatio(num!(2))));
+        assert_eq!(Ratio::new(-1), Err(Error::InvalidRatio(num!(-1))));
+        let val = num!(1.0000000000000000000000001);
+        assert_eq!(Ratio::new(val.clone()), Err(Error::InvalidRatio(val)));
+        let val = num!(-0.0000000000000000000000001);
+        assert_eq!(Ratio::new(val.clone()), Err(Error::InvalidRatio(val)));
+    }
+
+    #[test]
+    fn can_multiply_ratio() {
+        let ratio = Ratio::new(num!(0.5)).unwrap();
+        let mut costs = Costs::new();
+        costs.track_labor("machinist", num!(16.8));
+        costs.track_resource("steel", num!(5000), num!(0.004));
+        let mut costs2 = Costs::new();
+        costs2.track_labor("machinist", num!(8.4));
+        costs2.track_resource("steel", num!(2500), num!(0.004));
+        assert_eq!(ratio * costs, costs2);
+
+        let ratio = Ratio::new(num!(0.833912)).unwrap();
+        let mut costs = Costs::new();
+        costs.track_labor("machinist", num!(73.99));
+        costs.track_resource("steel", num!(8773), num!(0.003));
+        let mut costs2 = Costs::new();
+        costs2.track_labor("machinist", num!(73.99) * num!(0.833912));
+        costs2.track_resource("steel", num!(8773) * num!(0.833912), num!(0.003));
+        assert_eq!(costs * ratio, costs2);
     }
 }
 


### PR DESCRIPTION
Closes basisproject/tracker#120

Adds the ability to track the aggregate credit value of `Costs` *when resources and currencies are added*. This eliminates the need to know the current "market" value of currencies and resources when determining the *total* cost of `Costs` object in credits.