### PR TITLE
Remove company admin permissions

### DIFF
--- a/src/access.rs
+++ b/src/access.rs
@@ -30,8 +30,6 @@ pub enum Permission {
     AccountTransfer,
     AccountUpdate,
 
-    CompanyAdminDelete,
-    CompanyAdminUpdate,
     CompanyCreate,
     CompanyDelete,
     CompanyPayroll,
@@ -73,7 +71,6 @@ pub enum Permission {
 pub enum Role {
     SuperAdmin,
     IdentityAdmin,
-    CompanyAdmin,
     Bank,
     User,
     Guest,
@@ -95,12 +92,6 @@ impl Role {
                     Permission::UserDelete,
                 ]
             },
-            Role::CompanyAdmin => {
-                vec![
-                    Permission::CompanyAdminUpdate,
-                    Permission::CompanyAdminDelete,
-                ]
-            }
             Role::Bank => {
                 vec![
                     Permission::CurrencyCreate,
@@ -190,17 +181,6 @@ pub mod tests {
         assert!(super_admin.can(&Permission::UserAdminUpdate));
         assert!(super_admin.can(&Permission::UserDelete));
         assert!(super_admin.can(&Permission::CompanyCreate));
-        assert!(super_admin.can(&Permission::CompanyAdminUpdate));
-        assert!(super_admin.can(&Permission::CompanyAdminDelete));
-
-        let comp_admin = Role::CompanyAdmin;
-        assert!(!comp_admin.can(&Permission::UserCreate));
-        assert!(!comp_admin.can(&Permission::UserUpdate));
-        assert!(!comp_admin.can(&Permission::UserAdminUpdate));
-        assert!(!comp_admin.can(&Permission::UserDelete));
-        assert!(!comp_admin.can(&Permission::CompanyCreate));
-        assert!(comp_admin.can(&Permission::CompanyAdminUpdate));
-        assert!(comp_admin.can(&Permission::CompanyAdminDelete));
     }
 }
 

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -76,29 +76,29 @@ mod tests {
         let user = make_user(&UserID::create(), None, &now);
         assert!(user.can(&Permission::UserDelete));
         assert!(user.access_check(Permission::UserDelete).is_ok());
-        assert!(user.access_check(Permission::CompanyAdminDelete).is_err());
+        assert!(user.access_check(Permission::UserAdminCreate).is_err());
 
-        let user2 = make_user(&UserID::create(), Some(vec![Role::User, Role::CompanyAdmin]), &now);
+        let user2 = make_user(&UserID::create(), Some(vec![Role::User, Role::SuperAdmin]), &now);
         assert!(user2.can(&Permission::UserDelete));
         assert!(user2.access_check(Permission::UserDelete).is_ok());
-        assert!(user2.access_check(Permission::CompanyAdminDelete).is_ok());
+        assert!(user2.access_check(Permission::UserAdminCreate).is_ok());
 
         let user3 = make_user(&UserID::create(), Some(vec![]), &now);
         assert!(!user3.can(&Permission::UserDelete));
         assert!(user3.access_check(Permission::UserDelete).is_err());
-        assert!(user3.access_check(Permission::CompanyAdminDelete).is_err());
+        assert!(user3.access_check(Permission::UserAdminCreate).is_err());
 
         let mut user4 = user2.clone();
         user4.set_deleted(Some(now.clone()));
         assert!(!user4.can(&Permission::UserDelete));
         assert!(user4.access_check(Permission::UserDelete).is_err());
-        assert!(user4.access_check(Permission::CompanyAdminDelete).is_err());
+        assert!(user4.access_check(Permission::UserAdminCreate).is_err());
 
         let mut user5 = user2.clone();
         user5.set_active(false);
         assert!(!user5.can(&Permission::UserDelete));
         assert!(user5.access_check(Permission::UserDelete).is_err());
-        assert!(user5.access_check(Permission::CompanyAdminDelete).is_err());
+        assert!(user5.access_check(Permission::UserAdminCreate).is_err());
     }
 }
 


### PR DESCRIPTION
and update the company update/delete transactions to no longer take an `Option<&Member>` (just `&Member`). Closes basisproject/tracker#116 seckkkkk