### PR TITLE
Implementing UBI account

### DIFF
--- a/examples/create_new_user_and_company.rs
+++ b/examples/create_new_user_and_company.rs
@@ -3,6 +3,7 @@ use basis_core::{
     models::{
         Op,
 
+        account::AccountID,
         company::{Company, CompanyID},
         member::{Member, MemberID, MemberClass, MemberWorker},
         occupation::{Occupation, OccupationID},
@@ -31,7 +32,7 @@ fn example() -> Result<(User, Member, Company)> {
     //
     // transactions don't pass back models, but rather modifications on models
     // (aka, "add User" or "Update company" or "delete Member" etc).
-    let mods = user::create(UserID::new("389f9613-1ac6-435d-9d73-e96118e0ea71"), "user-8171287127nnx78.233b2c@basisproject.net", "Jerry", true, &Utc::now())?.into_vec();
+    let mods = user::create(UserID::new("389f9613-1ac6-435d-9d73-e96118e0ea71"), "user-8171287127nnx78.233b2c@basisproject.net", "Jerry", AccountID::new("9b7c9b40-b759-4a15-8615-4012be92f06a"), true, &Utc::now())?.into_vec();
     let user = mods[0].clone().expect_op::<User>(Op::Create)?;
 
     // create our first occupation (by democratic vote)

--- a/src/access.rs
+++ b/src/access.rs
@@ -28,6 +28,7 @@ pub enum Permission {
     AccountDelete,
     AccountSetOwners,
     AccountTransfer,
+    AccountUBIClaim,
     AccountUpdate,
 
     CompanyCreate,
@@ -119,6 +120,7 @@ impl Role {
                     Permission::ResourceSpecUpdate,
                     Permission::ResourceSpecDelete,
                     Permission::AccountCreate,
+                    Permission::AccountUBIClaim,
                     Permission::AccountUpdate,
                     Permission::AccountSetOwners,
                     Permission::AccountTransfer,

--- a/src/error.rs
+++ b/src/error.rs
@@ -85,6 +85,12 @@ pub enum Error {
     /// its quantities initialized via `produce`/`raise`/`transfer`/etc.
     #[error("a resource measurement (account/onhand quantity) is missing")]
     ResourceMeasureMissing,
+    /// We're trying to perform an action on a UBI account that isn't allowed.
+    #[error("operation cannot be performed on a UBI account")]
+    UBIAccountError,
+    /// A UBI account is required for the action you wish to perform.
+    #[error("operation can only be performed on a UBI account")]
+    UBIAccountRequired,
     /// When we try to convert an AgentID to another ID type but it fails (like
     /// `let company_id: CompanyID = AgentID::UserID(user_id).try_from()?;`).
     #[error("AgentID is the wrong type")]

--- a/src/models/account.rs
+++ b/src/models/account.rs
@@ -51,6 +51,11 @@ impl Ubi {
 }
 
 basis_model! {
+    /// Effectively a bank account or crypto "wallet" which stores credits
+    /// earned via labor/wages.
+    ///
+    /// Can be either a regular account (can transfer value freely) or a UBI
+    /// account which has some additional restrictions.
     pub struct Account {
         id: <<AccountID>>,
         /// The user ids of the account owners

--- a/src/models/account.rs
+++ b/src/models/account.rs
@@ -1,6 +1,7 @@
 //! Accounts are a place to hold credits earned through labor. Think of them
 //! like a bank account or crypto wallet.
 
+use chrono::{DateTime, Utc};
 use crate::{
     error::{Error, Result},
     models:: {
@@ -33,6 +34,22 @@ impl Multisig {
     }
 }
 
+/// Holds information about a basic income account.
+#[derive(Clone, Debug, PartialEq, Getters, Setters, Serialize, Deserialize)]
+#[getset(get = "pub", set = "pub(crate)")]
+pub struct Ubi {
+    last_claim: DateTime<Utc>,
+}
+
+impl Ubi {
+    /// Create a new UBI spec
+    pub fn new(now: DateTime<Utc>) -> Self {
+        Self {
+            last_claim: now,
+        }
+    }
+}
+
 basis_model! {
     pub struct Account {
         id: <<AccountID>>,
@@ -46,8 +63,9 @@ basis_model! {
         description: String,
         /// The account's balance
         balance: Decimal,
-        /// Whether or not this is a UBI account
-        ubi: bool,
+        /// Whether or not this is a UBI account, and if so, some information
+        /// about the UBI
+        ubi: Option<Ubi>,
     }
     AccountBuilder
 }

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -78,6 +78,7 @@ impl Modification {
     ///         Model,
     ///         Modification,
     ///         Op,
+    ///         account::AccountID,
     ///         user::{User, UserID},
     ///     },
     ///     transactions,
@@ -94,7 +95,7 @@ impl Modification {
     ///     Ok(())
     /// }
     ///
-    /// let mods = transactions::user::create(UserID::new("eb5af35f-8f48-4794-8d75-0cd07d7c6650"), "andrew@lyonbros.com", "andrew", true, &Utc::now()).unwrap();
+    /// let mods = transactions::user::create(UserID::new("eb5af35f-8f48-4794-8d75-0cd07d7c6650"), "andrew@lyonbros.com", "andrew", AccountID::new("5fcf7f71-d965-4f10-a4af-5a289335c586"), true, &Utc::now()).unwrap();
     /// for modification in mods {
     ///     save_mod(modification).unwrap();
     /// }
@@ -112,13 +113,14 @@ impl Modification {
     /// use basis_core::{
     ///     models::{
     ///         Op,
+    ///         account::AccountID,
     ///         user::{User, UserID},
     ///     },
     ///     transactions,
     /// };
     /// use chrono::Utc;
     ///
-    /// let mods = transactions::user::create(UserID::new("571c5e2b-1fde-43d4-a15b-9cbcb929849f"), "andrew@lyonbros.com", "andrew", true, &Utc::now()).unwrap().into_vec();
+    /// let mods = transactions::user::create(UserID::new("571c5e2b-1fde-43d4-a15b-9cbcb929849f"), "andrew@lyonbros.com", "andrew", AccountID::new("af1d3c55-a737-4979-b1b5-0ad18a810bb0"), true, &Utc::now()).unwrap().into_vec();
     /// // verifies that the first modification is User Create, and returns the
     /// // User model.
     /// let user = mods[0].clone().expect_op::<User>(Op::Create).unwrap();

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -2,5 +2,6 @@
 //! the system itself. For instance, a voting user/member that acts on behalf of
 //! the system or a company, or a user that masks/anonymizes consumer purchases.
 
+pub mod ubi;
 pub mod vote;
 

--- a/src/system/ubi.rs
+++ b/src/system/ubi.rs
@@ -1,0 +1,25 @@
+//! Defines systemic parameters for the Basis UBI, such as how much is paid
+//! over time and the upper ceiling on UBI accounts (to prevent endless
+//! accumulation).
+
+use getset::{Getters, Setters};
+use rust_decimal::Decimal;
+use serde::{Serialize, Deserialize};
+
+/// Holds systemic UBI parameters.
+#[derive(Clone, Default, Debug, PartialEq, Getters, Setters, Serialize, Deserialize)]
+#[getset(get = "pub", set = "pub(crate)")]
+pub struct UBIParameters {
+    /// The maximum balance a UBI account can hold
+    ceiling: Decimal,
+    /// How much UBI we get over time
+    balance_per_day: Decimal,
+}
+
+impl UBIParameters {
+    /// Create a new empty params object
+    pub fn new() -> Self {
+        Default::default()
+    }
+}
+

--- a/src/transactions/account.rs
+++ b/src/transactions/account.rs
@@ -12,6 +12,7 @@ use crate::{
         lib::basis_model::Model,
         user::{User, UserID},
     },
+    system::ubi::UBIParameters,
 };
 use rust_decimal::prelude::*;
 
@@ -59,11 +60,11 @@ pub fn update(caller: &User, mut subject: Account, name: Option<String>, descrip
 /// Set the owners and multisig of an account.
 pub fn set_owners(caller: &User, mut subject: Account, user_ids: Option<Vec<UserID>>, multisig: Option<Vec<Multisig>>, now: &DateTime<Utc>) -> Result<Modifications> {
     caller.access_check(Permission::AccountSetOwners)?;
-    if subject.ubi().is_some() {
-        Err(Error::UBIAccountError)?;
-    }
     if !subject.user_ids().contains(caller.id()) {
         Err(Error::InsufficientPrivileges)?;
+    }
+    if subject.ubi().is_some() {
+        Err(Error::UBIAccountError)?;
     }
     if let Some(user_ids) = user_ids {
         subject.set_user_ids(user_ids);
@@ -78,11 +79,11 @@ pub fn set_owners(caller: &User, mut subject: Account, user_ids: Option<Vec<User
 /// Transfer credits from one account to another.
 pub fn transfer(caller: &User, mut subject: Account, mut to_account: Account, amount: Decimal, now: &DateTime<Utc>) -> Result<Modifications> {
     caller.access_check(Permission::AccountTransfer)?;
-    if subject.ubi().is_some() {
-        Err(Error::UBIAccountError)?;
-    }
     if !subject.user_ids().contains(caller.id()) {
         Err(Error::InsufficientPrivileges)?;
+    }
+    if subject.ubi().is_some() {
+        Err(Error::UBIAccountError)?;
     }
     subject.adjust_balance(-amount)?;
     subject.set_updated(now.clone());
@@ -94,14 +95,37 @@ pub fn transfer(caller: &User, mut subject: Account, mut to_account: Account, am
     Ok(mods)
 }
 
+/// Claim UBI. This reads the difference between now and the last time UBI was
+/// claimed and puts the appropriate amount into the account (with an upper
+/// ceiling).
+///
+/// Takes a systemic `UBIParameters` object which tells us how the UBI behaves.
+pub fn claim_ubi(caller: &User, mut subject: Account, ubi_params: &UBIParameters, now: &DateTime<Utc>) -> Result<Modifications> {
+    caller.access_check(Permission::AccountUBIClaim)?;
+    if !subject.user_ids().contains(caller.id()) {
+        Err(Error::InsufficientPrivileges)?;
+    }
+    let ubi = if let Some(ubi) = subject.ubi().clone() {
+        ubi
+    } else {
+        return Err(Error::UBIAccountRequired);
+    };
+    let days_elapsed = Decimal::from(now.timestamp() - ubi.last_claim().timestamp()) / num!(86400);
+    let balance_adjustment = days_elapsed * ubi_params.balance_per_day().clone();
+    subject.adjust_balance(balance_adjustment)?;
+    subject.set_balance(subject.balance().clone().min(ubi_params.ceiling().clone()).normalize());
+    subject.set_updated(now.clone());
+    Ok(Modifications::new_single(Op::Update, subject))
+}
+
 /// Delete an account. Must have a 0 balance.
 pub fn delete(caller: &User, mut subject: Account, now: &DateTime<Utc>) -> Result<Modifications> {
     caller.access_check(Permission::AccountDelete)?;
-    if subject.ubi().is_some() {
-        Err(Error::UBIAccountError)?;
-    }
     if !subject.user_ids().contains(caller.id()) {
         Err(Error::InsufficientPrivileges)?;
+    }
+    if subject.ubi().is_some() {
+        Err(Error::UBIAccountError)?;
     }
     if subject.balance() != &Zero::zero() {
         Err(Error::CannotEraseCredits)?;
@@ -117,6 +141,9 @@ pub fn delete(caller: &User, mut subject: Account, now: &DateTime<Utc>) -> Resul
 mod tests {
     use super::*;
     use crate::{
+        models::{
+            account::Ubi,
+        },
         util::{self, test::{self, *}},
     };
 
@@ -284,6 +311,56 @@ mod tests {
 
         let res = testfn_inner(&state, num!(56));
         assert_eq!(res, Err(Error::NegativeAccountBalance));
+    }
+
+    #[test]
+    fn can_claim_ubi() {
+        let id = AccountID::create();
+        let now = util::time::now();
+        let mut state = TestState::standard(vec![], &now);
+        let multisig = vec![Multisig::new(1)];
+        let mods = create(state.user(), id.clone(), vec![state.user().id().clone()], multisig.clone(), "UBI", "UBI", true, &now).unwrap().into_vec();
+        let mut account = mods[0].clone().expect_op::<Account>(Op::Create).unwrap();
+        let mut ubi_params = UBIParameters::new();
+        ubi_params.set_ceiling(num!(100));
+        ubi_params.set_balance_per_day(num!(900) / num!(30));
+        account.set_ubi(Some(Ubi::new("2020-01-01T00:00:00Z".parse().unwrap())));
+        state.company = None;
+        state.member = None;
+        state.model = Some(account);
+
+        let now2 = "2020-01-06T12:30:00Z".parse().unwrap();
+        let testfn_inner = |state: &TestState<Account, Account>, ubi_params: &UBIParameters| {
+            claim_ubi(state.user(), state.model().clone(), ubi_params, &now2)
+        };
+        let testfn = |state: &TestState<Account, Account>| {
+            testfn_inner(state, &ubi_params)
+        };
+        test::standard_transaction_tests(&state, &testfn);
+
+        let mods = testfn(&state).unwrap().into_vec();
+        assert_eq!(mods.len(), 1);
+        let account2 = mods[0].clone().expect_op::<Account>(Op::Update).unwrap();
+        assert_eq!(account2.id(), state.model().id());
+        assert_eq!(account2.balance(), &num!(100));
+        assert_eq!(account2.created(), state.model().created());
+        assert_eq!(account2.updated(), &now2);
+        assert_eq!(account2.deleted(), &None);
+
+        let mut ubi_params2 = ubi_params.clone();
+        ubi_params2.set_ceiling(num!(5000));
+        let mods = testfn_inner(&state, &ubi_params2).unwrap().into_vec();
+        assert_eq!(mods.len(), 1);
+        let account3 = mods[0].clone().expect_op::<Account>(Op::Update).unwrap();
+        assert_eq!(account3.id(), state.model().id());
+        assert_eq!(account3.balance(), &num!(165.625));
+        assert_eq!(account3.created(), state.model().created());
+        assert_eq!(account3.updated(), &now2);
+
+        //let mut state2 = state.clone();
+        //state2.user_mut().set_id(UserID::create());
+        //let res = testfn(&state2);
+        //assert_eq!(res, Err(Error::InsufficientPrivileges));
     }
 
     #[test]

--- a/src/transactions/account.rs
+++ b/src/transactions/account.rs
@@ -254,6 +254,11 @@ mod tests {
         state2.user_mut().set_id(UserID::create());
         let res = testfn(&state2);
         assert_eq!(res, Err(Error::InsufficientPrivileges));
+
+        let mut state3 = state.clone();
+        state3.model_mut().set_ubi(Some(Ubi::new(now2.clone())));
+        let res = testfn(&state3);
+        assert_eq!(res, Err(Error::UBIAccountError));
     }
 
     #[test]
@@ -311,6 +316,11 @@ mod tests {
 
         let res = testfn_inner(&state, num!(56));
         assert_eq!(res, Err(Error::NegativeAccountBalance));
+
+        let mut state3 = state.clone();
+        state3.model_mut().set_ubi(Some(Ubi::new(now2.clone())));
+        let res = testfn(&state3);
+        assert_eq!(res, Err(Error::UBIAccountError));
     }
 
     #[test]
@@ -361,6 +371,11 @@ mod tests {
         state2.user_mut().set_id(UserID::create());
         let res = testfn(&state2);
         assert_eq!(res, Err(Error::InsufficientPrivileges));
+
+        let mut state3 = state.clone();
+        state3.model_mut().set_ubi(None);
+        let res = testfn(&state3);
+        assert_eq!(res, Err(Error::UBIAccountRequired));
     }
 
     #[test]
@@ -405,6 +420,11 @@ mod tests {
         state3.model_mut().set_balance(num!(21.55));
         let res = testfn(&state3);
         assert_eq!(res, Err(Error::CannotEraseCredits));
+
+        let mut state4 = state.clone();
+        state4.model_mut().set_ubi(Some(Ubi::new(now2.clone())));
+        let res = testfn(&state4);
+        assert_eq!(res, Err(Error::UBIAccountError));
     }
 }
 

--- a/src/transactions/account.rs
+++ b/src/transactions/account.rs
@@ -357,10 +357,10 @@ mod tests {
         assert_eq!(account3.created(), state.model().created());
         assert_eq!(account3.updated(), &now2);
 
-        //let mut state2 = state.clone();
-        //state2.user_mut().set_id(UserID::create());
-        //let res = testfn(&state2);
-        //assert_eq!(res, Err(Error::InsufficientPrivileges));
+        let mut state2 = state.clone();
+        state2.user_mut().set_id(UserID::create());
+        let res = testfn(&state2);
+        assert_eq!(res, Err(Error::InsufficientPrivileges));
     }
 
     #[test]

--- a/src/transactions/user.rs
+++ b/src/transactions/user.rs
@@ -48,6 +48,8 @@ fn create_inner<T: Into<String>>(id: UserID, roles: Vec<Role>, email: T, name: T
 }
 
 /// Create a new user with a `Role::User` role. No permissions required.
+///
+/// Also creates a UBI account for the user.
 pub fn create<T: Into<String>>(id: UserID, email: T, name: T, ubi_account_id: AccountID, active: bool, now: &DateTime<Utc>) -> Result<Modifications> {
     access::guest_check(Permission::UserCreate)?;
     create_inner(id, vec![Role::User], email, name, ubi_account_id, active, now)
@@ -56,6 +58,8 @@ pub fn create<T: Into<String>>(id: UserID, email: T, name: T, ubi_account_id: Ac
 /// Create a new user with a specific set of permissions using a current user as
 /// the originator. Effectively an admin create. Requires the 
 /// `Permission::UserCreate` permission.
+///
+/// Also creates a UBI account for the user.
 pub fn create_permissioned<T: Into<String>>(caller: &User, id: UserID, roles: Vec<Role>, email: T, name: T, ubi_account_id: AccountID, active: bool, now: &DateTime<Utc>) -> Result<Modifications> {
     caller.access_check(Permission::UserAdminCreate)?;
     create_inner(id, roles, email, name, ubi_account_id, active, now)

--- a/src/transactions/user.rs
+++ b/src/transactions/user.rs
@@ -11,15 +11,16 @@ use crate::{
     models::{
         Op,
         Modifications,
+        account::{Account, AccountID, Multisig, Ubi},
         lib::basis_model::Model,
         user::{User, UserID},
     },
 };
 
 /// Create a user (private implementation, meant to be wrapped).
-fn create_inner<T: Into<String>>(id: UserID, roles: Vec<Role>, email: T, name: T, active: bool, now: &DateTime<Utc>) -> Result<Modifications> {
+fn create_inner<T: Into<String>>(id: UserID, roles: Vec<Role>, email: T, name: T, ubi_account_id: AccountID, active: bool, now: &DateTime<Utc>) -> Result<Modifications> {
     let model = User::builder()
-        .id(id)
+        .id(id.clone())
         .roles(roles)
         .email(email)
         .name(name)
@@ -28,21 +29,36 @@ fn create_inner<T: Into<String>>(id: UserID, roles: Vec<Role>, email: T, name: T
         .updated(now.clone())
         .build()
         .map_err(|e| Error::BuilderFailed(e))?;
-    Ok(Modifications::new_single(Op::Create, model))
+    let ubi = Account::builder()
+        .id(ubi_account_id)
+        .user_ids(vec![id])
+        .multisig(vec![Multisig::new(1)])
+        .name("UBI")
+        .description("Your UBI account")
+        .balance(0)
+        .ubi(Some(Ubi::new(now.clone())))
+        .created(now.clone())
+        .updated(now.clone())
+        .build()
+        .map_err(|e| Error::BuilderFailed(e))?;
+    let mut mods = Modifications::new();
+    mods.push(Op::Create, model);
+    mods.push(Op::Create, ubi);
+    Ok(mods)
 }
 
 /// Create a new user with a `Role::User` role. No permissions required.
-pub fn create<T: Into<String>>(id: UserID, email: T, name: T, active: bool, now: &DateTime<Utc>) -> Result<Modifications> {
+pub fn create<T: Into<String>>(id: UserID, email: T, name: T, ubi_account_id: AccountID, active: bool, now: &DateTime<Utc>) -> Result<Modifications> {
     access::guest_check(Permission::UserCreate)?;
-    create_inner(id, vec![Role::User], email, name, active, now)
+    create_inner(id, vec![Role::User], email, name, ubi_account_id, active, now)
 }
 
 /// Create a new user with a specific set of permissions using a current user as
 /// the originator. Effectively an admin create. Requires the 
 /// `Permission::UserCreate` permission.
-pub fn create_permissioned<T: Into<String>>(caller: &User, id: UserID, roles: Vec<Role>, email: T, name: T, active: bool, now: &DateTime<Utc>) -> Result<Modifications> {
+pub fn create_permissioned<T: Into<String>>(caller: &User, id: UserID, roles: Vec<Role>, email: T, name: T, ubi_account_id: AccountID, active: bool, now: &DateTime<Utc>) -> Result<Modifications> {
     caller.access_check(Permission::UserAdminCreate)?;
-    create_inner(id, roles, email, name, active, now)
+    create_inner(id, roles, email, name, ubi_account_id, active, now)
 }
 
 /// Update a user object
@@ -103,36 +119,58 @@ mod tests {
     #[test]
     fn can_create() {
         let id = UserID::create();
+        let account_id = AccountID::create();
         let now = util::time::now();
-        let mods = create(id.clone(), "zing@lyonbros.com", "leonard", true, &now).unwrap().into_vec();
-        assert_eq!(mods.len(), 1);
+        let mods = create(id.clone(), "zing@lyonbros.com", "leonard", account_id.clone(), true, &now).unwrap().into_vec();
+        assert_eq!(mods.len(), 2);
 
         let model = mods[0].clone().expect_op::<User>(Op::Create).unwrap();
+        let account = mods[1].clone().expect_op::<Account>(Op::Create).unwrap();
         assert_eq!(model.id(), &id);
         assert_eq!(model.email(), "zing@lyonbros.com");
         assert_eq!(model.name(), "leonard");
         assert_eq!(model.active(), &true);
+
+        assert_eq!(account.id(), &account_id);
+        assert_eq!(account.user_ids(), &vec![id.clone()]);
+        assert_eq!(account.name(), "UBI");
+        assert_eq!(account.balance(), &num!(0));
+        assert_eq!(account.ubi(), &Some(Ubi::new(now.clone())));
+        assert_eq!(account.created(), &now);
+        assert_eq!(account.updated(), &now);
+        assert_eq!(account.deleted(), &None);
     }
 
     #[test]
     fn can_create_permissioned() {
         let id = UserID::create();
+        let account_id = AccountID::create();
         let now = util::time::now();
         let mut state = TestState::standard(vec![], &now);
         let user = make_user(&id, Some(vec![Role::IdentityAdmin]), &now);
         state.user = Some(user);
 
         let testfn = |state: &TestState<User, User>| {
-            create_permissioned(state.user(), id.clone(), vec![Role::User], "zing@lyonbros.com", "leonard", true, &now)
+            create_permissioned(state.user(), id.clone(), vec![Role::User], "zing@lyonbros.com", "leonard", account_id.clone(), true, &now)
         };
 
         let mods = testfn(&state).unwrap().into_vec();
-        assert_eq!(mods.len(), 1);
+        assert_eq!(mods.len(), 2);
         let model = mods[0].clone().expect_op::<User>(Op::Create).unwrap();
+        let account = mods[1].clone().expect_op::<Account>(Op::Create).unwrap();
         assert_eq!(model.id(), &id);
         assert_eq!(model.email(), "zing@lyonbros.com");
         assert_eq!(model.name(), "leonard");
         assert_eq!(model.active(), &true);
+
+        assert_eq!(account.id(), &account_id);
+        assert_eq!(account.user_ids(), &vec![id.clone()]);
+        assert_eq!(account.name(), "UBI");
+        assert_eq!(account.balance(), &num!(0));
+        assert_eq!(account.ubi(), &Some(Ubi::new(now.clone())));
+        assert_eq!(account.created(), &now);
+        assert_eq!(account.updated(), &now);
+        assert_eq!(account.deleted(), &None);
 
         let mut state2 = state.clone();
         state2.user_mut().set_roles(vec![Role::User]);
@@ -143,10 +181,11 @@ mod tests {
     #[test]
     fn can_update() {
         let id = UserID::create();
+        let account_id = AccountID::create();
         let now = util::time::now();
         let mut state = TestState::standard(vec![], &now);
         let user = make_user(&id, Some(vec![Role::IdentityAdmin]), &now);
-        let mods = create_permissioned(&user, id.clone(), vec![Role::User], "zing@lyonbros.com", "leonard", true, &now).unwrap().into_vec();
+        let mods = create_permissioned(&user, id.clone(), vec![Role::User], "zing@lyonbros.com", "leonard", account_id.clone(), true, &now).unwrap().into_vec();
         let new_user = mods[0].clone().expect_op::<User>(Op::Create).unwrap();
         state.user = Some(user);
         state.model = Some(new_user);

--- a/src/util/test.rs
+++ b/src/util/test.rs
@@ -215,7 +215,7 @@ pub fn make_account<T: Into<String>, D: Into<Decimal>>(id: &AccountID, user_id: 
         .name(name.into())
         .description("THIS IS MY ACCOUNT. IF YOU SHOUT A STATEMENT IT MAKES IT MORE TRUE. ASK RON.")
         .balance(balance.into())
-        .ubi(false)
+        .ubi(None)
         .active(true)
         .created(now.clone())
         .updated(now.clone())


### PR DESCRIPTION
Closes basisproject/tracker#113. For some reason this feels incomplete, like I'm missing something, but I think the only thing missing is withdrawls which is a bigger can of worms (see basisproject/tracker#121).

For now, creating a user creates a UBI account, and they can claim their ubi via a transaction.

Oh, now I remember what's missing: there's no way to manage the systemic UBI params. I will add a separate issue for this since it's kind of its own thing anyway.